### PR TITLE
Posture 2 gates 1–2: Event types + condition sibling form

### DIFF
--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -37,6 +37,8 @@ export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals,
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target
 export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
+export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
+export indicator_kernel, feature_value, BOOLEAN_SPACE
 export Functional, Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure
 export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1084,6 +1084,20 @@ function condition(m::Measure, k::Kernel, obs; n_particles::Int=1000)
     CategoricalMeasure(Finite(samples), log_weights)
 end
 
+# ── condition — sibling form taking an Event directly ──
+#
+# Provably equivalent to conditioning on `indicator_kernel(e)` at
+# observation `true`, for deterministic events. Di Lavore–Román–
+# Sobociński Proposition 4.9: Pearl and Jeffrey coincide on
+# deterministic observations, both equal Bayesian inversion at the
+# observed point. The parametric form `condition(m, k, obs)` stays
+# the primary signature for existing consumers; this form is the
+# natural idiom for new code whose conditioning object is an event
+# rather than a kernel-observation pair.
+function condition(m::Measure, e::Event)
+    condition(m, indicator_kernel(e), true)
+end
+
 # ================================================================
 # AXIOM-CONSTRAINED FUNCTION: push_measure
 # ================================================================

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -18,6 +18,8 @@ export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals,
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target, kernel_params
 export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
+export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
+export indicator_kernel, feature_value, BOOLEAN_SPACE
 export Functional, Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure
 export factor, replace_factor
 export condition, expect, push_measure, density, log_predictive, log_marginal
@@ -333,6 +335,229 @@ Kernel(source::Space, target::Space, gen::Function, ld::Function;
 kernel_source(k::Kernel) = k.source
 kernel_target(k::Kernel) = k.target
 kernel_params(k::Kernel) = k.params
+
+# ================================================================
+# TYPE 4: Event — first-class declared structure
+# ================================================================
+# An Event is a declared proposition about the state of a Space.
+# Events are bearers of probability in the de Finettian sense:
+# P(A) is defined directly, not derived from a measure on subsets.
+#
+# Every Event constructor witnesses a computable `indicator_kernel`
+# into a declared Boolean Space. That witness is the mechanical
+# bridge between the event layer and the kernel layer: when
+# `condition(m, e::Event)` is invoked (sibling form), it expands to
+# `condition(m, indicator_kernel(e), true)` — Di Lavore–Román–
+# Sobociński Prop. 4.9 applied in one line.
+#
+# Declared structure per Invariant 2: no opaque predicate closures
+# at the axiom layer. Every Event carries the data its kernel needs
+# in a typed field, not in a captured lambda.
+
+abstract type Event end
+
+"""
+    TagSet(space, tags)
+
+Event stating that a mixture component's tag lies in a declared finite
+set of `Int`s. Peer of `FiringByTag` on the expect / posterior side:
+declarative tag-based dispatch, no opaque closures.
+
+Applicable to mixtures whose components carry `Int` tags (e.g.
+`TaggedBetaMeasure`). The indicator kernel uses `_tag_of(component)`
+to read the tag at dispatch time; add a `_tag_of` method for any new
+tag-bearing Measure type.
+"""
+struct TagSet <: Event
+    space::Space
+    tags::Set{Int}
+end
+
+"""
+    FeatureEquals(space, feature, value)
+
+Deterministic equality event on a declared feature of hypotheses in
+`space`. The indicator kernel queries `feature_value(h, feature)` —
+add a method per hypothesis type when needed.
+
+Valid only for discrete features; continuous equality is a
+measure-zero event and must go through a disintegration primitive
+(not yet implemented) — this constructor does not guard that case at
+construction time; the dispatch is undefined on measure-zero events.
+"""
+struct FeatureEquals{T} <: Event
+    space::Space
+    feature::Symbol
+    value::T
+end
+
+"""
+    FeatureInterval(space, feature, lo, hi)
+
+Event stating a declared continuous feature lies in the closed
+interval [lo, hi]. `feature_value(h, feature)` must return a real
+number for hypotheses `h` drawn from `space`.
+"""
+struct FeatureInterval <: Event
+    space::Space
+    feature::Symbol
+    lo::Float64
+    hi::Float64
+end
+
+"""
+    Conjunction(left, right)
+
+Event that holds iff both `left` and `right` hold. Operands must
+share the same Space (checked at `indicator_kernel` construction).
+"""
+struct Conjunction <: Event
+    left::Event
+    right::Event
+end
+
+"""
+    Disjunction(left, right)
+
+Event that holds iff `left` or `right` holds.
+"""
+struct Disjunction <: Event
+    left::Event
+    right::Event
+end
+
+"""
+    Complement(inner)
+
+Event that holds iff `inner` does not.
+"""
+struct Complement <: Event
+    inner::Event
+end
+
+# ── Boolean Space — shared target for all indicator kernels ──
+const BOOLEAN_SPACE = Finite([false, true])
+
+# ── Tag accessor: declared-structure dispatch, not an opaque closure ──
+# Extend with one-line methods for any new tag-bearing Measure type.
+_tag_of(m::TaggedBetaMeasure) = m.tag
+
+# ── Feature accessor: method dispatch is the registry ──
+# Domains extend with their hypothesis types.
+"""
+    feature_value(h, name::Symbol)
+
+Extract the named feature from hypothesis `h`. Default: NamedTuple
+index / struct field access. Override for domain-specific hypothesis
+types via method dispatch.
+"""
+feature_value(h::NamedTuple, name::Symbol) = h[name]
+feature_value(h, name::Symbol) = getfield(h, name)
+
+# ── indicator_kernel: the mechanical bridge ──
+# For each Event, produce a Kernel from the event's Space to
+# BOOLEAN_SPACE whose log_density is 0 when the event holds and -Inf
+# otherwise. `likelihood_family = Flat()` because the indicator does
+# not depend on the Beta parameter of a tagged component — it is a
+# structural predicate on the component's tag. Under Flat dispatch,
+# `condition(::TaggedBetaMeasure, k, _)` returns the component
+# unchanged; the effective work is done by `_predictive_ll` on the
+# mixture, which propagates the log_density as a weight multiplier.
+
+"""
+    indicator_kernel(event) → Kernel
+
+Witness that an Event is expressible as a declared indicator kernel
+into BOOLEAN_SPACE. Used internally by `condition(::Measure, ::Event)`.
+Also the mechanical proof that Invariant 2 is preserved: events reach
+the axiom layer only through declared kernels.
+"""
+function indicator_kernel(e::TagSet)
+    ld = (h, o) -> begin
+        holds = _tag_of(h) in e.tags
+        (o === true && holds) || (o === false && !holds) ? 0.0 : -Inf
+    end
+    gen = h -> begin
+        holds = _tag_of(h) in e.tags
+        CategoricalMeasure(
+            BOOLEAN_SPACE,
+            [holds ? -Inf : 0.0,   # logw at false
+             holds ? 0.0 : -Inf],  # logw at true
+        )
+    end
+    Kernel(e.space, BOOLEAN_SPACE, gen, ld; likelihood_family = Flat())
+end
+
+function indicator_kernel(e::FeatureEquals{T}) where T
+    ld = (h, o) -> begin
+        holds = feature_value(h, e.feature) == e.value
+        (o === true && holds) || (o === false && !holds) ? 0.0 : -Inf
+    end
+    gen = h -> begin
+        holds = feature_value(h, e.feature) == e.value
+        CategoricalMeasure(
+            BOOLEAN_SPACE,
+            [holds ? -Inf : 0.0, holds ? 0.0 : -Inf],
+        )
+    end
+    Kernel(e.space, BOOLEAN_SPACE, gen, ld; likelihood_family = Flat())
+end
+
+function indicator_kernel(e::FeatureInterval)
+    ld = (h, o) -> begin
+        v = feature_value(h, e.feature)
+        holds = e.lo <= v <= e.hi
+        (o === true && holds) || (o === false && !holds) ? 0.0 : -Inf
+    end
+    gen = h -> begin
+        v = feature_value(h, e.feature)
+        holds = e.lo <= v <= e.hi
+        CategoricalMeasure(
+            BOOLEAN_SPACE,
+            [holds ? -Inf : 0.0, holds ? 0.0 : -Inf],
+        )
+    end
+    Kernel(e.space, BOOLEAN_SPACE, gen, ld; likelihood_family = Flat())
+end
+
+# Boolean algebra — compose indicator log-densities. The result is a
+# single Kernel whose log_density reads the two operand indicators at
+# observation `true` and combines them.
+function indicator_kernel(e::Conjunction)
+    kl = indicator_kernel(e.left)
+    kr = indicator_kernel(e.right)
+    kl.source === kr.source ||
+        error("Conjunction: operands must share the same Space instance")
+    ld = (h, o) -> begin
+        holds = kl.log_density(h, true) == 0.0 && kr.log_density(h, true) == 0.0
+        (o === true && holds) || (o === false && !holds) ? 0.0 : -Inf
+    end
+    gen = h -> error("indicator_kernel(Conjunction).generate not used in condition")
+    Kernel(kl.source, BOOLEAN_SPACE, gen, ld; likelihood_family = Flat())
+end
+
+function indicator_kernel(e::Disjunction)
+    kl = indicator_kernel(e.left)
+    kr = indicator_kernel(e.right)
+    kl.source === kr.source ||
+        error("Disjunction: operands must share the same Space instance")
+    ld = (h, o) -> begin
+        holds = kl.log_density(h, true) == 0.0 || kr.log_density(h, true) == 0.0
+        (o === true && holds) || (o === false && !holds) ? 0.0 : -Inf
+    end
+    gen = h -> error("indicator_kernel(Disjunction).generate not used in condition")
+    Kernel(kl.source, BOOLEAN_SPACE, gen, ld; likelihood_family = Flat())
+end
+
+function indicator_kernel(e::Complement)
+    ki = indicator_kernel(e.inner)
+    ld = (h, o) -> begin
+        holds = ki.log_density(h, true) != 0.0  # inner did NOT hold
+        (o === true && holds) || (o === false && !holds) ? 0.0 : -Inf
+    end
+    gen = h -> error("indicator_kernel(Complement).generate not used in condition")
+    Kernel(ki.source, BOOLEAN_SPACE, gen, ld; likelihood_family = Flat())
+end
 
 # ================================================================
 # AXIOM-CONSTRAINED FUNCTION: density


### PR DESCRIPTION
First PR in the de Finettian posture-2 sequence. Additive only — no existing axiom changes signature or semantics.

## What lands

**Gate 1 (`30f5ff3`)** — `Event` as a fourth first-class declared type alongside Space / Measure / Kernel, with six constructors closing under Boolean operations plus three domain primitives:

- `TagSet(space, tags)` — mixture-component tag membership
- `FeatureEquals(space, name, value)` — discrete feature equality
- `FeatureInterval(space, name, lo, hi)` — closed interval on a continuous feature
- `Conjunction`, `Disjunction`, `Complement`

Each event witnesses an `indicator_kernel(::Event) → Kernel` into `BOOLEAN_SPACE = Finite([false, true])`, with `likelihood_family = Flat()` so that `condition(::TaggedBetaMeasure, k, _)` returns the component unchanged and weight adjustment falls out of `_predictive_ll` propagation at the mixture level — same mechanics as `FiringByTag`, just with the 0 / -Inf density in place of BetaBernoulli.

Declared-structure compliant per Invariant 2: `TagSet` carries a typed `Set{Int}`; feature events reach the hypothesis through `feature_value(h, name)` method dispatch, overridable per hypothesis type. No opaque predicate closures reach the axiom layer.

**Gate 2 (`81ef0b6`)** — the `condition(::Measure, ::Event)` sibling form. Three lines:

```julia
function condition(m::Measure, e::Event)
    condition(m, indicator_kernel(e), true)
end
```

Provably equivalent to the parametric form at observation `true` for deterministic events (Di Lavore–Román–Sobociński 2024, Prop. 4.9 — Pearl and Jeffrey coincide on deterministic observations). Parametric `condition(m, k, obs)` remains primary; every existing consumer keeps working verbatim. This is a sibling, not a replacement.

## Why coherence-first, not measure-first

The operational consequence of the de Finettian framing — preferred over Kolmogorov's — is that events become first-class bearers of probability rather than derived subsets of a measurable space. The framing change is argued at the SPEC level in a later gate; this PR is the type-system work that makes the surface syntax possible. Parametric Bayesian update becomes one derived instance of conditional probability, the primary form stays put, and ordinary consumer code is untouched.

## What this PR does NOT do

- No changes to `condition`'s primary `(m, k, obs)` signature.
- No sub-probability or partial-measure machinery — the axiom layer stays affine.
- No new execution-layer machinery — conjugate, quadrature, particle, enumeration dispatch all unaffected.
- No `disintegrate` primitive — measure-zero conditioning on continuous features is still unsupported.
- No consumer changes — the `email_agent` rewrite and CLAUDE.md / SPEC.md updates follow in later gates of the sequence.

## Verification

- `julia --project=. test/test_core.jl` — green (ALL TESTS PASSED, nothing touched).
- Smoke-tested `indicator_kernel(TagSet)`: `log_density(tag-in-set, true) == 0.0`; `log_density(tag-out-of-set, true) == -Inf`.
- Smoke-tested `condition(::MixtureMeasure, ::TagSet)` on a 4-component mixture with uniform weights and `fires = Set([1, 3])` — posterior weights come back `[0.5, 0.0, 0.5, 0.0]`, exactly the conditional mass. Gate 3 pins this with a 35-check test suite; gate 4 adds the equivalence-to-parametric-form canary.

## Follow-up sequence

This is PR 1 of 5. Subsequent PRs (each green on CI before the next opens):

- Gate 3 — `test/test_events.jl` (35 checks) + `MixtureMeasure` zero-mass guard (drive-by).
- Gate 4 — equivalence test pinning sibling form to parametric form.
- Gate 5 — `email_agent/compute_eu_primitive` rewrite; **closes #6** (the posterior-iteration pragma that motivated this branch).
- Gates 6+7 — CLAUDE.md `event-conditioning` precedent + SPEC.md §1.0 Foundations.

Refs #6.