### PR TITLE
Posture 3 Move 1: Prevision primitive type + TestFunction hierarchy

### DIFF
--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -16,6 +16,7 @@
 module Credence
 
 include("parse.jl")
+include("prevision.jl")
 include("ontology.jl")
 include("eval.jl")
 include("persistence.jl")
@@ -27,6 +28,7 @@ include("program_space/perturbation.jl")
 include("program_space/agent_state.jl")
 
 using .Parse
+using .Previsions
 using .Ontology
 import .Ontology: truncate  # resolve ambiguity with Base.truncate
 using .Eval
@@ -40,6 +42,7 @@ export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, Flat, FiringByTag,
 export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
 export indicator_kernel, feature_value, BOOLEAN_SPACE
 export Functional, Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure
+export Prevision, TestFunction, Indicator, apply
 export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal
 export draw

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -1,0 +1,179 @@
+"""
+    prevision.jl — the de Finettian primitive type and its test function hierarchy.
+
+Declared here (Move 1 of the Posture 3 reconstruction):
+  - `Prevision` (abstract) — coherent linear functional on a declared test
+    function space, in the sense of de Finetti (1974) and Whittle (1992).
+  - `TestFunction` (abstract) and concrete shells: `Identity`, `Projection`,
+    `NestedProjection`, `Tabular`, `LinearCombination`, `OpaqueClosure`,
+    `Indicator`.
+  - `apply` — abstract evaluator `apply(f::TestFunction, s) → ℝ`. Methods
+    land in Move 2.
+
+Not declared here:
+  - `expect` dispatch (Move 2)
+  - `ConjugatePrevision`, `MixturePrevision`, `ExchangeablePrevision`, etc.
+    (Moves 4-5)
+  - `ParticlePrevision`, `QuadraturePrevision` (Move 6)
+  - `condition(p::Prevision, e::Event)` primary form (Move 7)
+  - `TestFunctionSpace` container — deferred; see
+    `docs/posture-3/move-1-design.md` §5.1 for the three-option analysis
+    that settled on option (c).
+
+Loaded before `ontology.jl` so that Move 3's Measure-as-view refactor can
+wrap `Prevision` subtypes in `Measure` fields. At Move 1 there are no
+`Prevision` subtypes yet and no consumers; the ordering is forward-looking.
+
+See `docs/posture-3/master-plan.md` for the full branch plan.
+"""
+module Previsions
+
+export Prevision, TestFunction, Indicator, apply
+# Not exported: Identity, Projection, NestedProjection, Tabular,
+# LinearCombination, OpaqueClosure. They clash with the current `Functional`
+# subtype names in `Ontology`; Move 2 aliases Ontology's versions onto these
+# and exports unify at that point. Qualified access `Prevision.Identity` is
+# available for sites that need the new declarations now.
+
+# ── Prevision ─────────────────────────────────────────────────────────────
+
+"""
+    Prevision
+
+Abstract type for a coherent linear functional on a declared test function
+space. Coherence is the single rationality axiom (Dutch-book equivalent;
+de Finetti 1937, 1974; Walley 1991):
+
+1. Non-negativity: `p(f) ≥ 0` when `f ≥ 0` everywhere.
+2. Normalisation: `p(𝟙) = 1`.
+3. Linearity: `p(αf + βg) = α·p(f) + β·p(g)`.
+4. (Optional) σ-continuity: `p(inf_n f_n) = inf_n p(f_n)` when `f_n ↓` —
+   Whittle's A5. A technical strengthening for the bounded-measurable
+   setting; Credence's default `Prevision` is finitely coherent, with
+   σ-continuous subclasses declared explicitly where needed.
+
+Concrete `Prevision` subtypes land in subsequent moves:
+  - Move 3: `BetaPrevision`, `CategoricalPrevision`, `GaussianPrevision`,
+    `GammaPrevision`, `DirichletPrevision`, `NormalGammaPrevision`, etc.
+  - Move 4: `ConjugatePrevision{Prior, Likelihood}`
+  - Move 5: `MixturePrevision`, `ExchangeablePrevision`
+  - Move 6: `ParticlePrevision`, `QuadraturePrevision`
+
+Move 1 declares only the abstract type — no dispatch, no consumers.
+"""
+abstract type Prevision end
+
+# ── TestFunction hierarchy ────────────────────────────────────────────────
+
+"""
+    TestFunction
+
+Abstract type for test functions — the arguments to a Prevision's action.
+A `TestFunction` `f` is any element of the declared test function space
+over a base `Space`; the Prevision's action `expect(p, f)` evaluates `f`
+at the (implicit) representing measure.
+
+Concrete subtypes declared here are *shells*: no dispatch yet. Move 2
+wires the `expect` dispatch through these types, aliasing the existing
+`Functional` hierarchy in `ontology.jl` onto them.
+"""
+abstract type TestFunction end
+
+"""
+    Identity() <: TestFunction
+
+The identity test function: `apply(Identity(), s) = s` for scalar `s`.
+Used to compute the mean of a scalar-valued prevision.
+"""
+struct Identity <: TestFunction end
+
+"""
+    Projection(index::Int) <: TestFunction
+
+Selects the `index`-th factor of a product-structured point (e.g. an atom
+from a `ProductMeasure` over a `ProductSpace`).
+"""
+struct Projection <: TestFunction
+    index::Int
+end
+
+"""
+    NestedProjection(indices::Vector{Int}) <: TestFunction
+
+Selects a nested factor through a path of indices — walks successive
+`ProductSpace` levels, terminating at a scalar leaf.
+"""
+struct NestedProjection <: TestFunction
+    indices::Vector{Int}
+end
+
+"""
+    Tabular(values::Vector{Float64}) <: TestFunction
+
+A tabulated test function over a finite space: value at atom `i` is
+`values[i]`. Length must match the space's atom count at dispatch time
+(enforced by the `expect(::CategoricalPrevision, ::Tabular)` method in
+Move 2).
+"""
+struct Tabular <: TestFunction
+    values::Vector{Float64}
+end
+
+"""
+    LinearCombination(terms, offset=0.0) <: TestFunction
+
+A linear combination of test functions: `sum(c * f for (c, f) in terms)
++ offset`. Composition is part of structure — each sub-functional
+navigates its own shape via its own `apply` method.
+"""
+struct LinearCombination <: TestFunction
+    terms::Vector{Tuple{Float64, TestFunction}}
+    offset::Float64
+
+    LinearCombination(terms::Vector{Tuple{Float64, TestFunction}}, offset::Float64 = 0.0) =
+        new(terms, offset)
+end
+
+"""
+    OpaqueClosure(f::Function) <: TestFunction
+
+Escape hatch: a test function wrapped around an opaque Julia closure.
+Use this only when no declared `TestFunction` subtype fits; forfeits the
+type-structural dispatch the other subtypes enable, falling back to
+whatever default integration strategy the prevision implements.
+"""
+struct OpaqueClosure <: TestFunction
+    f::Function
+end
+
+"""
+    Indicator{E}(event::E) <: TestFunction
+
+The indicator of an event: `apply(Indicator(e), s) = 1` if `s ∈ e`, else
+`0`. The bridge between previsions and probabilities —
+`probability(μ, e) = expect(μ.prevision, Indicator(e))` (Move 3).
+
+Parametric on `E` because the `Event` hierarchy lives in `ontology.jl`,
+which loads *after* `prevision.jl`. The structural constraint `E <:
+Ontology.Event` is enforced at method dispatch (Move 7's
+`condition(p, e::Event)` wraps `e` into `Indicator(e)` only for `Event`
+subtypes), not at the field level. See `docs/posture-3/move-1-design.md`
+§5.3 for the placement discussion.
+"""
+struct Indicator{E} <: TestFunction
+    event::E
+end
+
+# ── apply — abstract evaluator ────────────────────────────────────────────
+
+"""
+    apply(f::TestFunction, s) → ℝ
+
+Evaluate a test function `f` at a point `s`. Methods land in Move 2 —
+one per `(Prevision, TestFunction)` pair that requires a distinct
+implementation. This declaration exists so that Move 2's additions are
+method-level (on an already-declared function), not type-level.
+"""
+function apply end
+
+end # module Previsions


### PR DESCRIPTION
## Summary

Move 1 of the Posture 3 reconstruction. The smallest of the eight moves: new abstract type declarations, no dispatch, no consumer churn, no behaviour change. Full existing test suite passes unchanged. Matches the scope committed in PR #19's design doc (`docs/posture-3/move-1-design.md`).

### What lands

**New file — `src/prevision.jl`** (~180 lines):
- `abstract type Prevision end` with coherence-axiom docstring (de Finetti 1937, 1974; Walley 1991; Whittle 1992).
- `abstract type TestFunction end` and concrete shells: `Identity`, `Projection(::Int)`, `NestedProjection(::Vector{Int})`, `Tabular(::Vector{Float64})`, `LinearCombination(terms, offset=0.0)`, `OpaqueClosure(::Function)`, `Indicator{E}(::E)`.
- `function apply end` — abstract evaluator. Methods land in Move 2.
- **No `TestFunctionSpace`** per PR #19's §5.1 three-option analysis (option (c): defer to Move 5 if ever needed).

**Modified — `src/Credence.jl`:**
- `include("prevision.jl")` added *before* `include("ontology.jl")` so Move 3's Measure-as-view refactor has `Prevision` subtypes loaded when `ontology.jl` parses.
- `using .Previsions` brings `Prevision`, `TestFunction`, `Indicator`, `apply` into Credence scope. The submodule is named `Previsions` (plural) to avoid a docstring-attachment collision between module name and abstract-type name — both being `Prevision` trips Julia's `doc!` dispatch.
- Exports add `Prevision`, `TestFunction`, `Indicator`, `apply`.

### Design notes landed during implementation

**`Indicator` is parametric, not Event-constrained at the field level.** The design doc's §5.3 recommended declaring `Indicator(e::Event)` in `prevision.jl`, importing `Event` from `Ontology`. At implementation, that turned out to be a forward reference — `prevision.jl` loads *before* `ontology.jl`, so `Ontology.Event` doesn't exist when `prevision.jl` parses. Resolution: `struct Indicator{E} <: TestFunction` is parametric on `E` with no type constraint at the field level; the `E <: Event` constraint is enforced at method dispatch (Move 7's `condition(p, e::Event)` only creates `Indicator(e)` for Event subtypes). Documented in the struct's docstring; cross-referenced from `docs/posture-3/move-1-design.md` §5.3.

**Module name `Previsions` (plural), not `Prevision`.** `module Prevision` + `abstract type Prevision end` creates a docstring-attachment collision (Julia's `doc!` dispatches on `::Module` vs `::Type{...}` and can't disambiguate when the name is the same). Renaming the module to `Previsions` resolves cleanly; the abstract type stays `Prevision`, user-facing names unaffected.

**Shell concretes unexported from `Previsions` at Move 1.** `Identity`, `Projection`, etc. in `Previsions` share names with existing `Functional` subtypes in `Ontology`. Exporting both would cause ambiguity on `using Credence`. `Previsions` exports only `Prevision`, `TestFunction`, `Indicator`, `apply` at Move 1; Move 2 aliases `Ontology.Identity = Previsions.Identity` etc. and exports unify then.

## Test plan

- [x] `julia -e 'push!(LOAD_PATH, "src"); using Credence'` loads cleanly — exit 0, no warnings.
- [x] `julia test/test_core.jl` — passes unchanged.
- [x] `julia test/test_events.jl` — 35 checks pass.
- [x] `julia test/test_flat_mixture.jl` — passes unchanged.
- [x] `julia test/test_program_space.jl` — passes unchanged.
- [x] `julia test/test_host.jl` — passes unchanged.
- [x] `julia test/test_grid_world.jl` — passes unchanged.
- [x] `julia test/test_email_agent.jl` — passes unchanged.
- [x] `julia test/test_rss.jl` — 57540 checks pass.
- [x] `cd apps/julia/pomdp_agent && julia --project=. -e 'using Pkg; Pkg.test()'` — 55 Stage-1 tests pass.

No new tests added at Move 1 (no dispatch to test yet). Strata-1 tests open at Move 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)