### PR TITLE
Posture 2 gate 4: equivalence test — condition(m, e) ≡ condition(m, indicator_kernel(e), true)

### DIFF
--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -1432,5 +1432,40 @@ end
 println()
 
 println("=" ^ 60)
+println("TEST: condition(m, e::Event) equivalence to condition(m, indicator_kernel(e), true)")
+println("=" ^ 60)
+
+# Di Lavore–Román–Sobociński Prop. 4.9 in the codebase:
+# the sibling form is provably equivalent to the parametric form at
+# observation `true` for any deterministic event. Pin this as a
+# regression canary — if someone later routes condition(::Event)
+# through a separate code path, this catches semantic drift.
+
+let
+    sp = Interval(0.0, 1.0)
+    components = [TaggedBetaMeasure(sp, t, BetaMeasure(2.0 + t, 3.0)) for t in 1:5]
+    m = MixtureMeasure(sp, components, Float64[0.0, -0.5, 0.1, 0.2, -0.3])
+
+    events = Event[
+        TagSet(sp, Set([1, 3, 5])),
+        TagSet(sp, Set([2, 4])),
+        TagSet(sp, Set([1, 2, 3, 4, 5])),        # all — trivial case
+        Complement(TagSet(sp, Set([3]))),
+        Conjunction(TagSet(sp, Set([1, 2, 3, 4])), TagSet(sp, Set([2, 3, 4, 5]))),
+        Disjunction(TagSet(sp, Set([1])), TagSet(sp, Set([5]))),
+    ]
+    for (i, e) in enumerate(events)
+        lhs = condition(m, e)
+        rhs = condition(m, indicator_kernel(e), true)
+        w_lhs = weights(lhs)
+        w_rhs = weights(rhs)
+        close_enough = all(abs(w_lhs[j] - w_rhs[j]) < 1e-12 for j in eachindex(w_lhs))
+        @assert close_enough "event $i: weights diverge"
+    end
+    println("PASSED: 6 event variants — both condition forms agree to 1e-12")
+end
+
+println()
+println("=" ^ 60)
 println("ALL TESTS PASSED")
 println("=" ^ 60)


### PR DESCRIPTION
Fourth PR in the de Finettian posture-2 sequence. Regression canary pinning the sibling form to the parametric form.

## What lands

Appends a test to `test/test_core.jl` that verifies `condition(m, e::Event)` and `condition(m, indicator_kernel(e), true)` produce bit-equivalent posteriors (to 1e-12) across six event variants on a non-trivially weighted 5-component mixture of `TaggedBeta(2+t, 3)`:

- `TagSet` — firing subset
- `TagSet` — different firing subset
- `TagSet` — all tags (trivial case)
- `Complement(TagSet)`
- `Conjunction(TagSet, TagSet)`
- `Disjunction(TagSet, TagSet)`

All six pass.

## Why it's worth encoding even when the invariant is trivially true today

`condition(m, e::Event)` is a three-line delegation to `condition(m, indicator_kernel(e), true)`. Trivially true today. But:

- If someone later routes the Event form through a separate fast path (e.g., for a domain subtype with a specialised dispatch), this test catches semantic drift before gate 5's email_agent rewrite hits it.
- If someone introduces a new `Event` subtype without providing a well-formed `indicator_kernel`, the equivalence test flags it at PR time.
- Di Lavore–Román–Sobociński Prop. 4.9 (Pearl and Jeffrey coincide on deterministic observations) is made mechanical in the test suite — the mathematical claim becomes a CI check.

## Verification

- `julia --project=. test/test_core.jl` — includes the new section; all tests green.

## Follow-up

PR 4 of 5. Gate 5 (email_agent rewrite; closes #6) depends semantically on this gate: if the equivalence weren't pinned, a regression in gate 5 could silently shift the posterior arithmetic. Gate 5 opens once this merges.

Refs #6.