### PR TITLE
Fix #22: skin lifecycle budgets — startup sentinel + bounded teardown

### DIFF
--- a/apps/skin/client.py
+++ b/apps/skin/client.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import json
 import logging
+import select
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -37,7 +39,7 @@ class SkinClient:
         self,
         julia: str = "julia",
         server_path: str | Path | None = None,
-        startup_timeout: float = 60.0,
+        startup_timeout: float = 120.0,
         project: str | Path | None = None,
     ):
         if server_path is None:
@@ -64,6 +66,62 @@ class SkinClient:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,  # line-buffered
+        )
+        self._wait_for_ready()
+
+    def _wait_for_ready(self):
+        """Wait for the Julia skin server's startup-complete sentinel.
+
+        The server emits `{"status": "ready"}\\n` on stdout after all
+        module loading finishes, before entering the JSON-RPC accept
+        loop (`apps/skin/server.jl::main()`). This method reads stdout
+        until that line arrives, with `process.poll()` polled alongside
+        to detect early crash, and a generous ceiling
+        (`self._startup_timeout`, default 120s) that accommodates
+        cold-compile + loaded-runner variance. See issue #22 for the
+        class of lifecycle-budget failures this replaces.
+        """
+        assert self._process is not None
+        assert self._process.stdout is not None
+        deadline = time.monotonic() + self._startup_timeout
+        while time.monotonic() < deadline:
+            exit_code = self._process.poll()
+            if exit_code is not None:
+                stderr = ""
+                if self._process.stderr:
+                    stderr = self._process.stderr.read()
+                raise SkinError(
+                    -1,
+                    f"Skin process exited with code {exit_code} before "
+                    f"ready sentinel. stderr: {stderr}",
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            # Poll stdout with a short budget; loop re-checks process.poll().
+            readable, _, _ = select.select(
+                [self._process.stdout.fileno()], [], [], min(remaining, 1.0),
+            )
+            if not readable:
+                continue
+            line = self._process.stdout.readline()
+            if not line:
+                # EOF; process exited. Loop catches it via .poll() next iter.
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                # Not a JSON line (e.g. stray Julia warning to stdout).
+                # Shouldn't happen in practice — stderr captures warnings —
+                # but guard defensively.
+                continue
+            if isinstance(msg, dict) and msg.get("status") == "ready":
+                log.info("Skin process ready")
+                return
+        raise SkinError(
+            -1,
+            f"Skin process did not emit ready sentinel within "
+            f"{self._startup_timeout}s",
         )
 
     def _call(self, method: str, params: dict[str, Any] | None = None) -> Any:
@@ -121,25 +179,57 @@ class SkinClient:
         return self._call("initialize", params)
 
     def shutdown(self):
-        """Graceful shutdown.
+        """Bounded-time shutdown.
 
-        The 30s wait is sized for CI flake resistance on Julia processes
-        carrying a fully-initialised Credence depot and a loaded BDSL —
-        Julia shutdown is rarely instantaneous. A clean exit in practice
-        should be well under 10s; if shutdown ever takes longer than
-        that in real runs, treat it as a signal to investigate the
-        shutdown path (mutex held across the subprocess boundary, async
-        task not cancelled, etc.) rather than bumping this number
-        further. See issue #9.
+        Steps:
+          1. Send `shutdown` RPC (the server's main loop returns on receipt).
+          2. Close stdin to signal EOF (the server's `eachline(stdin)` loop
+             exits on EOF even if the RPC path didn't land cleanly).
+          3. `wait(timeout=5)` for clean exit.
+          4. If still alive: `terminate()` (SIGTERM), `wait(timeout=5)`.
+          5. If still alive: `kill()` (SIGKILL), `wait(timeout=2)`.
+
+        Total ceiling ~12s; guaranteed to complete (SIGKILL cannot be
+        ignored). Replaces the earlier 30s `wait-after-terminate` pattern
+        that flaked under cold-compile + loaded-runner variance (issue #22,
+        matching class as #9's teardown-path flake). Per the repo precedent,
+        further timeout bumps would be a signal that something in shutdown
+        regressed, not a budget inadequacy.
         """
+        if self._process is None:
+            return
+
         try:
             self._call("shutdown")
         except (SkinError, BrokenPipeError):
             pass
-        if self._process:
+
+        # Close stdin so the server's `eachline(stdin)` loop sees EOF and exits,
+        # even if the shutdown RPC path didn't land (e.g. broken pipe).
+        try:
+            if self._process.stdin:
+                self._process.stdin.close()
+        except (BrokenPipeError, OSError):
+            pass
+
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            log.info("Skin process did not exit cleanly; sending SIGTERM")
             self._process.terminate()
-            self._process.wait(timeout=30)
-            self._process = None
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                log.warning("Skin process ignored SIGTERM; sending SIGKILL")
+                self._process.kill()
+                try:
+                    self._process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    log.error(
+                        "Skin process still alive after SIGKILL+2s; giving up"
+                    )
+
+        self._process = None
 
     def __del__(self):
         if self._process and self._process.poll() is None:

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -1014,6 +1014,15 @@ end
 function main()
     log_msg("Credence skin server starting...")
 
+    # Startup-complete sentinel (issue #22). All `using Credence` / module
+    # loading above has completed; emit a JSON line on stdout so the
+    # Python client can detect readiness with `process.poll()` safeguard
+    # instead of relying on a fixed timeout that misfires under cold-
+    # compile + loaded-runner variance. The matching read lives in
+    # `apps/skin/client.py::SkinClient._wait_for_ready()`.
+    println(stdout, JSON3.write(Dict("status" => "ready")))
+    flush(stdout)
+
     for line in eachline(stdin)
         isempty(strip(line)) && continue
 


### PR DESCRIPTION
Closes #22.

## Triage correction

PR #21's CI failure was `subprocess.TimeoutExpired` after 30s on `julia ... server.jl`, raised from `SkinClient.shutdown()`'s `self._process.wait(timeout=30)` (`apps/skin/client.py:141`). The concrete flake was **teardown**, not startup — issue #22's body was filed mis-triaged; corrected in [issue #22 comment](https://github.com/gfrmin/credence/issues/22#issuecomment-4283295082). The class-shape framing ("Julia process lifecycle budgets exceed fixed timeouts under cold-compile + loaded runner") applies to both sides of the lifecycle, so this PR fixes both.

## Design choices

### Startup: Shape 1 (stdout sentinel + process.poll safeguard)

Per the design guidance on issue #22: prefer a sentinel-based robust-by-construction pattern over a timeout bump. Two shapes considered:

- **Shape 1 (implemented):** Julia prints `{\"status\": \"ready\"}\\n` on stdout after module loading; Python polls stdout line-by-line with a generous ceiling (120s) and `process.poll()` safeguard for early-crash detection.
- **Shape 2 (not chosen):** JSON-RPC ping with exponential backoff. More robust against Julia server evolution, but couples more state and spams the wire during cold-compile. Simpler pattern wins when the server's startup ordering is stable, which it is.

Safeguard: if Julia crashes before emitting the sentinel, `_wait_for_ready` surfaces `SkinError(\"Skin process exited with code N before ready sentinel. stderr: ...\")` within one poll cycle — old behaviour hung at the first `_call`'s `stdout.readline()`.

### Teardown: bounded SIGTERM → SIGKILL escalation

The 30s wait-after-terminate was #9's fix-by-bump. Per the repo precedent (two skin-timeout bumps establish a floor; further failures are regression signals, not budget inadequacy), the fix is structural:

1. Send `shutdown` RPC (best-effort; server's main loop returns on it).
2. Close stdin → server's `eachline(stdin)` exits on EOF.
3. `wait(timeout=5)` for clean exit.
4. If still alive: `terminate()` (SIGTERM), `wait(timeout=5)`.
5. If still alive: `kill()` (SIGKILL), `wait(timeout=2)`.

Total ceiling ~12s; guaranteed to complete (SIGKILL cannot be ignored).

## Verification

- [x] `python -m skin.test_skin` — 7 smoke tests pass (basic_inference, categorical, snapshot_restore, unknown_state_id, unknown_method, factor_on_non_product_measure, replace_factor_identity_pin). Router_roundtrip SKIPs on a pre-existing path bug unrelated to this PR.
- [x] `uv run pytest apps/python/credence_router/tests/test_routing_domain.py::TestRoutingDomainWithBrain` — all 4 tests pass in the class-scope-fixture setup that flaked on PR #21. Local run finishes in 10.6s.
- [x] `julia test/test_core.jl`, `julia test/test_prevision_unit.jl` — unchanged (Julia core unaffected by the server.jl sentinel addition).

## Sequencing

Per the master plan, this fix must land before Move 3's design doc opens because Move 3 is where `python -m skin.test_skin` becomes mandatory at end-of-PR. Move 3 design doc opens after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)