### PR TITLE
fix(skin): bump shutdown timeout 5s → 30s

### DIFF
--- a/apps/skin/client.py
+++ b/apps/skin/client.py
@@ -121,14 +121,24 @@ class SkinClient:
         return self._call("initialize", params)
 
     def shutdown(self):
-        """Graceful shutdown."""
+        """Graceful shutdown.
+
+        The 30s wait is sized for CI flake resistance on Julia processes
+        carrying a fully-initialised Credence depot and a loaded BDSL —
+        Julia shutdown is rarely instantaneous. A clean exit in practice
+        should be well under 10s; if shutdown ever takes longer than
+        that in real runs, treat it as a signal to investigate the
+        shutdown path (mutex held across the subprocess boundary, async
+        task not cancelled, etc.) rather than bumping this number
+        further. See issue #9.
+        """
         try:
             self._call("shutdown")
         except (SkinError, BrokenPipeError):
             pass
         if self._process:
             self._process.terminate()
-            self._process.wait(timeout=5)
+            self._process.wait(timeout=30)
             self._process = None
 
     def __del__(self):


### PR DESCRIPTION
Closes #9.

Bump the `SkinClient.shutdown()` subprocess wait from 5s to 30s. A CI flake during teardown of `TestRoutingDomainWithBrain.test_learned_reliability_structure` confirmed the budget was too tight for Julia processes carrying a fully-initialised Credence depot.

Framing pinned in the docstring: **the bump is for CI flake resistance, not for accommodating genuinely slow shutdown**. A clean exit in practice should be well under 10s. If teardown ever takes longer than that in real runs, investigate the shutdown path (mutex held across the subprocess boundary, async task not cancelled, etc.) rather than bumping the timeout further.

One-line change plus a seven-line docstring. Should land before gate 3 opens so the Posture 2 sequencing rule isn't compromised by residual flakes across PRs 2–5.