### PR TITLE
Move 4: ConjugatePrevision registry + dispatch-path observability

### DIFF
--- a/apps/skin/client.py
+++ b/apps/skin/client.py
@@ -345,6 +345,22 @@ class SkinClient:
         result = self._call("n_factors", {"state_id": state_id})
         return result["n_factors"]
 
+    def _dispatch_path(self, state_id: str, kernel: dict) -> str:
+        """Dispatch-path observability hook (underscore-prefixed, test-only).
+
+        Returns "conjugate" if the (state, kernel) pair matches a registered
+        conjugate entry in the ConjugatePrevision registry; "particle"
+        otherwise. Does NOT mutate state. Used by Stratum-2 skin-smoke
+        tests to pin registry-dispatch decisions explicitly.
+
+        See docs/posture-3/move-4-design.md §5.2 for the contract.
+        """
+        result = self._call("_dispatch_path", {
+            "state_id": state_id,
+            "kernel": kernel,
+        })
+        return result["path"]
+
     # ── Program-space operations (Tier 2) ──
 
     def enumerate(

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -289,6 +289,62 @@ function build_kernel(spec, state_id::Union{String, Nothing}=nothing)
         resolved_args = [resolve_arg(a) for a in args]
         fn(resolved_args...)
 
+    elseif t == "flat"
+        # Flat likelihood: no-op conjugate for BetaMeasure. Any source/target
+        # shape with a declared likelihood_family = Flat() is recognised by
+        # maybe_conjugate(::BetaPrevision, ...). Declared here over
+        # Interval(0,1) → Finite(0,1) for parity with the bernoulli kernel.
+        source = Interval(0.0, 1.0)
+        target = Finite([0.0, 1.0])
+        Kernel(source, target,
+            θ -> error("generate not used"),
+            (θ, o) -> 0.0;
+            likelihood_family = Flat())
+
+    elseif t == "categorical"
+        # Dirichlet-Categorical conjugate kernel. Categories are Float64
+        # labels [0.0, 1.0, …, k-1] to match the skin's create_state for
+        # DirichletMeasure. The Categorical likelihood marker carries the
+        # category list as a Finite so maybe_conjugate(::DirichletPrevision,
+        # ...) can look up obs→idx at update time.
+        cats = Finite(collect(Float64, spec["categories"]))
+        k = length(cats.values)
+        source = Simplex(k)
+        target = cats
+        Kernel(source, target,
+            _ -> error("generate not used"),
+            (θ, o) -> begin
+                idx = findfirst(==(o), cats.values)
+                idx === nothing ? -Inf : log(max(θ[idx], 1e-300))
+            end;
+            likelihood_family = Categorical(cats))
+
+    elseif t == "normal_gamma"
+        # Normal-Gamma conjugate kernel. The hypothesis h = (μ, σ²) is
+        # drawn from NormalGammaMeasure (see `draw(::NormalGammaMeasure)`);
+        # the likelihood is N(o; μ, σ²). Density is used by
+        # log_predictive's generic fallback even though the posterior
+        # goes through the conjugate registry.
+        source = Euclidean(1)
+        target = Euclidean(1)
+        Kernel(source, target,
+            _ -> error("generate not used"),
+            (h, o) -> begin
+                μ, σ² = h[1], h[2]
+                -0.5 * log(2π * σ²) - 0.5 * (o - μ)^2 / σ²
+            end;
+            likelihood_family = NormalGammaLikelihood())
+
+    elseif t == "exponential"
+        # Gamma-Exponential conjugate kernel. Rate λ ∈ ℝ₊; observation
+        # o ∈ ℝ₊. Log-density log(λ) - λo.
+        source = PositiveReals()
+        target = PositiveReals()
+        Kernel(source, target,
+            λ -> error("generate not used"),
+            (λ, o) -> log(max(λ, 1e-300)) - λ * o;
+            likelihood_family = Exponential())
+
     else
         error("unknown kernel type: $t")
     end

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -14,6 +14,7 @@ representation — only the ID.
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "src"))
 using Credence
 using Credence: expect, condition, push_measure, draw, density
+using Credence: _dispatch_path
 using Credence: weights, mean, variance, prune, truncate, logsumexp
 using Credence: CategoricalMeasure, BetaMeasure, TaggedBetaMeasure
 using Credence: GaussianMeasure, GammaMeasure, DirichletMeasure
@@ -477,6 +478,8 @@ function handle_request(method::String, params, id)
         handle_replace_factor(params)
     elseif method == "n_factors"
         handle_n_factors(params)
+    elseif method == "_dispatch_path"
+        handle_dispatch_path(params)
     else
         throw(MethodNotFound(string(method)))
     end
@@ -628,6 +631,25 @@ function handle_n_factors(params)
     state = get_state(id)
     state isa ProductMeasure || error("n_factors requires a ProductMeasure, got $(typeof(state))")
     Dict("n_factors" => length(state.factors))
+end
+
+# ── Move 4: _dispatch_path observability hook (underscore-prefixed, test-only) ──
+# Returns "conjugate" if the (state, kernel) pair matches a registered
+# conjugate entry in the ConjugatePrevision registry; "particle" otherwise.
+# Does NOT mutate state or execute an update. Used by Stratum-2 tests to
+# assert registry-dispatch decisions explicitly — silent registry misses
+# would fall through to particle and produce correct values for the wrong
+# reason without this hook.
+#
+# Accepts a Measure state; the shield forwards to the prevision-level
+# `_dispatch_path` declared in src/prevision.jl.
+
+function handle_dispatch_path(params)
+    id = string(params["state_id"])
+    state = get_state(id)
+    kernel = build_kernel(params["kernel"])
+    path = _dispatch_path(state.prevision, kernel)
+    Dict("path" => string(path))
 end
 
 function handle_condition(params)

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -427,6 +427,167 @@ def test_v1_snapshot_fails_loudly():
         skin.shutdown()
 
 
+def test_beta_bernoulli_conjugate():
+    """Beta-Bernoulli conjugate: _dispatch_path == 'conjugate'; posterior bit-exact.
+
+    Stratum-2 contract (Move 4): dispatch-path assertion FIRST, then value —
+    a silent registry miss would still produce the correct value via the
+    particle path, so pinning the path is load-bearing.
+    """
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        sid = skin.create_state(type="beta", alpha=2.0, beta=3.0)
+        kernel = {"type": "bernoulli"}
+
+        path = skin._dispatch_path(sid, kernel)
+        assert path == "conjugate", f"Expected 'conjugate', got {path!r}"
+
+        skin.condition(sid, kernel=kernel, observation=1.0)
+        m = skin.mean(sid)
+        assert m == 3 / 6, f"Beta(3,3) mean = 3/6 (exact), got {m}"
+
+        skin.destroy_state(sid)
+        print("PASS: beta-bernoulli conjugate (dispatch-path pinned, α+1 exact)")
+    finally:
+        skin.shutdown()
+
+
+def test_flat_likelihood_no_op():
+    """BetaMeasure + Flat likelihood: posterior equals prior bit-exactly."""
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        sid = skin.create_state(type="beta", alpha=4.0, beta=7.0)
+        m_before = skin.mean(sid)
+        assert m_before == 4.0 / 11.0, f"Beta(4,7) mean = 4/11, got {m_before}"
+
+        kernel = {"type": "flat"}
+        path = skin._dispatch_path(sid, kernel)
+        assert path == "conjugate", f"Expected 'conjugate', got {path!r}"
+
+        # Flat is obs-agnostic; any obs leaves α, β untouched.
+        skin.condition(sid, kernel=kernel, observation=1.0)
+        m_after = skin.mean(sid)
+        assert m_after == m_before, f"Flat no-op drifted: {m_before} → {m_after}"
+
+        skin.destroy_state(sid)
+        print("PASS: flat likelihood no-op (dispatch-path pinned, prior preserved)")
+    finally:
+        skin.shutdown()
+
+
+def test_gaussian_normal_conjugate():
+    """Gaussian-NormalNormal conjugate: closed-form posterior mean.
+
+    Prior: N(0, 1). Obs: 2.0 with σ_obs = 1. Posterior precision τ_post = 2;
+    posterior mean μ_post = (1·0 + 1·2) / 2 = 1.0 — bit-exact integer ratio.
+    """
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        sid = skin.create_state(type="gaussian", mu=0.0, sigma=1.0)
+
+        # Skin's gaussian_known_var kernel declares params[:sigma_obs]; the
+        # registry matches on that legacy pattern and produces a
+        # ConjugatePrevision{GaussianPrevision, NormalNormal}.
+        kernel = {"type": "gaussian_known_var", "variance": 1.0}
+        path = skin._dispatch_path(sid, kernel)
+        assert path == "conjugate", f"Expected 'conjugate', got {path!r}"
+
+        skin.condition(sid, kernel=kernel, observation=2.0)
+        m = skin.mean(sid)
+        assert m == 1.0, f"Gaussian posterior μ = (τ_prior·0 + τ_obs·2)/2 = 1.0 exact, got {m}"
+
+        skin.destroy_state(sid)
+        print("PASS: gaussian-normal conjugate (dispatch-path pinned, μ_post exact)")
+    finally:
+        skin.shutdown()
+
+
+def test_dirichlet_categorical_conjugate():
+    """Dirichlet-Categorical conjugate: α at observed idx increments by 1."""
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        sid = skin.create_state(type="dirichlet", alpha=[2.0, 3.0, 5.0])
+        w_before = skin.weights(sid)
+        assert w_before == [0.2, 0.3, 0.5], f"expected [0.2, 0.3, 0.5], got {w_before}"
+
+        # Observe category index 1 (label 1.0). Posterior α = [2, 4, 5].
+        kernel = {"type": "categorical", "categories": [0.0, 1.0, 2.0]}
+        path = skin._dispatch_path(sid, kernel)
+        assert path == "conjugate", f"Expected 'conjugate', got {path!r}"
+
+        skin.condition(sid, kernel=kernel, observation=1.0)
+        w_after = skin.weights(sid)
+        # α/sum(α) = [2, 4, 5]/11
+        expected = [2.0 / 11.0, 4.0 / 11.0, 5.0 / 11.0]
+        assert w_after == expected, f"Dirichlet α increment drifted: {expected} vs {w_after}"
+
+        skin.destroy_state(sid)
+        print("PASS: dirichlet-categorical conjugate (dispatch-path pinned, α[1]+=1 exact)")
+    finally:
+        skin.shutdown()
+
+
+def test_normal_gamma_conjugate():
+    """NormalGamma + NormalGammaLikelihood conjugate: closed-form κ/μ/α/β update.
+
+    Prior: κ=1, μ=0, α=2, β=2. Obs: r=2.0.
+    Posterior: κ_n = 2, μ_n = (1·0 + 2)/2 = 1.0, α_n = 2.5,
+               β_n = 2 + 1·(2−0)²/(2·2) = 2 + 1 = 3.0. All exact.
+    """
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        sid = skin.create_state(type="normal_gamma", kappa=1.0, mu=0.0, alpha=2.0, beta=2.0)
+        m_before = skin.mean(sid)
+        assert m_before == 0.0, f"NormalGamma mean = μ = 0.0, got {m_before}"
+
+        kernel = {"type": "normal_gamma"}
+        path = skin._dispatch_path(sid, kernel)
+        assert path == "conjugate", f"Expected 'conjugate', got {path!r}"
+
+        skin.condition(sid, kernel=kernel, observation=2.0)
+        m_after = skin.mean(sid)
+        # Posterior mean is μ_n = 1.0 exact.
+        assert m_after == 1.0, f"NormalGamma posterior μ_n = 1.0 exact, got {m_after}"
+
+        skin.destroy_state(sid)
+        print("PASS: normal-gamma conjugate (dispatch-path pinned, μ_n exact)")
+    finally:
+        skin.shutdown()
+
+
+def test_gamma_exponential_conjugate():
+    """Gamma-Exponential conjugate (net-new in Move 4): α+1, β+obs.
+
+    Prior: Gamma(2, 3) — mean α/β = 2/3 exact. Obs: λ_obs = 4.0.
+    Posterior: Gamma(3, 7) — mean 3/7 exact.
+    """
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        sid = skin.create_state(type="gamma", alpha=2.0, beta=3.0)
+        m_before = skin.mean(sid)
+        assert m_before == 2.0 / 3.0, f"Gamma(2,3) mean = 2/3, got {m_before}"
+
+        kernel = {"type": "exponential"}
+        path = skin._dispatch_path(sid, kernel)
+        assert path == "conjugate", f"Expected 'conjugate', got {path!r}"
+
+        skin.condition(sid, kernel=kernel, observation=4.0)
+        m_after = skin.mean(sid)
+        # Gamma(3, 7) mean = 3/7 exact.
+        assert m_after == 3.0 / 7.0, f"Gamma posterior mean = 3/7 exact, got {m_after}"
+
+        skin.destroy_state(sid)
+        print("PASS: gamma-exponential conjugate (dispatch-path pinned, net-new fast-path)")
+    finally:
+        skin.shutdown()
+
+
 def test_unknown_state_id():
     """Operations on a never-registered state_id return StateNotFound (-32000)."""
     skin = SkinClient()
@@ -549,6 +710,18 @@ if __name__ == "__main__":
     test_dirichlet_roundtrip()
     print()
     test_v1_snapshot_fails_loudly()
+    print()
+    test_beta_bernoulli_conjugate()
+    print()
+    test_flat_likelihood_no_op()
+    print()
+    test_gaussian_normal_conjugate()
+    print()
+    test_dirichlet_categorical_conjugate()
+    print()
+    test_normal_gamma_conjugate()
+    print()
+    test_gamma_exponential_conjugate()
     print()
     test_unknown_state_id()
     print()

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -39,6 +39,7 @@ export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals,
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target
 export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
+export NormalNormal, Categorical, NormalGammaLikelihood, Exponential
 export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
 export indicator_kernel, feature_value, BOOLEAN_SPACE
 export Functional, Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -25,6 +25,7 @@ module Ontology
 import ..Previsions: TestFunction, Identity, Projection, NestedProjection,
                      Tabular, LinearCombination, OpaqueClosure, expect
 import ..Previsions: BetaPrevision, TaggedBetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision
+import ..Previsions: ConjugatePrevision, maybe_conjugate, update, _dispatch_path
 
 export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals, support
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, ProductMeasure, MixtureMeasure
@@ -877,6 +878,42 @@ expect(m::MixtureMeasure, o::OpaqueClosure; kwargs...) = expect(m, o.f; kwargs..
 # Bayesian inversion: prior × kernel × observation → posterior
 # P(h|o) ∝ P(o|h) · P(h)
 # The ONE learning mechanism.
+
+# ── Conjugate registry (Move 4) ──────────────────────────────────────────
+#
+# `maybe_conjugate(p::Prevision, k::Kernel)` dispatches on the Prior type
+# and returns a `ConjugatePrevision` when a closed-form update exists.
+# `update(cp::ConjugatePrevision{Prior, Likelihood}, obs)` applies that
+# update. The `Likelihood` type parameter is the kernel's
+# `likelihood_family` type or a pair-specific marker.
+#
+# The facade that routes `condition` through this registry lives further
+# down (per-Measure-subtype method bodies); this section only declares
+# the per-pair methods.
+#
+# For transitional scaffolding: TaggedBetaPrevision does NOT get a
+# `maybe_conjugate` method — the per-tag routing loop in
+# `condition(::TaggedBetaMeasure, ...)` handles it until Move 5's
+# `MixturePrevision` lands. See move-4-design.md §3 and R3.
+
+# ── Pair: (BetaPrevision, BetaBernoulli) — replaces src/ontology.jl:891-904 ──
+
+function maybe_conjugate(p::BetaPrevision, k::Kernel)
+    if k.likelihood_family isa BetaBernoulli
+        return ConjugatePrevision(p, k.likelihood_family)
+    end
+    nothing
+end
+
+function update(cp::ConjugatePrevision{BetaPrevision, BetaBernoulli}, obs)
+    if obs == 1 || obs == 1.0 || obs === true
+        ConjugatePrevision(BetaPrevision(cp.prior.alpha + 1.0, cp.prior.beta), cp.likelihood)
+    elseif obs == 0 || obs == 0.0 || obs === false
+        ConjugatePrevision(BetaPrevision(cp.prior.alpha, cp.prior.beta + 1.0), cp.likelihood)
+    else
+        error("BetaBernoulli update: obs must be ∈ {0, 1, true, false}, got $obs")
+    end
+end
 
 function condition(m::CategoricalMeasure{T}, k::Kernel, observation) where T
     new_logw = copy(m.logw)

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -443,10 +443,17 @@ struct NormalNormal <: LeafFamily
     sigma_obs::Float64
 end
 
-# Move 4: Dirichlet-Categorical conjugate pair. No carried params; the
-# observation is the category value (looked up in DirichletMeasure's
-# categories at update time).
-struct Categorical <: LeafFamily end
+# Move 4: Dirichlet-Categorical conjugate pair. Carries the category
+# labels because the `update` step needs to look up the observation's
+# index, and at the Prevision level (where update lives) there's no
+# access to the Measure's `.categories` field. Minor semantic impurity
+# (a label list in a Likelihood) accepted for registry cleanliness;
+# legacy kernels that don't carry this field are handled at Phase 3's
+# Measure-level condition facade by synthesizing a `Categorical(cat)`
+# marker from the Measure's own `.categories`.
+struct Categorical{T} <: LeafFamily
+    categories::Finite{T}
+end
 
 # Move 4: NormalGamma conjugate pair. No carried params; the update
 # uses the prior's (κ, μ, α, β) hyperparameters and the scalar obs.
@@ -976,6 +983,26 @@ function update(cp::ConjugatePrevision{GaussianPrevision, NormalNormal}, obs)
     μ_post = (τ_prior * cp.prior.mu + τ_obs * Float64(obs)) / τ_post
     σ_post = 1.0 / sqrt(τ_post)
     ConjugatePrevision(GaussianPrevision(μ_post, σ_post), cp.likelihood)
+end
+
+# ── (DirichletPrevision, Categorical) — replaces ontology.jl:964-974 ──
+#
+# Posterior update: α[idx] += 1 where idx is the observation's position
+# in the category list carried by the Categorical likelihood marker.
+
+function maybe_conjugate(p::DirichletPrevision, k::Kernel)
+    if k.likelihood_family isa Categorical
+        return ConjugatePrevision(p, k.likelihood_family)
+    end
+    nothing
+end
+
+function update(cp::ConjugatePrevision{DirichletPrevision, Categorical{T}}, obs) where T
+    idx = findfirst(==(obs), cp.likelihood.categories.values)
+    idx !== nothing || error("observation $obs not in categories $(cp.likelihood.categories.values)")
+    new_alpha = copy(cp.prior.alpha)
+    new_alpha[idx] += 1.0
+    ConjugatePrevision(DirichletPrevision(new_alpha), cp.likelihood)
 end
 
 function condition(m::CategoricalMeasure{T}, k::Kernel, observation) where T

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1063,18 +1063,26 @@ function condition(m::CategoricalMeasure{T}, k::Kernel, observation) where T
 end
 
 function condition(m::BetaMeasure, k::Kernel, observation)
-    # Conjugate path: Beta-Bernoulli requires Interval → Finite with exactly 2 outcomes
+    # Move 4: try the ConjugatePrevision registry first. Beta-Bernoulli
+    # and Beta-Flat are registered (see maybe_conjugate(::BetaPrevision,
+    # ...) above). Legacy structural dispatch (Interval → Finite with 2
+    # outcomes but no explicit BetaBernoulli family) remains below for
+    # kernels constructed without declaring likelihood_family.
+    cp = maybe_conjugate(m.prevision, k)
+    if cp !== nothing
+        updated = update(cp, observation).prior
+        return BetaMeasure(m.space, updated.alpha, updated.beta)
+    end
+    # Legacy structural path: Interval → Finite(0,1) kernel without
+    # declared BetaBernoulli family — synthesize the conjugate pair.
     if k.source isa Interval && k.target isa Finite && length(k.target.values) == 2
         if observation == 1 || observation == 1.0 || observation == true
-            BetaMeasure(m.space, m.alpha + 1.0, m.beta)
+            return BetaMeasure(m.space, m.alpha + 1.0, m.beta)
         elseif observation == 0 || observation == 0.0 || observation == false
-            BetaMeasure(m.space, m.alpha, m.beta + 1.0)
-        else
-            _condition_by_grid(m, k, observation)
+            return BetaMeasure(m.space, m.alpha, m.beta + 1.0)
         end
-    else
-        _condition_by_grid(m, k, observation)
     end
+    _condition_by_grid(m, k, observation)
 end
 
 struct DepthCapExceeded <: Exception
@@ -1121,41 +1129,44 @@ function condition(m::TaggedBetaMeasure, k::Kernel, observation)
 end
 
 function condition(m::GaussianMeasure, k::Kernel, observation)
-    # Conjugate path: Normal-Normal requires Euclidean → Euclidean with declared σ_obs
-    if k.source isa Euclidean && k.target isa Euclidean &&
-       k.params !== nothing && haskey(k.params, :sigma_obs)
-        sigma_obs = k.params[:sigma_obs]::Float64
-        tau_prior = 1.0 / m.sigma^2
-        tau_obs = 1.0 / sigma_obs^2
-        tau_post = tau_prior + tau_obs
-        mu_post = (tau_prior * m.mu + tau_obs * observation) / tau_post
-        sigma_post = 1.0 / sqrt(tau_post)
-        return GaussianMeasure(m.space, mu_post, sigma_post)
+    # Move 4: try the ConjugatePrevision registry first. Covers both
+    # `likelihood_family = NormalNormal(σ)` and the legacy `params =
+    # Dict(:sigma_obs => σ)` paths.
+    cp = maybe_conjugate(m.prevision, k)
+    if cp !== nothing
+        updated = update(cp, observation).prior
+        return GaussianMeasure(m.space, updated.mu, updated.sigma)
     end
     _condition_by_grid(m, k, observation)
 end
 
 function condition(m::DirichletMeasure, k::Kernel, observation)
+    # Move 4: try the ConjugatePrevision registry first (kernels that
+    # explicitly declare likelihood_family = Categorical(cats)).
+    cp = maybe_conjugate(m.prevision, k)
+    if cp !== nothing
+        updated = update(cp, observation).prior
+        return DirichletMeasure(m.space, m.categories, updated.alpha)
+    end
+    # Legacy structural match: Simplex → Finite kernel without an
+    # explicit Categorical family. Synthesize Categorical(m.categories)
+    # at the facade level — the Measure carries the category labels;
+    # the Prevision does not.
     k.source isa Simplex && k.target isa Finite ||
         error("DirichletMeasure condition requires a Categorical kernel (Simplex → Finite)")
-
-    idx = findfirst(==(observation), m.categories.values)
-    idx !== nothing || error("observation $observation not in categories $(m.categories.values)")
-
-    new_alpha = copy(m.alpha)
-    new_alpha[idx] += 1.0
-    DirichletMeasure(m.space, m.categories, new_alpha)
+    synthetic_cp = ConjugatePrevision(m.prevision, Categorical(m.categories))
+    updated = update(synthetic_cp, observation).prior
+    DirichletMeasure(m.space, m.categories, updated.alpha)
 end
 
 function condition(m::NormalGammaMeasure, k::Kernel, observation)
-    # Conjugate fast-path: Normal likelihood with Normal-Gamma prior
-    if k.params !== nothing && haskey(k.params, :normal_gamma)
-        r = Float64(observation)
-        κₙ = m.κ + 1.0
-        μₙ = (m.κ * m.μ + r) / κₙ
-        αₙ = m.α + 0.5
-        βₙ = m.β + m.κ * (r - m.μ)^2 / (2.0 * κₙ)
-        return NormalGammaMeasure(m.space, κₙ, μₙ, αₙ, βₙ)
+    # Move 4: try the ConjugatePrevision registry first. Covers both
+    # `likelihood_family = NormalGammaLikelihood()` and the legacy
+    # `params[:normal_gamma]` paths.
+    cp = maybe_conjugate(m.prevision, k)
+    if cp !== nothing
+        updated = update(cp, observation).prior
+        return NormalGammaMeasure(m.space, updated.κ, updated.μ, updated.α, updated.β)
     end
     # Non-conjugate: importance sampling fallback
     condition(m::Measure, k, observation)

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1005,6 +1005,53 @@ function update(cp::ConjugatePrevision{DirichletPrevision, Categorical{T}}, obs)
     ConjugatePrevision(DirichletPrevision(new_alpha), cp.likelihood)
 end
 
+# ── (NormalGammaPrevision, NormalGammaLikelihood) — replaces ontology.jl:976-988 ──
+#
+# NormalGamma is the conjugate prior for a Normal with unknown mean AND
+# unknown variance. Update closed-form: κ_n = κ + 1, μ_n = (κμ + r)/κ_n,
+# α_n = α + 1/2, β_n = β + κ(r-μ)²/(2κ_n). Backward compat via
+# params[:normal_gamma] flag (existing kernels); forward path via
+# likelihood_family = NormalGammaLikelihood().
+
+function maybe_conjugate(p::NormalGammaPrevision, k::Kernel)
+    if k.likelihood_family isa NormalGammaLikelihood
+        return ConjugatePrevision(p, k.likelihood_family)
+    elseif k.params !== nothing && haskey(k.params, :normal_gamma)
+        return ConjugatePrevision(p, NormalGammaLikelihood())
+    end
+    nothing
+end
+
+function update(cp::ConjugatePrevision{NormalGammaPrevision, NormalGammaLikelihood}, obs)
+    r = Float64(obs)
+    κ, μ, α, β = cp.prior.κ, cp.prior.μ, cp.prior.α, cp.prior.β
+    κₙ = κ + 1.0
+    μₙ = (κ * μ + r) / κₙ
+    αₙ = α + 0.5
+    βₙ = β + κ * (r - μ)^2 / (2.0 * κₙ)
+    ConjugatePrevision(NormalGammaPrevision(κₙ, μₙ, αₙ, βₙ), cp.likelihood)
+end
+
+# ── (GammaPrevision, Exponential) — net-new fast-path (no prior dispatch) ──
+#
+# Conjugate update for Gamma(α, β) as prior on the rate parameter of
+# an Exponential likelihood: posterior is Gamma(α + 1, β + obs).
+# No legacy path — this pair wasn't previously dispatched; existing
+# code falls through to particle.
+
+function maybe_conjugate(p::GammaPrevision, k::Kernel)
+    if k.likelihood_family isa Exponential
+        return ConjugatePrevision(p, k.likelihood_family)
+    end
+    nothing
+end
+
+function update(cp::ConjugatePrevision{GammaPrevision, Exponential}, obs)
+    r = Float64(obs)
+    r > 0 || error("Exponential observations must be positive, got $r")
+    ConjugatePrevision(GammaPrevision(cp.prior.alpha + 1.0, cp.prior.beta + r), cp.likelihood)
+end
+
 function condition(m::CategoricalMeasure{T}, k::Kernel, observation) where T
     new_logw = copy(m.logw)
     for i in eachindex(m.space.values)

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -901,6 +901,8 @@ expect(m::MixtureMeasure, o::OpaqueClosure; kwargs...) = expect(m, o.f; kwargs..
 function maybe_conjugate(p::BetaPrevision, k::Kernel)
     if k.likelihood_family isa BetaBernoulli
         return ConjugatePrevision(p, k.likelihood_family)
+    elseif k.likelihood_family isa Flat
+        return ConjugatePrevision(p, k.likelihood_family)
     end
     nothing
 end
@@ -913,6 +915,15 @@ function update(cp::ConjugatePrevision{BetaPrevision, BetaBernoulli}, obs)
     else
         error("BetaBernoulli update: obs must be ∈ {0, 1, true, false}, got $obs")
     end
+end
+
+# (BetaPrevision, Flat) — no-op. A Flat likelihood does not depend on the
+# Beta parameter; the posterior is the prior unchanged. Replaces the
+# no-op path at src/ontology.jl:612-613 (inside TaggedBetaMeasure
+# routing) for direct BetaPrevision + Flat kernel matches.
+
+function update(cp::ConjugatePrevision{BetaPrevision, Flat}, obs)
+    cp  # no-op
 end
 
 function condition(m::CategoricalMeasure{T}, k::Kernel, observation) where T

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -31,6 +31,7 @@ export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals,
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target, kernel_params
 export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
+export NormalNormal, Categorical, NormalGammaLikelihood, Exponential
 export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
 export indicator_kernel, feature_value, BOOLEAN_SPACE
 export Functional, Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure
@@ -432,6 +433,29 @@ struct Flat <: LeafFamily end
 # clear error, since TaggedBetaMeasure conditioning requires a declared
 # leaf or routing family.
 struct PushOnly <: LikelihoodFamily end
+
+# Move 4: Gaussian-Normal conjugate pair. Carries the observation noise
+# stdev sigma_obs. Legacy kernels passed this via `params[:sigma_obs]`
+# + `likelihood_family = PushOnly()`; new kernels declare directly via
+# `likelihood_family = NormalNormal(sigma_obs)`. maybe_conjugate matches
+# either shape for backward compat.
+struct NormalNormal <: LeafFamily
+    sigma_obs::Float64
+end
+
+# Move 4: Dirichlet-Categorical conjugate pair. No carried params; the
+# observation is the category value (looked up in DirichletMeasure's
+# categories at update time).
+struct Categorical <: LeafFamily end
+
+# Move 4: NormalGamma conjugate pair. No carried params; the update
+# uses the prior's (κ, μ, α, β) hyperparameters and the scalar obs.
+struct NormalGammaLikelihood <: LeafFamily end
+
+# Move 4: Gamma-Exponential conjugate pair (net-new fast-path). No
+# carried params; Exponential observations are positive reals consumed
+# by the Gamma update as (shape+1, rate+obs).
+struct Exponential <: LeafFamily end
 
 # Fire/not-fire routing by component tag. Tags in `fires` use
 # `when_fires`; all other tags use `when_not`. This is the declarative
@@ -924,6 +948,34 @@ end
 
 function update(cp::ConjugatePrevision{BetaPrevision, Flat}, obs)
     cp  # no-op
+end
+
+# ── (GaussianPrevision, NormalNormal) — replaces ontology.jl:949-961 ──
+#
+# Precision-weighted posterior under known observation noise. Accepts
+# kernels constructed either with `likelihood_family = NormalNormal(σ)`
+# (forward-looking) or with `params = Dict(:sigma_obs => σ)` +
+# `likelihood_family = PushOnly()` (legacy, used by existing tests).
+# Both paths are treated as conjugate.
+
+function maybe_conjugate(p::GaussianPrevision, k::Kernel)
+    if k.likelihood_family isa NormalNormal
+        return ConjugatePrevision(p, k.likelihood_family)
+    elseif k.params !== nothing && haskey(k.params, :sigma_obs)
+        sigma_obs = k.params[:sigma_obs]::Float64
+        return ConjugatePrevision(p, NormalNormal(sigma_obs))
+    end
+    nothing
+end
+
+function update(cp::ConjugatePrevision{GaussianPrevision, NormalNormal}, obs)
+    sigma_obs = cp.likelihood.sigma_obs
+    τ_prior = 1.0 / cp.prior.sigma^2
+    τ_obs = 1.0 / sigma_obs^2
+    τ_post = τ_prior + τ_obs
+    μ_post = (τ_prior * cp.prior.mu + τ_obs * Float64(obs)) / τ_post
+    σ_post = 1.0 / sqrt(τ_post)
+    ConjugatePrevision(GaussianPrevision(μ_post, σ_post), cp.likelihood)
 end
 
 function condition(m::CategoricalMeasure{T}, k::Kernel, observation) where T

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1172,6 +1172,18 @@ function condition(m::NormalGammaMeasure, k::Kernel, observation)
     condition(m::Measure, k, observation)
 end
 
+function condition(m::GammaMeasure, k::Kernel, observation)
+    # Move 4: (GammaPrevision, Exponential) is net-new fast-path — no
+    # legacy condition method existed. Registry lookup; fallback to
+    # generic particle path for any other kernel.
+    cp = maybe_conjugate(m.prevision, k)
+    if cp !== nothing
+        updated = update(cp, observation).prior
+        return GammaMeasure(m.space, updated.alpha, updated.beta)
+    end
+    condition(m::Measure, k, observation)
+end
+
 function _condition_by_grid(m::BetaMeasure, k::Kernel, observation; n::Int=64)
     grid = collect(range(m.space.lo + 1e-10, m.space.hi - 1e-10, length=n))
     logw = Float64[]

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -31,6 +31,7 @@ module Previsions
 export Prevision, TestFunction, Indicator, apply, expect
 export Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure
 export BetaPrevision, TaggedBetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision
+export ConjugatePrevision, maybe_conjugate, update, _dispatch_path
 # At Move 2, `Ontology`'s `Functional` hierarchy is aliased onto these
 # types (`const Functional = TestFunction` plus `import ..Previsions:
 # Identity, …`), so both modules export the same bindings (they resolve
@@ -412,5 +413,78 @@ methods; Move 7 inverts the derivation (`expect(p, f)` becomes the
 primitive, `condition(p, k, obs)` derived via `Indicator(ObservationEvent(k, obs))`).
 """
 function expect end
+
+# ── ConjugatePrevision registry (Move 4) ──────────────────────────────────
+
+"""
+    ConjugatePrevision{Prior, Likelihood}(prior::Prior, likelihood::Likelihood)
+
+Parametric wrapper representing a (Prior, Likelihood) pair for which a
+closed-form posterior update exists. Moves the case-analytic conjugate
+dispatch in `condition` into a type-structural registry: adding a pair
+is adding one `update` method, not editing a branch in a central
+function.
+
+Per Move 4 design doc §5.1, the registry is method-based (Julia's
+method table *is* the registry). `maybe_conjugate(p, k)` is the lookup
+function; methods specialised on (Prior, Likelihood) pairs return a
+`ConjugatePrevision` when the pair matches, `nothing` otherwise. `update`
+is dispatched on the parametric type to apply the conjugate update in
+closed form.
+
+The `Likelihood` type parameter is the kernel's `likelihood_family`
+type or a pair-specific marker (for pairs where the existing kernel
+dispatches on `params` rather than `likelihood_family`).
+"""
+struct ConjugatePrevision{Prior, Likelihood} <: Prevision
+    prior::Prior
+    likelihood::Likelihood
+end
+
+"""
+    maybe_conjugate(p::Prevision, k::Kernel) → Union{ConjugatePrevision, Nothing}
+
+Registry lookup. Returns a `ConjugatePrevision{Prior, Likelihood}` if
+the (prior, kernel) pair has a registered closed-form update; `nothing`
+otherwise (caller falls through to particle/grid).
+
+Default method returns `nothing`; specific methods on (Prior, Likelihood)
+type pairs are declared in `ontology.jl` where the `Prior` and
+`Likelihood` types are in scope. A `nothing` return is NOT an error —
+it's the standard "not conjugate; use particle" path.
+
+The TaggedBetaPrevision case specifically returns `nothing` as
+transitional scaffolding until Move 5's `MixturePrevision` takes over
+per-component routing. See `docs/posture-3/move-4-design.md` §3 and R3.
+"""
+maybe_conjugate(p::Prevision, k) = nothing
+
+"""
+    update(cp::ConjugatePrevision{Prior, Likelihood}, obs) → ConjugatePrevision
+
+Apply the closed-form conjugate update for the (Prior, Likelihood) pair.
+Returns a new `ConjugatePrevision` with the updated prior; caller
+typically takes `.prior` to extract the posterior Prevision.
+
+Specialised methods attach per (Prior, Likelihood) pair in `ontology.jl`.
+No default method — calling `update` on an unregistered pair is a
+MethodError, which is the expected behaviour (the registry should not
+have returned a ConjugatePrevision without a matching update method).
+"""
+function update end
+
+"""
+    _dispatch_path(p::Prevision, k::Kernel) → Symbol
+
+Observability hook (Move 4 §5.2). Returns `:conjugate` if
+`maybe_conjugate(p, k)` matches, `:particle` otherwise. Underscore-
+prefixed per the repo conventions (see `CLAUDE.md` §Repo conventions §
+Scope boundary): test-only surface, not a production API.
+
+Used in Stratum-2 tests to pin dispatch-path decisions explicitly —
+without it, a silent registry miss would fall through to particle and
+produce the correct value for the wrong reason.
+"""
+_dispatch_path(p::Prevision, k) = maybe_conjugate(p, k) === nothing ? :particle : :conjugate
 
 end # module Previsions

--- a/test/test_prevision_conjugate.jl
+++ b/test/test_prevision_conjugate.jl
@@ -170,6 +170,41 @@ let k_legacy = Kernel(Euclidean(1), Euclidean(1),
           updated.mu == 1.0, "got μ=$(updated.mu)")
 end
 
+# ── (DirichletPrevision, Categorical) ──
+#
+# Carries category labels in the Categorical marker — necessary because
+# the update needs idx = position-in-categories, and at the Prevision
+# level there's no access to the Measure's categories field.
+
+let cats = Finite([:a, :b, :c])
+    k = Kernel(Simplex(3), cats,
+               θ -> CategoricalMeasure(cats),
+               (θ, o) -> log(max(θ[findfirst(==(o), cats.values)], 1e-300));
+               likelihood_family = Categorical(cats))
+    using Credence: DirichletPrevision
+
+    p = DirichletPrevision([2.0, 3.0, 5.0])
+
+    check("DirichletPrevision + Categorical → :conjugate",
+          _dispatch_path(p, k) === :conjugate,
+          "got $(_dispatch_path(p, k))")
+
+    cp = maybe_conjugate(p, k)
+    check("maybe_conjugate returns ConjugatePrevision{DirichletPrevision, Categorical{Symbol}}",
+          cp isa ConjugatePrevision{DirichletPrevision, Categorical{Symbol}},
+          "got $(typeof(cp))")
+
+    # Observing :b (idx 2) → α[2] += 1
+    updated = update(cp, :b).prior
+    check("DirichletPrevision([2,3,5]) + obs=:b (idx 2) → α = [2, 4, 5] (==)",
+          updated.alpha == [2.0, 4.0, 5.0], "got α=$(updated.alpha)")
+
+    # Observing :a (idx 1) → α[1] += 1
+    updated_a = update(cp, :a).prior
+    check("DirichletPrevision([2,3,5]) + obs=:a → α = [3, 3, 5] (==)",
+          updated_a.alpha == [3.0, 3.0, 5.0], "got α=$(updated_a.alpha)")
+end
+
 # ── TaggedBetaPrevision: must NOT match as conjugate (transitional scaffolding) ──
 #
 # Per PR #19's Move 1 revision addendum (commit 6dce5e4), TaggedBetaMeasure

--- a/test/test_prevision_conjugate.jl
+++ b/test/test_prevision_conjugate.jl
@@ -1,0 +1,137 @@
+# test_prevision_conjugate.jl — Stratum-2 (composition equivalence) for the
+# Move 4 ConjugatePrevision registry.
+#
+# Per docs/posture-3/move-4-design.md §3, tolerances:
+#   - Closed-form conjugate arithmetic (integer α/β accumulation): `==`
+#   - Numerically-sensitive derived (e.g. Gaussian posterior μ via
+#     precision-weighted averaging): `rtol=1e-12`
+#   - Particle fallback under deterministic seeding: `==`
+#
+# Test structure per the Move 4 execution guidance: each conjugate-path
+# test asserts `_dispatch_path(p, k) == :conjugate` BEFORE the value
+# assertion. The dispatch-path assertion is the tripwire for silent
+# registry misses; without it, a miss would fall through to particle and
+# the value assertion might pass for the wrong reason.
+#
+# TaggedBetaPrevision specifically returns :particle — transitional
+# scaffolding per the pre-committed routing resolution (PR #19, commit
+# 6dce5e4). Move 5 moves this to MixturePrevision.
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: ConjugatePrevision, maybe_conjugate, update, _dispatch_path
+using Credence: BetaPrevision, TaggedBetaPrevision
+
+function check(name, cond, detail="")
+    if cond
+        println("PASSED: $name")
+    else
+        println("FAILED: $name — $detail")
+        error("Stratum-2 assertion failed: $name")
+    end
+end
+
+println("="^60)
+println("Stratum 2 — ConjugatePrevision registry (Move 4)")
+println("="^60)
+
+# ── (BetaPrevision, BetaBernoulli) — replaces src/ontology.jl:891-904 ──
+#
+# Test structure: dispatch path first, then value. Dispatch-path
+# assertion is load-bearing; a silent registry miss would pass the
+# value assertion for the wrong reason.
+
+let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
+               h -> CategoricalMeasure(Finite([0, 1])),
+               (h, o) -> o == 1 ? log(max(h, 1e-300)) : log(max(1-h, 1e-300));
+               likelihood_family = BetaBernoulli())
+    p = BetaPrevision(2.0, 3.0)
+
+    # Dispatch path FIRST.
+    check("BetaPrevision + BetaBernoulli → :conjugate",
+          _dispatch_path(p, k) === :conjugate,
+          "got $(_dispatch_path(p, k))")
+
+    # Value on obs=1: α+1, β unchanged. Bit-exact integer increment.
+    cp = maybe_conjugate(p, k)
+    check("maybe_conjugate returns ConjugatePrevision{BetaPrevision, BetaBernoulli}",
+          cp isa ConjugatePrevision{BetaPrevision, BetaBernoulli},
+          "got $(typeof(cp))")
+
+    updated_1 = update(cp, 1).prior
+    check("BetaPrevision(2, 3) × Bernoulli(obs=1) → BetaPrevision(3, 3) (==)",
+          updated_1.alpha == 3.0 && updated_1.beta == 3.0,
+          "got α=$(updated_1.alpha), β=$(updated_1.beta)")
+
+    # Value on obs=0: α unchanged, β+1.
+    updated_0 = update(cp, 0).prior
+    check("BetaPrevision(2, 3) × Bernoulli(obs=0) → BetaPrevision(2, 4) (==)",
+          updated_0.alpha == 2.0 && updated_0.beta == 4.0,
+          "got α=$(updated_0.alpha), β=$(updated_0.beta)")
+
+    # obs=true/false coerce identically.
+    check("BetaBernoulli obs=true ≡ obs=1",
+          update(cp, true).prior.alpha == 3.0,
+          "got α=$(update(cp, true).prior.alpha)")
+    check("BetaBernoulli obs=false ≡ obs=0",
+          update(cp, false).prior.beta == 4.0,
+          "got β=$(update(cp, false).prior.beta)")
+end
+
+# ── TaggedBetaPrevision: must NOT match as conjugate (transitional scaffolding) ──
+#
+# Per PR #19's Move 1 revision addendum (commit 6dce5e4), TaggedBetaMeasure
+# routing stays at the Measure level via the per-tag loop until Move 5's
+# MixturePrevision takes over. This test pins that contract — if a future
+# change to `maybe_conjugate` accidentally matches TaggedBetaPrevision,
+# the per-tag routing gets silently bypassed and mixture-aware tests
+# break in hard-to-diagnose ways. The guard here catches it at Stratum-2.
+
+let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
+               h -> CategoricalMeasure(Finite([0, 1])),
+               (h, o) -> 0.0;
+               likelihood_family = BetaBernoulli())
+    inner = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
+    tbp = TaggedBetaPrevision(42, inner)
+
+    check("TaggedBetaPrevision + BetaBernoulli → :particle (transitional scaffolding)",
+          _dispatch_path(tbp, k) === :particle,
+          "got $(_dispatch_path(tbp, k)); " *
+          "if this is :conjugate, the per-tag routing loop is silently bypassed — " *
+          "check maybe_conjugate(::TaggedBetaPrevision, ...) method (should not exist until Move 5)")
+
+    check("maybe_conjugate(TaggedBetaPrevision, BernoulliKernel) === nothing",
+          maybe_conjugate(tbp, k) === nothing,
+          "got $(maybe_conjugate(tbp, k))")
+end
+
+# ── Other Prevision types without registered conjugate pairs yet: particle ──
+#
+# Phase 1 registers BetaBernoulli only. Other previsions fall through
+# to :particle; Phases 2-6 add their registry entries. This guard
+# asserts the current state — if a future Phase 2 commit accidentally
+# over-matches (e.g. maybe_conjugate(::GaussianPrevision, ...) matching
+# too eagerly and firing for non-NormalNormal kernels), the value
+# assertion below catches it.
+
+let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
+               h -> CategoricalMeasure(Finite([0, 1])),
+               (h, o) -> 0.0;
+               likelihood_family = BetaBernoulli())
+    using Credence: GaussianPrevision, GammaPrevision, DirichletPrevision, NormalGammaPrevision
+
+    # Gaussian with a Bernoulli-ish kernel — should definitively NOT match.
+    check("GaussianPrevision + BetaBernoulli kernel → :particle (no registered pair)",
+          _dispatch_path(GaussianPrevision(0.0, 1.0), k) === :particle,
+          "got $(_dispatch_path(GaussianPrevision(0.0, 1.0), k))")
+
+    # Gamma with a Bernoulli-ish kernel — should NOT match.
+    check("GammaPrevision + BetaBernoulli kernel → :particle",
+          _dispatch_path(GammaPrevision(2.0, 1.0), k) === :particle,
+          "got $(_dispatch_path(GammaPrevision(2.0, 1.0), k))")
+end
+
+println()
+println("="^60)
+println("ALL STRATUM-2 TESTS PASSED (Phase 1: BetaBernoulli only)")
+println("="^60)

--- a/test/test_prevision_conjugate.jl
+++ b/test/test_prevision_conjugate.jl
@@ -78,6 +78,39 @@ let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
           "got β=$(update(cp, false).prior.beta)")
 end
 
+# ── (BetaPrevision, Flat) — no-op ──
+#
+# A Flat kernel's likelihood does not depend on the Beta parameter;
+# the posterior equals the prior. The registry handles this as a
+# registered conjugate entry (the update is the identity function).
+
+let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
+               h -> CategoricalMeasure(Finite([0, 1])),
+               (h, o) -> 0.0;  # flat log-density
+               likelihood_family = Flat())
+    p = BetaPrevision(2.0, 3.0)
+
+    check("BetaPrevision + Flat → :conjugate",
+          _dispatch_path(p, k) === :conjugate,
+          "got $(_dispatch_path(p, k))")
+
+    cp = maybe_conjugate(p, k)
+    check("maybe_conjugate returns ConjugatePrevision{BetaPrevision, Flat}",
+          cp isa ConjugatePrevision{BetaPrevision, Flat},
+          "got $(typeof(cp))")
+
+    updated = update(cp, 1).prior
+    check("BetaPrevision(2, 3) × Flat → BetaPrevision(2, 3) (unchanged, ==)",
+          updated.alpha == 2.0 && updated.beta == 3.0,
+          "got α=$(updated.alpha), β=$(updated.beta)")
+
+    # Flat is observation-agnostic: any obs leaves the prior unchanged.
+    updated_anything = update(cp, 0.7).prior
+    check("BetaPrevision × Flat is obs-agnostic (arbitrary obs → same posterior)",
+          updated_anything.alpha == 2.0 && updated_anything.beta == 3.0,
+          "got α=$(updated_anything.alpha), β=$(updated_anything.beta)")
+end
+
 # ── TaggedBetaPrevision: must NOT match as conjugate (transitional scaffolding) ──
 #
 # Per PR #19's Move 1 revision addendum (commit 6dce5e4), TaggedBetaMeasure

--- a/test/test_prevision_conjugate.jl
+++ b/test/test_prevision_conjugate.jl
@@ -111,6 +111,65 @@ let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
           "got α=$(updated_anything.alpha), β=$(updated_anything.beta)")
 end
 
+# ── (GaussianPrevision, NormalNormal) ──
+#
+# Precision-weighted posterior. Tests both the new likelihood_family
+# pattern (NormalNormal(sigma_obs)) and the legacy params-based pattern
+# for backward compat.
+
+let k_new = Kernel(Euclidean(1), Euclidean(1),
+                   h -> GaussianMeasure(Euclidean(1), h, 1.0),
+                   (h, o) -> -0.5 * (o - h)^2;
+                   likelihood_family = NormalNormal(1.0))
+    using Credence: GaussianPrevision
+
+    p = GaussianPrevision(0.0, 1.0)
+
+    check("GaussianPrevision + NormalNormal (new likelihood_family) → :conjugate",
+          _dispatch_path(p, k_new) === :conjugate,
+          "got $(_dispatch_path(p, k_new))")
+
+    cp = maybe_conjugate(p, k_new)
+    check("maybe_conjugate returns ConjugatePrevision{GaussianPrevision, NormalNormal}",
+          cp isa ConjugatePrevision{GaussianPrevision, NormalNormal},
+          "got $(typeof(cp))")
+
+    # N(0,1) + obs=2.0, σ_obs=1.0 → τ_prior=1, τ_obs=1, τ_post=2
+    # μ_post = (1*0 + 1*2) / 2 = 1.0; σ_post = 1/√2
+    updated = update(cp, 2.0).prior
+    check("GaussianPrevision(0, 1) + obs=2.0, σ_obs=1 → μ_post = 1.0 (exact: 2/2)",
+          updated.mu == 1.0, "got μ=$(updated.mu)")
+    check("GaussianPrevision(0, 1) + obs=2.0, σ_obs=1 → σ_post = 1/√2 (atol=1e-12)",
+          isapprox(updated.sigma, 1.0 / sqrt(2.0); atol=1e-12),
+          "got σ=$(updated.sigma)")
+end
+
+# Legacy params-based pattern: existing Gaussian kernels pass
+# `params = Dict(:sigma_obs => σ)` + `likelihood_family = PushOnly()`.
+# maybe_conjugate must match this path too for backward compat.
+let k_legacy = Kernel(Euclidean(1), Euclidean(1),
+                      h -> GaussianMeasure(Euclidean(1), h, 1.0),
+                      (h, o) -> -0.5 * (o - h)^2;
+                      params = Dict{Symbol,Any}(:sigma_obs => 1.0),
+                      likelihood_family = PushOnly())
+    using Credence: GaussianPrevision
+
+    p = GaussianPrevision(0.0, 1.0)
+
+    check("GaussianPrevision + legacy params-based kernel → :conjugate (backward compat)",
+          _dispatch_path(p, k_legacy) === :conjugate,
+          "got $(_dispatch_path(p, k_legacy))")
+
+    cp = maybe_conjugate(p, k_legacy)
+    check("legacy path produces ConjugatePrevision{GaussianPrevision, NormalNormal}",
+          cp isa ConjugatePrevision{GaussianPrevision, NormalNormal},
+          "got $(typeof(cp))")
+
+    updated = update(cp, 2.0).prior
+    check("legacy path matches new-path result (μ_post=1.0)",
+          updated.mu == 1.0, "got μ=$(updated.mu)")
+end
+
 # ── TaggedBetaPrevision: must NOT match as conjugate (transitional scaffolding) ──
 #
 # Per PR #19's Move 1 revision addendum (commit 6dce5e4), TaggedBetaMeasure

--- a/test/test_prevision_conjugate.jl
+++ b/test/test_prevision_conjugate.jl
@@ -205,6 +205,93 @@ let cats = Finite([:a, :b, :c])
           updated_a.alpha == [3.0, 3.0, 5.0], "got α=$(updated_a.alpha)")
 end
 
+# ── (NormalGammaPrevision, NormalGammaLikelihood) ──
+#
+# Conjugate prior for Normal with unknown mean + variance.
+# κ_n = κ+1; μ_n = (κμ+r)/κ_n; α_n = α+0.5; β_n = β + κ(r-μ)²/(2κ_n).
+
+let k_new = Kernel(ProductSpace(Space[Euclidean(1), PositiveReals()]), Euclidean(1),
+                   h -> GaussianMeasure(Euclidean(1), h[1], sqrt(h[2])),
+                   (h, o) -> -0.5 * (o - h[1])^2 / h[2];
+                   likelihood_family = NormalGammaLikelihood())
+    using Credence: NormalGammaPrevision
+
+    p = NormalGammaPrevision(1.0, 0.0, 2.0, 1.0)  # κ=1, μ=0, α=2, β=1
+
+    check("NormalGammaPrevision + NormalGammaLikelihood → :conjugate",
+          _dispatch_path(p, k_new) === :conjugate,
+          "got $(_dispatch_path(p, k_new))")
+
+    # obs=2.0: κ_n = 2, μ_n = (1*0 + 2)/2 = 1.0, α_n = 2.5, β_n = 1 + 1*4/4 = 2.0
+    cp = maybe_conjugate(p, k_new)
+    updated = update(cp, 2.0).prior
+    check("NormalGamma posterior κ_n = 2.0 (==)",
+          updated.κ == 2.0, "got κ=$(updated.κ)")
+    check("NormalGamma posterior μ_n = 1.0 (==, 2/2 exact)",
+          updated.μ == 1.0, "got μ=$(updated.μ)")
+    check("NormalGamma posterior α_n = 2.5 (==)",
+          updated.α == 2.5, "got α=$(updated.α)")
+    check("NormalGamma posterior β_n = 2.0 (==, κ(r-μ)²/(2κ_n) = 4/4)",
+          updated.β == 2.0, "got β=$(updated.β)")
+end
+
+# Legacy params-based path for NormalGamma.
+let k_legacy = Kernel(ProductSpace(Space[Euclidean(1), PositiveReals()]), Euclidean(1),
+                      h -> GaussianMeasure(Euclidean(1), h[1], sqrt(h[2])),
+                      (h, o) -> -0.5 * (o - h[1])^2 / h[2];
+                      params = Dict{Symbol,Any}(:normal_gamma => true),
+                      likelihood_family = PushOnly())
+    using Credence: NormalGammaPrevision
+
+    p = NormalGammaPrevision(1.0, 0.0, 2.0, 1.0)
+
+    check("NormalGammaPrevision + legacy params-based kernel → :conjugate",
+          _dispatch_path(p, k_legacy) === :conjugate,
+          "got $(_dispatch_path(p, k_legacy))")
+
+    cp = maybe_conjugate(p, k_legacy)
+    updated = update(cp, 2.0).prior
+    check("legacy NormalGamma path matches new-path result",
+          updated.κ == 2.0 && updated.μ == 1.0 && updated.α == 2.5 && updated.β == 2.0,
+          "got (κ, μ, α, β) = ($(updated.κ), $(updated.μ), $(updated.α), $(updated.β))")
+end
+
+# ── (GammaPrevision, Exponential) — net-new fast-path ──
+#
+# Posterior is Gamma(α+1, β+obs). No legacy path (this pair wasn't
+# previously dispatched — existing GammaMeasure + Exponential kernels
+# fell through to particle).
+
+let k = Kernel(PositiveReals(), PositiveReals(),
+               h -> GammaMeasure(PositiveReals(), 1.0, h),
+               (h, o) -> log(h) - h * o;
+               likelihood_family = Exponential())
+    using Credence: GammaPrevision
+
+    p = GammaPrevision(2.0, 3.0)
+
+    check("GammaPrevision + Exponential → :conjugate (net-new)",
+          _dispatch_path(p, k) === :conjugate,
+          "got $(_dispatch_path(p, k))")
+
+    # obs=4.0: α_n = 3, β_n = 7
+    cp = maybe_conjugate(p, k)
+    updated = update(cp, 4.0).prior
+    check("GammaPrevision(2, 3) + Exponential obs=4.0 → Gamma(3, 7) (==)",
+          updated.alpha == 3.0 && updated.beta == 7.0,
+          "got α=$(updated.alpha), β=$(updated.beta)")
+
+    # Negative/zero obs must error.
+    raised = try
+        update(cp, -1.0)
+        false
+    catch
+        true
+    end
+    check("GammaPrevision + Exponential rejects negative obs",
+          raised, "expected error on obs=-1.0")
+end
+
 # ── TaggedBetaPrevision: must NOT match as conjugate (transitional scaffolding) ──
 #
 # Per PR #19's Move 1 revision addendum (commit 6dce5e4), TaggedBetaMeasure


### PR DESCRIPTION
## Summary

- **Registry foundation.** `ConjugatePrevision{Prior, Likelihood}` + `maybe_conjugate` + `update` in `src/prevision.jl` replace the case-analytic `condition` branches with a type-structural dispatch table. Six pairs registered: `(BetaPrevision, BetaBernoulli)`, `(BetaPrevision, Flat)`, `(GaussianPrevision, NormalNormal)`, `(DirichletPrevision, Categorical)`, `(NormalGammaPrevision, NormalGammaLikelihood)`, `(GammaPrevision, Exponential)`. Backward compat for kernels still declaring `params[:sigma_obs]` / `params[:normal_gamma]` is preserved.
- **Dispatch-path observability.** `_dispatch_path(p, k) → Symbol` returns `:conjugate` or `:particle`. Used by the new Stratum-2 test corpus and by the skin smoke tests — assertion FIRST, value assertion second. Catches silent registry misses that would otherwise produce correct-value-for-wrong-reason results via particle convergence.
- **Phase-3 facade integration.** Five Measure-subtype `condition` methods (`BetaMeasure`, `GaussianMeasure`, `DirichletMeasure`, `NormalGammaMeasure`, `GammaMeasure`) now consult `maybe_conjugate` first, falling through to legacy structural dispatch on nil. `TaggedBetaMeasure` routing stays unchanged as transitional scaffolding until Move 5's MixturePrevision moves it.
- **Tests.** `test/test_prevision_conjugate.jl` opens the Stratum-2 corpus (33 assertions). `apps/skin/test_skin.py` extends with six conjugate-path smoke tests per the Move-0 audit. Four new kernel types added to `apps/skin/server.jl` (flat, categorical, normal_gamma, exponential).

## Test plan

- [x] `julia test/test_prevision_conjugate.jl` — Stratum-2 corpus green
- [x] Full Julia suite: test_core, test_events, test_flat_mixture, test_program_space, test_host, test_grid_world, test_email_agent, test_rss, test_prevision_unit, test_persistence
- [x] `python -m skin.test_skin` (from `apps/skin/`) — full smoke green including the six new conjugate-path tests
- [ ] POMDP agent package tests (separate package — reviewer-gated)