### PR TITLE
ci: run publish-image workflow on PRs to master

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master]
     tags: ["v*.*.*"]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 env:
@@ -55,13 +57,11 @@ jobs:
             --ignore=apps/python/credence_router/tests/test_live.py \
             -v
 
-  build-smoke-publish:
-    name: Build, smoke-test, publish
+  smoke-build:
+    name: Build amd64 + smoke test
     runs-on: ubuntu-latest
     needs: unit-tests
-    permissions:
-      contents: read
-      packages: write
+    # No packages: write — this job only builds and smoke-tests locally.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -72,28 +72,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract image metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,format=short
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
-
       # Build amd64 locally so we can run it as a startup smoke test.
       # If startup fails here, we never push — the exact class of bug
-      # that slipped into v0.3.1 (KeyError on Julia symbol).
+      # that slipped into v0.3.1 (KeyError on Julia symbol). Cache
+      # layers are written to GHA for the publish job to reuse.
       - name: Build amd64 for smoke test
         uses: docker/build-push-action@v6
         with:
@@ -134,7 +116,50 @@ jobs:
           docker stop credence-proxy-smoke
           exit 1
 
-      - name: Build and push multi-arch (gated on smoke test above)
+  publish:
+    name: Publish multi-arch to GHCR
+    runs-on: ubuntu-latest
+    needs: smoke-build
+    # Job-level gate: publish only on master pushes and version tags.
+    # PR runs and workflow_dispatch on non-master refs never enter this
+    # job at all, so the packages: write permission is scoped to the
+    # pushes that actually need it.
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+
+      # Multi-arch build + push. Reuses cache layers written by
+      # smoke-build above; amd64 is a cache hit, arm64 is fresh.
+      - name: Build and push multi-arch
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
Meta-change, not part of the Posture 2 sequence.

## What

Two changes in one commit:

1. **Add `pull_request: branches: [master]`** to the workflow's `on:` block so CI actually reports on PRs targeting master.

2. **Split `build-smoke-publish` into two jobs:**
   - `smoke-build` — amd64 build + `/ready` probe. Runs on every trigger. No `packages: write` permission.
   - `publish` — multi-arch build + GHCR push. Gated at the job level with `if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))`. `packages: write` lives only here.

## Why now

The sequencing rule for the Posture 2 PR split — "each PR green on CI before the next opens" — assumed CI reported on PRs. It didn't. `publish-image.yml` was push-only, so PR 7 (and every planned PR 8–10) would have no status checks; gate failures could only be discovered post-merge, which defeats the whole point of the queue.

## Why the split

Three things the single-job structure couldn't give us:

- **Granularity matches the semantic boundary.** "Run the smoke test" and "publish the image" are different operations that should have different triggers; a job-level `if:` on a combined job would gate both, which is why the first version of this PR used a step-level `if:`.
- **`packages: write` is scoped to the pushes that need it.** The old structure granted write permission on every PR run even though the only step that would use it was gated away. Split means PR runs never hold the token.
- **Bisection is easier.** "smoke-build failed" vs "publish failed" are different diagnoses; in the combined job they surfaced as a single composite failure.

**Cost:** publish does its own checkout + buildx setup (~15–30s) and a multi-arch build. Amd64 is a GHA cache hit from smoke-build (`cache-from: type=gha` + `cache-to: type=gha,mode=max` propagates layers across jobs). Arm64 is a fresh build either way.

## Scope discipline

- Deliberately not bundled into any Posture 2 PR — CI changes are their own concern and conflating them would muddy the posture-2 history.
- Doesn't queue behind PR 7. This is what makes PR 7's CI actually report; it should land first and independently.

## Chicken-and-egg

This PR can't itself be CI-gated on the CI it enables. Review by eye, merge on trust, verify on the next PR — standard resolution for bootstrap changes.

## Verification after merge

- GitHub should re-run CI on PR 7 automatically. If not, trigger manually via `gh workflow run publish-image.yml --ref de-finetti/p2-gates-1-2`.
- Worth opening a trivial throwaway PR (one-line README edit) against master to confirm CI fires on arbitrary PRs and not just on this specific branch — rules out the "works on my branch only" class of misconfiguration.

## Follow-up

Once this merges and PR 7 reports green, the Posture 2 sequence proceeds: merge PR 7, open PR 8 (gate 3), etc.