### PR TITLE
Posture 4: branch opens — six docs land as ceremonial opener

### DIFF
--- a/docs/posture-4/DESIGN-DOC-TEMPLATE.md
+++ b/docs/posture-4/DESIGN-DOC-TEMPLATE.md
@@ -1,0 +1,68 @@
+# Posture 4 — Design doc template
+
+Every `docs/posture-4/move-N-design.md` PR must include the following sections. Reviewers reject design docs that omit "Open design questions" or that fill it with questions whose answer is obvious from the master plan.
+
+Inherited from `docs/posture-3/DESIGN-DOC-TEMPLATE.md` with two Posture-4-specific additions: §0 (final-state alignment check) and §8 (de Finettian discipline self-audit).
+
+## 0. Final-state alignment
+
+One paragraph confirming that the move as proposed converges the current tip toward `master-plan.md` §"Final-state architecture", with explicit callouts where the move leaves transient state not yet aligned (e.g. Move 2 leaves Measure subtypes alive while changing their internal fields; this is explicit, not drift). Empty or hand-waved is grounds for revision.
+
+## 1. Purpose
+
+What this move accomplishes; one paragraph.
+
+## 2. Files touched
+
+Exhaustive list with line ranges. Files created, files deleted, files renamed. For moves that split or delete files, the destination or deletion target is named explicitly.
+
+## 3. Behaviour preserved
+
+What Stratum-1/2/3 tests assert about pre-/post-refactor equivalence. The reference is the Move 0 capture at `test/fixtures/posture-3-capture/`. Every assertion whose value at the Posture 4 tip diverges from the Move 0 capture must be justified: either the divergence is mathematically expected (new seed consumption, known-benign reassociation) or the divergence is a bug.
+
+## 4. Worked end-to-end example
+
+Trace one representative call through the new dispatch, naming which module owns each step. Mandatory for any move that introduces or extends dual residency (a type, value, or hook present in both an old home and a new home) or that changes the wire shape of an external interface.
+
+Worked examples must be concrete enough to copy-paste into a REPL; no pseudocode stubs.
+
+## 5. Open design questions
+
+1–3 specific points where Claude Code is expected to argue back. Example shapes:
+
+- "Should X be a sibling primitive or a derived form?"
+- "Do we pick option (a) or (b)?"
+- "Is this category-different from the type it would inherit from?"
+- "Does the most de Finettian option here conflict with Julia ergonomics, and if so, which yields?"
+
+Empty or boilerplate is grounds for revision. Answered-by-reference-to-master-plan questions are boilerplate; the master plan settles the strategy, the design doc wrestles with the tactics.
+
+## 6. Risk + mitigation
+
+What could go wrong; what test or invariance check catches it. For high-risk moves (Moves 2, 5, 7, 9 per `master-plan.md`), the risk section covers both technical failure modes and review-process failure modes.
+
+## 7. Verification cadence
+
+Which test files run at end-of-PR. The default is the full suite; moves that require smoke tests (Move 7: `apps/skin/test_skin.py`; Move 8: Python bindings integration) name them explicitly. Moves that touch persistence (Move 3, Move 9) run the round-trip fixture test.
+
+## 8. de Finettian discipline self-audit
+
+Four checks, all of which must return "yes" or carry an explicit justification. This section exists because Posture 4's central discipline is the de Finettian commitment and a design doc that does not self-audit against it is a design doc that has not thought about the discipline.
+
+1. **Is every numerical query in this move routed through `expect`?** Or equivalently: does this move introduce any named function that returns a `Float64` describing a probabilistic property of a prevision without calling `expect`? If so, justify on performance grounds and explain why the performance gain is worth the architectural concession.
+
+2. **Does this move hold a Prevision inside a Measure, or a Measure inside a Prevision, for any reason?** The first direction is being retired; the second was the Posture 3 concession being retired now. A "yes" answer without a dated deprecation note pointing at the move that removes it is grounds for revision.
+
+3. **Does this move introduce an opaque closure where a declared structure would fit?** Closures are a fallback for cases the declared structure doesn't cover; they are not a convenience for avoiding type-system work. If the move adds a closure-typed field, the justification names the declared structure it preferred and explains why the declared structure does not cover the case.
+
+4. **Does this move add a `getproperty` override on any Prevision subtype?** The Posture 3 shields retired with Measure; introducing a new one on a Prevision regresses the discipline. A "yes" answer without a matching "and this is temporary, scheduled for removal in Move N" note is grounds for revision.
+
+---
+
+## Reviewer checklist
+
+- [ ] §0 Final-state alignment is a paragraph, not a sentence, and names any transient state explicitly.
+- [ ] §5 Open design questions contains non-trivial questions.
+- [ ] §8 Self-audit returns "yes" on all four or carries explicit justification.
+- [ ] File-path:line citations present where the design doc references current-state code.
+- [ ] The move as described does not require a subsequent move to retract or rework it. If Move N requires Move N+1 to clean up after it, the two moves are collapsed or the sequencing is reconsidered.

--- a/docs/posture-4/README.md
+++ b/docs/posture-4/README.md
@@ -1,0 +1,86 @@
+# Posture 4 — Complete the de Finettian migration
+
+Branch: `de-finetti/complete`. Master plan: `docs/posture-4/master-plan.md`.
+
+## What this branch does
+
+Finishes the reconstruction Posture 3 started. Posture 3 landed prevision-first in `src/` and left a compatibility shim across the rest of the repository — Measure as a user-facing surface, JSON-RPC wire preservation, Previsions holding Measures, `getproperty` shields dispatching on Prevision subtype, v1→v2 persistence migration protecting fixtures that only exist to audit the migration itself. Every one of those costs was paid to a compatibility burden that does not exist. Nothing in this repository ships externally. The precaution has outlived its usefulness.
+
+Posture 4 retires the compatibility layer entirely. Measure is deleted as a user-facing type. Every caller — skin, Python bindings, apps, tests, BDSL stdlib, examples — speaks the Prevision API directly. Presentation helpers (`mean`, `variance`, `probability`, `weights`) become one-line wrappers over `expect` on particular test functions, because in the de Finettian view that is what they are. The body work (Gmail connection, feature extraction, Telegram loop, server loop, production persistence) lands in the same branch, against the clean foundation, as the evidence that the foundation is usable rather than merely correct.
+
+The deliverable is a repository in which the paper's foundational claim — that `expect` on a declared test function space is the single probabilistic primitive — holds end-to-end, not only below the axiom line.
+
+## The design principle for every ambiguous call
+
+**Take the most de Finettian option.** When a function could be a named method or a one-liner over `expect(p, f)`, it is the one-liner. When a field could be typed as `Prevision` or as `Any` for load-order convenience, it is `Prevision`. When a value could be carried as a declared structural type (an `Event`) or as an opaque closure, it is the declared type. The module structure bends to accommodate the type system, not the other way around. There is no "pragmatic impurity" docstring anywhere in the tip of this branch; if one would be needed, the pragmatic choice is wrong and the disciplined one is needed instead.
+
+Concretely, the principle produces:
+
+- `mean(p) = expect(p, Identity())` — mean is not a structural accessor; it is the action of the prevision on the identity test function, by definition.
+- `probability(p, e) = expect(p, Indicator(e))` — same.
+- `variance`, higher moments, `weights` over a finite space, `marginal` over a product space — all `expect(p, f)` for some declared `f`.
+- `MixturePrevision.components::Vector{Prevision}` — no `Any`, no untyped `Vector`, no Measure-view shortcuts.
+- `ConditionalPrevision{E <: Event}` — the event is carried as its declared type, with the event hierarchy and the prevision hierarchy co-located in whichever module lets both constraints hold simultaneously.
+
+There are exactly two primitive operations at the axiom layer: `expect` and `condition`. Everything else is derived. Structural fields on concrete Prevision subtypes exist as performance representations — `CategoricalPrevision.log_weights` is the representation that makes `expect(p, Indicator(a))` computable in O(1) — not as alternative probabilistic surfaces. If a numerical query on a prevision does not route through `expect`, the design is wrong.
+
+## Scope — everything
+
+Posture 3's scope boundary (decision-log #3) carved `apps/skin/server.jl`, `apps/python/*`, and body work out of the reconstruction. Posture 4 explicitly lifts that boundary. Every layer of the repository migrates on this branch:
+
+| Layer | Migration |
+|-------|-----------|
+| `src/ontology.jl` | Delete nine Measure subtypes; retain Space, Event, Kernel; presentation helpers as functions over Prevision |
+| `src/prevision.jl` | Previsions hold Previsions; `ConditionalPrevision{E <: Event}`; `log_weights` convention throughout |
+| `src/persistence.jl` | v3 only; v1 and v2 paths deleted; fixtures recaptured |
+| `src/stdlib.bdsl`, `examples/*.bdsl` | Prevision vocabulary; presentation helpers as DSL stdlib functions |
+| `test/test_*.jl` | Every Measure construction site rewritten as Prevision construction |
+| `apps/julia/{email_agent,qa_benchmark}/` | Host files speak Prevision |
+| `apps/skin/server.jl` | JSON-RPC surface redesigned; Prevision vocabulary on the wire |
+| `apps/python/{credence_bindings,credence_agents,credence_router,bayesian_if}/` | Rewritten against Prevision API |
+| `apps/julia/body/` (new) | Gmail connection, feature extraction, Telegram loop, server loop, persistence |
+| `SPEC.md`, `CLAUDE.md`, `README.md`, `docs/` | Prevision-first throughout |
+| `docs/posture-3/paper-draft.md` | Reconciled: implementation section reflects Posture 4 tip; Measure-as-view concessions removed |
+
+Nothing is out of scope. That is the point.
+
+## Ten moves, one completion
+
+| Move | Scope | Risk | Blocks |
+|------|-------|------|--------|
+| 0 | Pre-branch capture — commit SHA pinned, invariance test output captured at Strata 1/2/3 tolerances against current master | Low | — |
+| 1 | Field-name unification (`log_weights` throughout); `ConditionalPrevision{E}`; shield retirement inside `src/` | Low | 0 |
+| 2 | Previsions hold Previsions — `Vector{Prevision}`, no `Any`, no view shortcuts | Medium | 1 |
+| 3 | Persistence v3-only; v1/v2 migration code deleted; fixtures recaptured | Low | 2 |
+| 4 | Test suite migrated — every Measure construction rewritten against Prevision constructors | Medium | 3 |
+| 5 | Measure deleted from `src/` — the point of no return | **High** | 4 |
+| 6 | Apps (`email_agent`, `qa_benchmark`) and BDSL stdlib migrated | Medium | 5 |
+| 7 | Skin (`apps/skin/server.jl`) rewritten — internal belief is Prevision; JSON-RPC surface redesigned | Medium | 6 |
+| 8 | Python bindings (`apps/python/*`) rewritten against Prevision API | Medium | 7 |
+| 9 | Body work — Gmail, feature extraction, Telegram loop, server loop, production persistence | High | 8 |
+| 10 | Documentation (SPEC, CLAUDE, README, docs/) and paper draft reconciled | Low | 9 |
+
+Each move opens with a `docs/posture-4/move-N-design.md` docs-only PR, then a code PR. Roughly 20 PRs total.
+
+Move 0 is non-trivial — see `move-0-design.md`. The pre-branch capture is the invariance target for every subsequent behavioural assertion on the branch. Without it, a ten-move migration has no ground truth to check itself against.
+
+## What "rip the plaster" means operationally
+
+Posture 3's cadence was Socratic — design doc first, code second, review gate between them, reviewer-driven pace. Posture 4 inherits the cadence but with a sharper end-condition: at the tip, `grep -r 'pragmatic impurity' src/ apps/ test/ docs/` returns nothing; `grep -r 'Measure' src/` returns only references in docstrings that explicitly frame Measure as the deleted pre-Posture-4 type; and the paper's §4 Implementation section describes the Posture 4 tip without footnoted concessions.
+
+The reconstruction is not done when the tests pass. It is done when no caller, anywhere, is still speaking the Kolmogorov vocabulary as its primary idiom, and when the body work demonstrates that the Prevision vocabulary is a usable surface for real applications.
+
+## Conventions
+
+- File path:line citations everywhere, inherited from Posture 3.
+- "Should" and "must" mean what they sound like.
+- The paper draft is the gating artifact for Move 10 and by implication for the branch; if a choice arises between code-feature scope and paper completeness, default to paper completeness.
+- Design docs at `docs/posture-4/move-N-design.md` follow `DESIGN-DOC-TEMPLATE.md`. Non-boilerplate "Open design questions" sections are mandatory; empty or shallow ones are grounds for revision.
+
+## Reading order for new reviewers
+
+1. `decision-log.md` — the five decisions settled before this branch begins.
+2. `master-plan.md` — the full ten-move specification.
+3. `move-0-design.md` — the pre-branch capture protocol.
+4. `docs/posture-3/paper-draft.md` — the paper this branch is making true, unchanged until Move 10.
+5. `CLAUDE.md` — the repo constitution, updated incrementally across Moves 1–9 and consolidated at Move 10.

--- a/docs/posture-4/claude-code-prompts.md
+++ b/docs/posture-4/claude-code-prompts.md
@@ -1,0 +1,323 @@
+# Prompts for Claude Code — Posture 4
+
+This file contains one prompt per move, in the order they should be fed to Claude Code. Each prompt assumes the previous move has landed (design doc + code PR) and is on master. The Posture 3 review-then-implement discipline inherits: Claude Code produces the design doc for review first, then the code PR after the design doc is approved.
+
+The Move 0 artifacts (`README.md`, `decision-log.md`, `master-plan.md`, `DESIGN-DOC-TEMPLATE.md`, `move-0-design.md`) are already drafted and live in the repo at `docs/posture-4/`. The first Claude Code prompt is for Move 0's capture script and fixture generation — the design doc exists; the code does not.
+
+---
+
+## Prompt 0 — Move 0 code: capture script and fixtures
+
+You are implementing Move 0 of Posture 4, the pre-branch invariance capture. The design doc is at `docs/posture-4/move-0-design.md`; read it first, along with `README.md`, `decision-log.md`, and `master-plan.md` in the same directory. These are authoritative; your job is to realise them in code.
+
+Tasks:
+
+1. Implement `scripts/capture-invariance.jl` per the design doc. It walks every `test/test_*.jl` file, instruments every `@test` assertion, runs the test suite, and serialises the results to `test/fixtures/posture-3-capture/{strata-1,strata-2,strata-3}.jls` with the manifest at `test/fixtures/posture-3-capture/manifest.toml`.
+
+2. The instrumentation must not modify test behaviour. The captured LHS value is the literal LHS of the assertion expression at the time of evaluation; the captured RHS is the RHS; the tolerance is whatever `atol` / `rtol` the assertion declared, defaulting to `==` (Stratum 1) if none is declared.
+
+3. Resolve open design questions 1–4 in the Move 0 design doc by picking the disciplined option in each case and documenting your choice in the fixture README. My priors:
+
+   - Q1: Structural vs numerical equality — introduce the third axis. A `@test length(programs) == 22` assertion is captured as "structural:length==22" and compared via `==` regardless of stratum. Numerical assertions carry the tolerance.
+   - Q2: Particle seed capture — the conservative answer. Capture the sample sequences downstream of every `Random.seed!` call site in `test/`.
+   - Q3: Platform pinning — pin Linux x86_64 on the Docker image already used for the repo's CI. Record the exact Julia version and CPU string in the manifest.
+   - Q4: Broken/flaky assertions — capture them in their current broken state with a `status = "broken"` manifest entry. Move 10 has explicit permission to upgrade broken → passing if the cleaner foundation fixes them.
+
+4. Run the double-verification from §4 of the design doc. Confirm the fixtures are stable across two clean-checkout runs. Commit the fixtures and the manifest.
+
+5. Open the PR against `de-finetti/complete` with the design doc and code together. The design doc is already written; your PR is the code that realises it. Do not modify `src/`, `apps/`, or any `test/test_*.jl` files.
+
+Before writing code, state in a preamble: which modules of the Julia ecosystem you intend to use for the instrumentation (`Test.Testset` customisation, `ReTest`, `Aqua`, a bespoke macro-walker), and why. The preamble should be under 200 words and should name one alternative you considered and rejected.
+
+---
+
+## Prompt 1 — Move 1 design doc
+
+You are producing the Move 1 design doc at `docs/posture-4/move-1-design.md`. Follow `docs/posture-4/DESIGN-DOC-TEMPLATE.md` exactly, including §0 (final-state alignment), §8 (de Finettian self-audit), and the reviewer checklist.
+
+The move's scope is set in `master-plan.md`:
+
+- Rename `CategoricalPrevision.logw` to `log_weights` throughout.
+- Unify the field name across `CategoricalPrevision`, `ParticlePrevision`, `QuadraturePrevision`, `EnumerationPrevision`, `MixturePrevision`.
+- Rewrite `ConditionalPrevision` to `ConditionalPrevision{E <: Event}` with a typed `event::E` field, replacing the opaque `event_predicate::Function`.
+- Remove the `getproperty` branch on `CategoricalMeasure` that dispatches on the stored Prevision subtype (`src/ontology.jl:135-148`). The shield becomes unconditional forward, or retires if no external consumer still depends on `.logw` as a name.
+
+Scope discipline: no caller outside `src/` is touched in Move 1. Apps, tests, skin, Python, and BDSL stdlib are left untouched; they migrate in Moves 4, 6, 7, 8.
+
+Open design questions you must populate (examples — you may add more if genuinely open):
+
+1. Where does `ConditionalPrevision{E <: Event}` live — `previsions.jl` with `E` unconstrained at the struct level (matching `Indicator{E}`'s current discipline), or a new module where both `ConditionalPrevision <: Prevision` and `E <: Event` constraints hold at the struct level? The latter is more disciplined; it requires module restructure. Argue.
+
+2. If `log_weights` is the unified name, does `CategoricalMeasure.logw` retire entirely (the shield is deleted, not forwarded), or does the shield remain as a one-liner `getproperty(m, :logw) = m.prevision.log_weights` for a deprecation window? My prior: retire entirely; the shield exists for a reason that does not survive Posture 4.
+
+3. The `_dispatch_path` observability hook in `prevision.jl:679` is underscore-prefixed per Posture 3 conventions. Does it stay as-is, or does it migrate to a cleaner observability pattern now that the type system is disciplined?
+
+Address each open question by stating your preferred answer and the argument for it; the review cycle is where I push back. Non-trivial questions only — "should we use `log_weights` or `logs_weight`" is not a design question.
+
+The design doc ends with the reviewer checklist uncrossed. I cross it during review. Do not land code until the design doc is approved.
+
+---
+
+## Prompt 2 — Move 1 code
+
+The Move 1 design doc is approved and on master (merge SHA: fill in). Implement the code per the design doc. The fixtures at `test/fixtures/posture-3-capture/` are the invariance target; every Stratum-1 assertion must match bit-exactly, every Stratum-2 within `1e-12`, every Stratum-3 within `1e-10`.
+
+If any assertion diverges outside its stratum tolerance, halt and diagnose. Do not paper over a divergence with a tolerance relaxation.
+
+The code PR modifies only `src/`. Tests pass unchanged (they still construct Measure subtypes; Measure is still alive and the shields on it — now unconditional — forward correctly).
+
+Ship the PR with the full test suite output showing zero regressions against the Move 0 capture. The verification command lives in the Move 1 design doc §7.
+
+---
+
+## Prompt 3 — Move 2 design doc
+
+You are producing the Move 2 design doc at `docs/posture-4/move-2-design.md`. Same template, same discipline.
+
+The move's scope:
+
+- `TaggedBetaPrevision.beta::BetaPrevision` (was `::Any`).
+- `ProductPrevision.factors::Vector{Prevision}` (was `::Vector`).
+- `MixturePrevision.components::Vector{Prevision}` (was `::Vector`).
+
+Internal to `src/`. Measure subtypes still alive; their `getproperty` shields may need to reconstruct Measure-shaped views on the fly for consumers that still read `.components` and expect a `Vector{Measure}`. This transient reconstruction retires with Measure in Move 5.
+
+Open design questions:
+
+1. **On-the-fly Measure reconstruction via shields.** `MixtureMeasure.components` returning `[wrap_in_measure(p) for p in prevision.components]` is a per-access allocation. Is this acceptable for the Moves 2–4 window, given that Move 5 deletes it? The alternative — updating every caller in `src/` that reads `.components` as `Vector{Measure}` at Move 2, instead of at Move 5 — front-loads work. My prior: accept the allocation for the transient window; Move 5 removes it.
+
+2. **`ExchangeablePrevision.decompose` return type.** Currently returns `MixturePrevision` whose components are whatever the implementation constructs. With `Vector{Prevision}`, the return type is structurally the same but the elements are guaranteed Previsions. Should the return type be parametrically tightened to `MixturePrevision{T}` where `T <: Prevision` names the component type, or does Julia's existing `MixturePrevision` shape suffice?
+
+3. **Consumer migration inside `src/`.** Every `src/` site reading `m.components[i].alpha` now reads `m.components[i].alpha` where `m.components[i]` is a `BetaPrevision`, not a `BetaMeasure`. The read succeeds because `BetaPrevision` has an `alpha` field. But it bypasses the `expect-through-accessor` discipline we're preparing for Move 5. Do we update the internal callers in Move 2 to use `mean(components[i])` instead, or leave that for Move 5's stdlib introduction?
+
+Resolve each. Land the design doc. Await review.
+
+---
+
+## Prompt 4 — Move 2 code
+
+Implement Move 2 per the approved design doc. Invariance target unchanged. Transient `getproperty` reconstruction must not leak allocated Measure instances beyond the call site that requested them; profile if unsure.
+
+---
+
+## Prompt 5 — Move 3 design doc
+
+Scope: persistence v3-only. Delete v1 and v2 loader paths in `src/persistence.jl`. Delete v1 fixtures at `test/fixtures/agent_state_v1.jls` and `test/fixtures/email_agent_state_v1.jls`. Recapture v3 fixtures from the current tip (post-Move-2). Update `test/test_persistence.jl` to assert v3 round-trip only.
+
+Open design questions:
+
+1. **Fixture regeneration discipline.** The Posture 3 precedent was that fixtures are captured once and never regenerated to fix load bugs (fix the load code instead). Posture 4's v3 fixtures are regenerated because they're new; future Move 9 body-work state is another first capture. Does the "never regenerate" rule apply to v3 as soon as Move 3 lands, or only after Move 9's production-state fixtures are also captured? The difference matters if a Move 4–8 refactor changes the serialised shape of the belief state. My prior: "never regenerate" applies post-Move-9. Moves 3–8 may invalidate and recapture. State this explicitly.
+
+2. **Schema versioning in a single-schema world.** With v1 and v2 gone, the `__SCHEMA_VERSION` field is marking a single version. Does the field stay (for forward compatibility when future schema changes arrive) or retire (YAGNI)? If it stays, the value is `3` and Move 9's production persistence is free to bump it if body-work persistence requires fields not in v3.
+
+---
+
+## Prompt 6 — Move 3 code
+
+Implement Move 3. The v1 and v2 fixtures are deleted with `git rm`; the v3 fixtures are `git add`ed from the regeneration. Persistence round-trip test passes; all other tests pass against the Move 0 capture.
+
+---
+
+## Prompt 7 — Move 4 design doc
+
+Scope: migrate every `test/test_*.jl` file to construct Previsions directly rather than Measures. This is a mechanical but volumetric diff — every `CategoricalMeasure(...)`, `BetaMeasure(...)`, `MixtureMeasure(...)` construction becomes the Prevision equivalent.
+
+Open design questions:
+
+1. **Test file renames.** Currently there is `test_flat_mixture.jl`, `test_prevision_mixture.jl`, `test_prevision_conjugate.jl`, `test_prevision_particle.jl`, `test_prevision_unit.jl`. Posture 3 left some Measure-facing test files and added Prevision-facing ones in parallel. Move 4 unifies: do we consolidate `test_flat_mixture.jl` into `test_prevision_mixture.jl`, or rename? My prior: rename where the rename improves clarity; consolidate where two files have overlapping scope. The design doc lists the final test file inventory.
+
+2. **Constructor surface change.** Previously `CategoricalMeasure(Finite([:a, :b]), [0.0, 0.0])` constructed a measure over a finite space. The Prevision equivalent is `CategoricalPrevision([0.0, 0.0])` — but the space information is gone. Does `CategoricalPrevision` carry a space, or is the space a separate argument passed to `expect(p, Indicator(e))` where `e` references the space? The paper's §1.2 notes that `CategoricalPrevision{T}` is "not parametric on the atom type — the type connection lives at the Measure level." Move 4 is the moment to revisit: with Measure going, where does the atom type live? On the `Indicator{E}` side? On a new `Space` field of `CategoricalPrevision`? State and defend.
+
+3. **Test output diff vs Move 0 capture.** Because tests are being rewritten against a new constructor surface, the Julia value constructed is different even when the semantic content is the same. The invariance check is behavioural — `expect(p, f)` returns the same number — not syntactic. The design doc must state explicitly how the Move 0 capture's invariance is preserved when the LHS of the captured assertion is a Measure field access (`m.alpha`) and the post-refactor test reads a Prevision field (`p.alpha`). Options: capture the value, not the expression; or update the capture to reference the Prevision-surface access. My prior: value, not expression. The capture protocol should have been value-based from Move 0; verify this.
+
+---
+
+## Prompt 8 — Move 4 code
+
+Implement Move 4. The diff is large. Split into sub-PRs if review load warrants; otherwise ship as one code PR with the consolidated test suite migration.
+
+---
+
+## Prompt 9 — Move 5 design doc
+
+This is the point of no return. Read `master-plan.md` §"Move 5" carefully and `decision-log.md` Decision 1 in particular. The Measure type and every concrete subtype is deleted; `src/ontology.jl` is gutted and split.
+
+Scope:
+
+- Delete: `CategoricalMeasure`, `BetaMeasure`, `TaggedBetaMeasure`, `GaussianMeasure`, `DirichletMeasure`, `GammaMeasure`, `NormalGammaMeasure`, `ProductMeasure`, `MixtureMeasure`.
+- Delete: every `getproperty` shield, every Measure constructor, every Measure export in `src/Credence.jl`, the `Functional = TestFunction` alias.
+- Split `src/ontology.jl` into the six-file structure specified in `master-plan.md` §"New module structure": `spaces.jl`, `events.jl`, `kernels.jl`, `test_functions.jl`, `conjugate.jl`, `stdlib.jl`.
+- Introduce `src/stdlib.jl` with `mean`, `variance`, `probability`, `weights`, `marginal` as one-liners over `expect` per `decision-log.md` Decision 2.
+- Introduce the `expect-through-accessor` lint slug in `tools/credence-lint/`.
+
+Open design questions:
+
+1. **`variance` implementation.** `mean(p) = expect(p, Identity())` is a one-liner. `variance(p) = expect(p, ???) - mean(p)^2` requires a TestFunction that evaluates `x^2`. Do we introduce `Square` as a TestFunction subtype, `Power{n}` parametrically, or is variance implemented via `expect(p, CenteredSquare(mean(p)))` where `CenteredSquare` is a closure-over-mean? The last is the least de Finettian; the first is the most specific. My prior: introduce a small family — `Square`, `Cube`, `Power{n}` — and implement variance, third central moment, etc. in terms of them. State your answer.
+
+2. **`weights` for non-categorical previsions.** `weights(p::CategoricalPrevision)` returns the normalised probability vector over atoms. What is `weights(p::BetaPrevision)` — undefined, or the continuous analogue (the density function evaluated on a grid)? My prior: undefined for non-finite-space previsions; `weights` carries a domain restriction to `CategoricalPrevision`, `MixturePrevision`, `ParticlePrevision`, `QuadraturePrevision`, `EnumerationPrevision`. For continuous cases, consumers compute specific probabilities via `probability(p, Interval(lo, hi))`.
+
+3. **Module split granularity.** Six files per the master plan. Is this the right granularity — too fine (small files, one-concept-per-file, good navigation) or too coarse (keep `ontology.jl` but heavily trimmed)? I lean toward the split. Argue.
+
+4. **The lint slug.** `expect-through-accessor` flags call sites that read a Prevision's structural field to compute a probabilistic property. Implementation: a syntactic walker over `src/`, `apps/`, `test/` that flags `*.alpha`, `*.beta`, `*.log_weights` reads outside the module that defines the type. False positives: internal reads inside `expect` method bodies are legitimate; the lint must distinguish. State the false-positive mitigation.
+
+This design doc receives extra scrutiny. Expect back-and-forth; do not merge until every open question has a landed answer and the pre-merge checklist in the master plan is green.
+
+---
+
+## Prompt 10 — Move 5 code
+
+Only after Move 5 design doc is approved and `scripts/capture-invariance.jl` reports zero regressions against the Move 0 capture at the Move 4 tip.
+
+Implement Move 5. The diff is large (thousand-plus lines deleted, six new files created) but structurally simple — most of the complexity is in Moves 1–4 preparing the ground.
+
+Post-merge: the repo `grep -rE 'struct (Categorical|Beta|Tagged|Gaussian|Dirichlet|Gamma|NormalGamma|Product|Mixture)Measure' src/` returns empty.
+
+---
+
+## Prompt 11 — Move 6 design doc
+
+Scope: apps migration. `apps/julia/email_agent/host.jl`, `apps/julia/qa_benchmark/host.jl`, `examples/host_credence_agent.jl`, `src/stdlib.bdsl`, `examples/*.bdsl`. Every Measure construction rewritten against Prevision constructors; every accessor call migrated to `mean`, `probability`, `expect(p, f)` per the stdlib.
+
+Open design questions:
+
+1. **BDSL stdlib surface.** The BDSL currently exposes probability constructors and accessors. Does the BDSL surface mirror Julia (`beta 1 1`, `mean`, `probability`), or does it adopt its own idiom? The DSL/host boundary is strict (CLAUDE.md precedent); the DSL constructs mathematical objects, the host realises them. My prior: BDSL mirrors Julia naming; ergonomics are the host's concern, not the DSL's.
+
+2. **Host file structure.** The existing host files are long and mix setup, main loop, and observation handling. Move 6 is an opportunity to split — but splitting host files is out of scope per the master plan's "migration not elaboration" discipline. Is an in-place structural cleanup (reorganising without adding functionality) in scope, or is it deferred to a follow-up? My prior: defer. State.
+
+3. **`apps/julia/qa_benchmark/` ablation variants.** The benchmark host currently has no ablation variants implemented (per `papers/RESULTS.md` "Not Yet Run"). Move 6 migrates what exists; the ablation re-implementation is out of scope per the master plan. State this explicitly so Move 6 does not accidentally take on Paper 1's experimental work.
+
+---
+
+## Prompt 12 — Move 6 code
+
+Implement Move 6. All app tests and integration tests pass against the Move 0 capture. BDSL examples parse and execute under the new stdlib.
+
+---
+
+## Prompt 13 — Move 7 design doc
+
+Scope: `apps/skin/server.jl` and `apps/skin/test_skin.py`. Internal belief state is `Prevision`. JSON-RPC wire shape redesigned for Prevision vocabulary. Mutation operations are explicit Prevision-level APIs.
+
+Open design questions:
+
+1. **JSON-RPC method signatures.** The wire currently exposes `condition`, `expect`, `weights`, `mean`, `optimise`, `factor`, `snapshot_state`. Under Prevision vocabulary, do we keep these names (they generalise cleanly) or rename to flag the break (`prevision_expect`, etc.)? My prior: keep the names; the semantics are the same, the underlying types are cleaner. Breaking the names signals "new API" without adding meaning.
+
+2. **Prevision handle encoding over the wire.** JSON is a textual format; a Prevision has no canonical textual form. Does the wire carry handles (server-side opaque IDs that reference in-memory Previsions) or serialised forms (full JSON encodings of the Prevision's structure)? My prior: handles for working state, serialised forms for `snapshot_state` output. State.
+
+3. **Mutation API on the wire.** `push_component!` and `replace_component!` are Julia-internal APIs. The wire equivalent — `mixture.push_component(handle, component, log_weight)` — is the natural shape, but mutation over JSON-RPC is unusual; most RPC APIs are functional-style (return a new handle). Functional is cleaner; mutation matches Julia's in-place patterns. Pick one.
+
+---
+
+## Prompt 14 — Move 7 code
+
+Implement Move 7. Skin smoke test (`python -m skin.test_skin`) passes against the new wire format. Manifest comparison against Move 0 capture: only the wire shape changed, not the underlying belief values, so `expect(prevision, Identity())` over the wire returns the same numbers.
+
+---
+
+## Prompt 15 — Move 8 design doc
+
+Scope: Python bindings. `apps/python/credence_bindings/`, `apps/python/credence_agents/`, `apps/python/credence_router/`, `apps/python/bayesian_if/`. Constructor surface, query surface, and stdlib helpers per `master-plan.md` §"Move 8".
+
+Open design questions:
+
+1. **Python API idiom.** Does `mean` on a Python-side Prevision handle get exposed as `p.mean()` (method) or `mean(p)` (free function) or `p.mean` (property)? My prior: method, to match Julia and to leave `mean` free at the module level. Properties imply cheap synchronous reads; an RPC round trip is neither cheap nor synchronous in the general case.
+
+2. **TestFunction handles on the Python side.** Constructing an `Identity()` test function in Python requires either (a) a Python-side `TestFunction` class mirror, (b) a string name convention (`p.expect("identity")`), or (c) a callable convention (`p.expect(lambda s: s)`). The callable is flexibly, but it ships a closure over the wire — anti-pattern per Posture 4. (a) is the disciplined option. State.
+
+3. **Migration of `bayesian_if`.** This is the CLI / external-facing surface. Does it migrate to the new Python API at Move 8, or is it a thin follow-up? My prior: migrate at Move 8. The "rip the plaster" directive does not leave a Kolmogorov-vocabulary CLI in place for the body work to speak to.
+
+---
+
+## Prompt 16 — Move 8 code
+
+Implement Move 8. Python integration tests pass; credence-proxy Docker image rebuilds and runs clean.
+
+---
+
+## Prompt 17 — Move 9 design doc
+
+This is the body-work move. The largest by line count, the most external-surface-complex, the evidence that the foundation is usable.
+
+Scope per `master-plan.md` §"Move 9": Gmail connection (Maildir via mbsync), feature extraction (Ollama enrichment → `Dict{Symbol, Float64}`), Telegram training loop, server loop (polling execution, per-step conditioning, meta-actions), production persistence.
+
+Open design questions — expect many:
+
+1. **Connection abstraction interface.** Per the userMemories pattern: a `Connection` has `extract(event) → partial Dict` and `execute!(action) → Outcome`. The body assembles the full feature dictionary by merging all connections. State the formal interface — is `Connection` an abstract type with required methods, a protocol defined by trait, or a `@kwdef struct` with function fields? My prior: abstract type with required methods; traits in Julia are fragile.
+
+2. **Event-form vs parametric-form `condition` in body work.** Per `master-plan.md` §"Move 9" and the userMemories guidance. Email observations are feature dictionaries — structural predicates over the feature space — which map naturally to Event. Ollama enrichment produces noisy predictions, which are Kernel-obs pairs. The body work uses both, not one; state the convention for when each applies.
+
+3. **Meta-action implementation.** The hypothesis-space modification primitive. Meta-actions modify `MixturePrevision.components` by adding or removing components. Does this use the `push_component!` / `replace_component!` API introduced in Move 7, or does it construct a new MixturePrevision from scratch? Mutation is faster; reconstruction is cleaner. My prior: reconstruction unless a profile shows the allocation cost dominates.
+
+4. **Ollama discipline.** The prosthetic. State the prompting discipline: how the LLM's output is constrained to feature-dictionary shape, how parsing failures are handled (retry, fallback to empty dict, error), what the cost model for LLM calls is (per the no-separate-cost-model principle in userMemories).
+
+5. **Telegram training-loop preference encoding.** 👍 / 👎 reactions update the CIRL prior over utility parameters. State the exact mechanism: which TestFunction the reaction corresponds to, how the reaction is encoded as an Event or Kernel-obs pair, how the resulting `condition` call modifies the utility-parameter prevision.
+
+6. **Server loop scheduling.** Polling cadence, per-step conditioning overhead, when programs re-evaluate against the evolving feature dictionary. The existing design in userMemories is "closed-loop (options/Sutton 1999) always; programs re-evaluate at every step against evolving processing state." State this in the design doc with citations and concrete polling interval.
+
+7. **Production state schema.** The belief state is `MixturePrevision` of `ProductPrevision` of `BetaPrevision`. Persistence round-trips this. Does the schema version bump from v3 → v4 for production state (which may have fields — connection registries, program caches — that v3 did not)? My prior: yes. Move 3's v3 covers internal state; Move 9's v4 covers production state and gets its own fixture.
+
+8. **Smoke test for the end-to-end flow.** Email arrives at Maildir → feature extraction → Prevision update → action selection → user reaction → further Prevision update. State the test fixture: a set of emails in a test Maildir, a stubbed Ollama endpoint with deterministic responses, a stubbed Telegram bot that replies 👍 / 👎 on a schedule. The test asserts that the Prevision state evolves correctly across a defined sequence.
+
+This design doc is the one that warrants the most back-and-forth. Do not attempt to land it in one pass.
+
+---
+
+## Prompt 18 — Move 9 code
+
+Implement Move 9 per the approved design doc. This may split into 9a (Gmail + feature extraction + persistence) and 9b (Telegram + server loop + meta-actions) at your discretion, provided the split is proposed in the design doc and approved.
+
+---
+
+## Prompt 19 — Move 10 design doc and code (may be combined)
+
+Scope: documentation and paper reconciliation. `SPEC.md`, `CLAUDE.md`, `README.md`, `docs/` throughout, `docs/posture-3/paper-draft.md`.
+
+Per the Posture 3 precedent, Move 10's docs-only scope may fold design and code into a single PR.
+
+Open design questions:
+
+1. **CLAUDE.md frozen-types list.** Posture 3: Space, Prevision, Event, Kernel (Measure as view). Posture 4: Space, Prevision, Event, Kernel, TestFunction (Measure deleted). Is TestFunction a frozen type, or is it a derived concern that does not warrant frozen-type status? My prior: frozen. The TestFunction hierarchy is load-bearing for the `expect`-is-primitive story.
+
+2. **Paper reconciliation scope.** The paper was drafted against the Posture 3 tip. Move 10 reconciles it against the Posture 4 tip. Reconciliation is primarily editing — the claims stand, the implementation footnotes retire. Is there a deeper rewrite warranted? For example, §2.1's pre/post code snippets no longer need the Measure wrapping step, which simplifies the "post" side and clarifies the paper's claim. State which sections get only footnote-level updates and which warrant paragraph-level rewrites.
+
+3. **Reference implementation SHA pin.** The paper pins a SHA (`6ebec0767ab6231afdfc6367bbffe5856762c9a9` per the current draft) for reproducibility. Move 10 pins the Posture 4 tip SHA instead. State whether the Posture 3 SHA is retained in a "prior implementation" footnote for historical reference.
+
+---
+
+## Branch-level close-out
+
+After Move 10 merges, the branch is complete. The final verification sequence:
+
+```bash
+# The disciplines assertions
+grep -rE 'struct (Categorical|Beta|Tagged|Gaussian|Dirichlet|Gamma|NormalGamma|Product|Mixture)Measure' src/
+# Empty.
+
+grep -r 'pragmatic impurity' src/ apps/ test/ docs/
+# Empty.
+
+grep -r 'Measure' src/
+# Only references in docstrings that explicitly frame Measure as the deleted pre-Posture-4 type.
+
+# The behavioural assertion
+julia --project=. -e 'using Pkg; Pkg.test()'
+# All green.
+
+# The full invariance check against Move 0 capture
+julia --project=. scripts/verify-invariance.jl \
+  --against test/fixtures/posture-3-capture/
+# All assertions within their stratum tolerance.
+
+# The body-work end-to-end
+julia --project=. test/test_body_integration.jl
+# Passes.
+
+# The paper check
+# Open docs/posture-3/paper-draft.md. §4 references the Posture 4 tip SHA.
+# Abstract does not mention "Measure as a thin wrapper".
+# §2.1 post-refactor snippet has no BetaMeasure wrapping step.
+```
+
+If any assertion in the close-out fails, the branch is not done. Find the failing move, reopen the corresponding design doc with the failure as evidence, and ship a correction.
+
+The branch merges to master when the close-out is clean.

--- a/docs/posture-4/decision-log.md
+++ b/docs/posture-4/decision-log.md
@@ -1,0 +1,73 @@
+# Posture 4 — Decision log
+
+The five decisions settled before any code or design-doc work begins. Subsequent design-doc PRs reference this file by name; if a design doc proposes anything that conflicts with a decision recorded here, the design doc must propose an amendment to this file (with rationale) in the same PR. The bar for amendment is high — each of these decisions was load-bearing for the branch's scope or discipline and the costs of revisiting mid-branch are substantial.
+
+## Decision 1 — Measure is deleted, not retained as a view
+
+The Posture 3 concession was to keep `Measure` as a user-facing wrapper over `Prevision` so that existing consumer code (`m.alpha`, `weights(m)`, `mean(m)`) continued to work unchanged. Posture 4 retires the concession: every Measure subtype is deleted, every `getproperty` shield goes with them, every consumer site migrates to the Prevision API.
+
+Rejected alternatives:
+
+- **Keep Measure as a view, remove only the pragmatic impurities.** Considered as "Posture 4 cleanup branch" in an earlier draft of this plan. Rejected because keeping the view perpetuates two probabilistic vocabularies across the codebase, and every layer above `src/` then carries the cognitive burden of deciding which vocabulary applies. The paper's central claim is that the prevision is the single primitive; the implementation should not be negotiating with that claim.
+
+- **Delete Measure from `src/` but keep a translation layer at the skin boundary.** Considered as a halfway point. Rejected because the only callers of the translation layer would be other Credence modules that have not yet migrated, which puts the branch in an unstable middle state for however long the translation layer persists. No external consumer depends on Measure; there is nothing for a translation layer to serve.
+
+### Implication for presentation helpers
+
+`weights`, `mean`, `variance`, `probability` are retained as named functions but reimplemented as one-line wrappers over `expect` on declared test functions. This is not a compromise; it is the de Finettian reading. `mean(p) = expect(p, Identity())` is not a convenience — it is the definition. The helpers exist for ergonomics and for named call sites in the stdlib; they are not an alternative surface to `expect`.
+
+## Decision 2 — `expect` is the single numerical query; structural fields are performance, not surface
+
+Concrete `Prevision` subtypes have structural fields (`CategoricalPrevision.log_weights`, `BetaPrevision.alpha`, `MixturePrevision.components`). These fields are the performance representation that makes `expect(p, f)` computable — `expect(::CategoricalPrevision, ::Indicator{Atom})` consults `log_weights` because that is the representation that makes singleton-event probability evaluation O(1). The fields are part of the implementation, not part of the public probabilistic surface.
+
+Every numerical query on a prevision — anything that returns a `Float64` describing a probabilistic property — must route through `expect`. Directly reading `p.alpha` to compute `α / (α + β)` as "the mean of a Beta" is permitted inside the method body of `expect(::BetaPrevision, ::Identity)`; it is not permitted at call sites that want the mean. Call sites call `mean(p)` or `expect(p, Identity())` directly.
+
+Rejected alternatives:
+
+- **Accessor methods as the public surface.** `mean(p)`, `weights(p)`, `probability(p, e)` as the primary API with `expect` as an implementation detail. Rejected because it reproduces the measure-theoretic vocabulary at the type-system level — each new Prevision subtype would need a bespoke set of accessor methods — and the pattern that made conjugate dispatch case-analytic in the first place would reassert itself.
+
+- **Category-theoretic wrapper types (e.g. `Mean{P}`, `Variance{P}`).** Considered for type-clarity; rejected as over-engineered. `mean(p)` returning a `Float64` is clearer than `mean(p)` returning a `Mean{P}` that forwards to `Float64` on unwrapping.
+
+### Lint enforcement
+
+Claude Code implements a lint slug `expect-through-accessor` that flags any call site in `apps/`, `test/`, or `src/stdlib.bdsl` that reads a structural field of a concrete `Prevision` subtype to compute a numerical property — e.g. `p.alpha / (p.alpha + p.beta)` outside of `expect(::BetaPrevision, ::Identity)`'s method body. The slug retires at the tip when no violations remain.
+
+## Decision 3 — No compatibility, no migration path, no wire preservation
+
+The JSON-RPC surface in `apps/skin/server.jl` is redesigned for the Prevision vocabulary on the wire. No shipping users depend on the current wire format. Persistence uses schema v3 only; v1 and v2 fixtures and their loader paths are deleted, not migrated. Python bindings are rewritten rather than transitioned.
+
+Rejected alternatives:
+
+- **Preserve JSON-RPC wire shape.** The skin surface currently exposes `condition`, `expect`, `weights`, `mean`, `optimise`, `factor`, `snapshot_state` over a Measure-structured wire format. Preserving the shape was considered because it would narrow Move 7's blast radius. Rejected because the wire format inherits the Kolmogorov vocabulary (Measure handles, field-access patterns) and preserving it would force Python bindings to translate between vocabularies indefinitely. The `de-finetti/complete` branch does not leave translation layers behind.
+
+- **Persistence migration v2 → v3.** Considered as a mechanical extension of Posture 3 Move 3's v1 → v2 path. Rejected because no deployed state exists at v2 that needs protecting; the fixtures are there to audit the migration protocol itself and not to preserve data. Recapturing fixtures at v3 is simpler than porting the migration path forward.
+
+Nothing in the repository is shipped externally; compatibility with a user base that does not exist is a cost paid for no benefit.
+
+## Decision 4 — Body work lands on this branch, not a follow-up
+
+Posture 3's decision-log #3 scoped body work out. Posture 4 brings it in. The Gmail connection (Maildir via mbsync), feature extraction (Ollama enrichment → `Dict{Symbol, Float64}`), Telegram training loop, server loop, and production persistence all land as Move 9 of this branch.
+
+The rationale is architectural, not schedule-driven. Body work built against a half-migrated foundation accumulates its own compatibility debt — every Prevision-consuming body component would need a companion Measure-consuming shim for the duration of the migration, which negates the ten-move discipline. Body work built against the Posture 4 tip, after Moves 1–8 have retired Measure entirely, has no such debt. The incremental cost of delivering body work on this branch is lower than the incremental cost of delivering it on a follow-up branch that has to coexist with a half-migrated base.
+
+Move 9 is also the evidence that the foundation is usable. A reconstruction whose only consumers are the reconstruction's own tests is a reconstruction that has not been applied yet. The email agent with Maildir, feature enrichment, and the Telegram training loop is the first consumer of the foundation; the qa_benchmark and grid_world examples are test harnesses, not applications.
+
+Rejected alternatives:
+
+- **Body work as a follow-up branch.** The natural sequencing. Rejected for the reason above: the compatibility cost of delivering body work on a half-migrated base is substantial and avoidable.
+
+- **Body work as a parallel branch, merged after `de-finetti/complete`.** Considered for review-load reasons; rejected because it requires either (a) the parallel branch to build against a non-existent Posture 4 tip (impossible) or (b) the parallel branch to build against Posture 3 and then migrate at merge time (which is exactly the compatibility cost the decision is avoiding).
+
+## Decision 5 — PR cadence: move-per-PR with design docs, inherited from Posture 3
+
+Each of the 10 moves opens with a `docs/posture-4/move-N-design.md` docs-only PR, then a code PR. Roughly 20 PRs total (Move 0 capture + 10 design + 10 code; Move 10's design-and-code may fold into a single PR per the Posture 3 precedent if the documentation-only scope does not require review separation).
+
+Every move design doc follows `docs/posture-4/DESIGN-DOC-TEMPLATE.md`. Reviewers reject design docs that omit "Open design questions" or that fill it with questions whose answer is obvious from the plan.
+
+The reviewer-driven pace rule from Posture 3 carries over. No artificial cadence targets.
+
+Rejected alternatives:
+
+- **One PR per move, no design doc gates.** Saves ten PR openings; loses the Socratic discipline that catches reconstruction-level mistakes before they ship as code. The Posture 3 precedent validated the discipline; Posture 4 inherits it.
+
+- **Two-move PR batches.** Considered for velocity; rejected because the moves are tightly sequenced and a batched PR review that finds a problem in the first move of the batch invalidates the second move's diff. Each move as its own PR keeps the rollback granularity tight.

--- a/docs/posture-4/master-plan.md
+++ b/docs/posture-4/master-plan.md
@@ -1,0 +1,290 @@
+# Master plan — Complete the de Finettian migration
+
+Branch: `de-finetti/complete`.
+
+This is the durable in-repo copy of the branch's master plan. Surgical updates during the branch are permitted; contradictions with `decision-log.md` require amendment of the log in the same PR.
+
+## Context
+
+Posture 3 landed prevision-first in `src/` and stopped at the scope boundary set by its decision-log #3: `apps/skin/server.jl`, `apps/python/*`, and body work were carved out to narrow the blast radius and preserve JSON-RPC wire compatibility. The result is a codebase in which `src/` makes the paper's foundational claim and every layer above it contradicts the claim in order to preserve a compatibility surface that nothing depends on.
+
+Posture 4 finishes the reconstruction. The compatibility surface is retired. Every layer speaks Prevision directly. The body work lands against the clean foundation as Move 9 and serves as evidence that the foundation is usable, not merely correct.
+
+The guiding principle is set in `decision-log.md`: at every ambiguous design choice, take the most de Finettian option. There is exactly one numerical primitive — `expect(p, f)` — and one conditioning primitive — `condition(p, e)` or `condition(p, k, obs)`, peer primary per Posture 3 Move 7. Every other named function on a prevision is sugar over these. The type system bends to accommodate the foundation, not the other way around.
+
+## Final-state architecture
+
+The Posture 4 tip looks like this. Design docs reference this section as the convergence target; moves transform the current tip toward it.
+
+### Types retained
+
+- **Space hierarchy** — `Space`, `Finite`, `Interval`, `ProductSpace`, `Simplex`, `Euclidean`, `PositiveReals`. Structural, not probabilistic.
+- **Event hierarchy** — `Event`, `TagSet`, `FeatureEquals`, `FeatureInterval`, `Conjunction`, `Disjunction`, `Complement`. Structural predicates over a space.
+- **Kernel** — `Kernel`, `FactorSelector`, `LikelihoodFamily` and subtypes.
+- **Prevision hierarchy** — `Prevision`, concrete subtypes: `BetaPrevision`, `CategoricalPrevision`, `GaussianPrevision`, `GammaPrevision`, `DirichletPrevision`, `NormalGammaPrevision`, `TaggedBetaPrevision`, `ProductPrevision`, `MixturePrevision`, `ExchangeablePrevision`, `ConjugatePrevision{Prior, Likelihood}`, `ParticlePrevision`, `QuadraturePrevision`, `EnumerationPrevision`, `ConditionalPrevision{E <: Event}`.
+- **TestFunction hierarchy** — `TestFunction`, `Identity`, `Projection`, `NestedProjection`, `Tabular`, `LinearCombination`, `Indicator{E}`, `OpaqueClosure`.
+- **Grammar / Program / AgentState** — unchanged from Posture 3 except for the final-state rename of `Functional` → `TestFunction` throughout (Posture 3 left a type alias; Posture 4 deletes the alias).
+
+### Types deleted
+
+- `Measure` and every concrete subtype: `CategoricalMeasure`, `BetaMeasure`, `TaggedBetaMeasure`, `GaussianMeasure`, `DirichletMeasure`, `GammaMeasure`, `NormalGammaMeasure`, `ProductMeasure`, `MixtureMeasure`. Gone entirely from the type system, exports, SPEC, CLAUDE, tests, apps, BDSL stdlib, and paper.
+- The `Functional = TestFunction` alias (Posture 3 Move 2 scaffolding). All references updated to `TestFunction`.
+- Persistence v1 and v2 loader paths; all associated fixtures.
+- The `getproperty` shields on every Measure subtype; they retire with the Measure subtypes themselves.
+- The `_predictive_ll` helper and any other dual-residency artefact Posture 3 could not remove without breaking the Measure surface.
+
+### Internal representation invariants
+
+- **Previsions hold Previsions.** `TaggedBetaPrevision.beta::BetaPrevision`. `ProductPrevision.factors::Vector{Prevision}`. `MixturePrevision.components::Vector{Prevision}`. No `Any`, no untyped `Vector`. The `decompose(::ExchangeablePrevision) → MixturePrevision` path returns a genuine `MixturePrevision{Vector{Prevision}}`, making the paper's §1.4 claim structurally true.
+
+- **Unified field name.** `log_weights::Vector{Float64}` on `CategoricalPrevision`, `ParticlePrevision`, `QuadraturePrevision`, `EnumerationPrevision`, `MixturePrevision`. `CategoricalPrevision.logw` is renamed. The Posture 3 `getproperty` branch that dispatched on Prevision subtype to map `.logw` to the right underlying name retires with the shield.
+
+- **Events carried as declared types.** `ConditionalPrevision{E <: Event}` with `event::E`. The opaque-closure `event_predicate::Function` representation is gone. Where a truly structure-free conditional is needed, `OpaqueConditional` is the fallback, clearly marked.
+
+### Operational surface
+
+Exactly two primitive operations:
+
+```julia
+expect(p::Prevision, f::TestFunction) → Float64
+condition(p::Prevision, e::Event) → Prevision
+condition(p::Prevision, k::Kernel, obs) → Prevision
+```
+
+Everything else is sugar. The stdlib provides:
+
+```julia
+mean(p::Prevision)        = expect(p, Identity())
+variance(p::Prevision)    = expect(p, CenteredSquare(mean(p)))    # new TestFunction subtype
+probability(p, e::Event)  = expect(p, Indicator(e))
+weights(p::CategoricalPrevision) = [probability(p, SingletonEvent(a)) for a in atoms(p.space)]
+marginal(p::ProductPrevision, i::Int) = # pushforward via Projection(i)
+```
+
+Some of these definitions are implemented directly (`mean` = literally `expect(p, Identity())`, no special case) and some are implemented with performance representations that happen to sit directly on the concrete subtype's fields (`weights(p::CategoricalPrevision)` uses `exp.(p.log_weights)` directly inside its method body). The outer contract is the same: every numerical query on a prevision routes through `expect` at the call site, even when the inner implementation reads a structural field.
+
+The `expect-through-accessor` lint slug enforces this at call sites outside the concrete Prevision subtype's own method bodies.
+
+### Host boundary
+
+`draw(p::Prevision)` returns a sample. Sampling is a host operation, not a prevision operation — it requires RNG state and is not a coherent linear functional on test functions. The distinction is the same as Posture 3's; Posture 4 tightens it by retiring the `sample` alias if any remains.
+
+### New module structure
+
+```
+src/
+  Credence.jl          — module, exports
+  spaces.jl            — Space hierarchy (new file; split from ontology.jl)
+  events.jl            — Event hierarchy + indicator_kernel (new file; split from ontology.jl)
+  kernels.jl           — Kernel, LikelihoodFamily (new file; split from ontology.jl)
+  test_functions.jl    — TestFunction hierarchy (renamed from prevision.jl §TestFunction)
+  previsions.jl        — Prevision hierarchy, concrete subtypes, expect, condition (renamed from prevision.jl)
+  conjugate.jl         — ConjugatePrevision registry (new file; split from ontology.jl)
+  execution.jl         — Particle, Quadrature, Enumeration carriers + their expect methods
+  stdlib.jl            — mean, variance, probability, weights, marginal (new file; replaces the accessor soup currently in ontology.jl)
+  persistence.jl       — v3 only
+  host_helpers.jl      — draw, sampling, RNG-boundary operations
+  parse.jl             — unchanged
+  eval.jl              — unchanged structurally; updated for Prevision surface
+  program_space/       — unchanged structurally; updated to reference TestFunction directly
+```
+
+The `ontology.jl` file retires as a single 1860-line monolith. The split reflects the axiom / structure / representation tiers explicitly rather than mixing them in one file.
+
+## Moves
+
+### Move 0 — Pre-branch invariance capture
+
+Docs-only. Pin a commit SHA at the tip of current master (the Posture 3 completion point). Capture test output at Strata 1/2/3 tolerances for every behavioural assertion in `test/`. The capture becomes the invariance target for every subsequent move — every posterior-bearing assertion at the Posture 4 tip must match the capture at the declared tolerance.
+
+Ship `docs/posture-4/move-0-design.md` with:
+- The pinned SHA.
+- The capture protocol (Julia version, RNG seeding discipline, test invocation command).
+- The captured output, stored at `test/fixtures/posture-3-capture/` and checked in.
+- The list of assertions whose tolerance is Stratum 1 (`==` or `1e-14`), Stratum 2 (`1e-12`), and Stratum 3 (`1e-10`).
+
+Without Move 0, every subsequent move is flying blind on behavioural preservation. The capture is cheap and the savings downstream are substantial.
+
+### Move 1 — `src/` internal cleanup: field-name unification, parametric `ConditionalPrevision`, shield retirement inside `src/`
+
+Scope: `src/prevision.jl`, `src/ontology.jl`. Low blast radius — no caller outside `src/` is touched yet.
+
+Changes:
+- Rename `CategoricalPrevision.logw` → `log_weights`. Update the four carriers (`CategoricalPrevision`, `ParticlePrevision`, `QuadraturePrevision`, `EnumerationPrevision`) and `MixturePrevision` to share the name. Update every internal reader.
+- Rewrite `ConditionalPrevision` to `ConditionalPrevision{E <: Event}` with `event::E`. Move the type to a module where both constraints hold simultaneously (see Open design questions).
+- Remove the `getproperty` branch on `CategoricalMeasure` that dispatched on stored Prevision subtype. The shield becomes an unconditional forward, or retires entirely in favour of a direct accessor.
+
+Tests: unchanged externally; internal method bodies updated to read the new field name. Stratum-1 and Stratum-2 behavioural output bit-exact against the Move 0 capture.
+
+### Move 2 — Previsions hold Previsions
+
+Scope: `src/prevision.jl`, `src/ontology.jl`.
+
+Changes:
+- `TaggedBetaPrevision.beta::BetaPrevision`. Constructor takes `BetaPrevision`, not `BetaMeasure`. Existing consumers within `src/` that pass a BetaMeasure get updated to pass the underlying Prevision.
+- `ProductPrevision.factors::Vector{Prevision}`. Constructor and internal consumers updated.
+- `MixturePrevision.components::Vector{Prevision}`. Constructor, `expect`, `condition`, `decompose` methods updated.
+
+Measure subtypes still exist at this point — they are retired in Move 5. The `getproperty` shields on the remaining Measure subtypes may need to reconstruct a Measure-shaped view for external consumers (e.g. `MixtureMeasure.components` returns `Vector{Measure}` via on-the-fly wrapping); this transient state is what allows tests and apps to continue working until Move 4/5 rewrites them.
+
+Behavioural capture: bit-exact against Move 0.
+
+### Move 3 — Persistence v3-only
+
+Scope: `src/persistence.jl`, `test/fixtures/`, `test/test_persistence.jl`.
+
+Changes:
+- Delete v1 and v2 loader paths.
+- Delete `test/fixtures/agent_state_v1.jls`, `test/fixtures/email_agent_state_v1.jls`, and any v2 analogues.
+- Recapture v3 fixtures from the Move 2 tip.
+- Update `test/test_persistence.jl` to assert v3 round-trip only.
+
+Justification: no deployed state depends on v1/v2; the fixtures exist to audit the migration and the migration is done. Keeping the paths alive through Move 5 would require either updating them as Measure retires (pointless churn) or keeping Measure alive inside persistence (which perpetuates the type system's disagreement with the rest of `src/`).
+
+### Move 4 — Test suite migrated
+
+Scope: every `test/test_*.jl` file.
+
+Changes: every Measure construction rewritten as Prevision construction. `CategoricalMeasure(Finite([:a, :b]), [0.0, 0.0])` → `CategoricalPrevision([0.0, 0.0])` with the space information carried separately where needed. `BetaMeasure(1.0, 1.0)` → `BetaPrevision(1.0, 1.0)`. And so on for each subtype.
+
+Test files are renamed where the rename improves clarity: `test_flat_mixture.jl` describes a Prevision-level concern under the new foundation and may become `test_mixture_prevision.jl`; `test_prevision_mixture.jl` absorbs or co-locates with it.
+
+Behavioural capture: every assertion's value matches the Move 0 capture at the declared tolerance. If any assertion *fails* this check, the cause is investigated before Move 5 proceeds — Move 5 is the point of no return and a surviving behavioural regression at Move 4 is a diagnostic signal about Moves 1–3.
+
+### Move 5 — Measure deleted from `src/`
+
+Scope: `src/ontology.jl` (and its split successors per the final-state module structure), `src/Credence.jl`.
+
+Changes:
+- Delete the nine Measure subtypes.
+- Delete their `getproperty` shields, constructors, exports.
+- Split `src/ontology.jl` into `spaces.jl`, `events.jl`, `kernels.jl`, `test_functions.jl`, `conjugate.jl`, `stdlib.jl` per the final-state module structure. This is the natural moment to perform the split because the file is being gutted regardless.
+- Introduce `src/stdlib.jl` with `mean(p) = expect(p, Identity())`, `probability(p, e) = expect(p, Indicator(e))`, `variance`, `weights`, `marginal`.
+- Introduce the `expect-through-accessor` lint slug.
+
+This is the largest diff of the branch. It is also the simplest: if Moves 1–4 landed correctly, Move 5 is mostly deletion and file splits.
+
+Behavioural capture: bit-exact against Move 0. Any regression is a bug in a prior move that Move 4 did not catch, and Move 5 halts until the regression is fixed at its source.
+
+### Move 6 — Apps and BDSL stdlib migrated
+
+Scope: `apps/julia/email_agent/`, `apps/julia/qa_benchmark/`, `src/stdlib.bdsl`, `examples/*.bdsl`, `examples/host_credence_agent.jl`.
+
+Changes: every Measure construction in the apps and examples migrated to Prevision construction. The BDSL stdlib functions that construct probability objects produce Previsions. The host files realise Previsions directly.
+
+Tests: the apps have their own test harnesses (28 tests in `test_email_agent.jl`, 10 in `test_grid_world.jl`) which were migrated in Move 4; they pass unchanged here.
+
+### Move 7 — Skin rewritten
+
+Scope: `apps/skin/server.jl`, `apps/skin/test_skin.py`, any `apps/skin/*.jl` helpers.
+
+Changes:
+- Internal belief state is `Prevision`, not `Measure`. Where the current code maintains `state.belief::MixtureMeasure`, the new code maintains `state.belief::MixturePrevision`.
+- JSON-RPC method signatures redesigned for Prevision vocabulary on the wire. `condition`, `expect`, `weights`, `mean`, `optimise`, `factor`, `snapshot_state` are Prevision-over-the-wire.
+- Mutation operations become explicit Prevision-level APIs: `push_component!(::MixturePrevision, ::Prevision, log_weight)`, `replace_component!(::MixturePrevision, i, ::Prevision)`. No more `push!(state.belief.components, ...)` through field access.
+- `apps/skin/test_skin.py` rewritten for the new wire format.
+
+Design decision: Python callers now speak Prevision vocabulary over JSON-RPC, which motivates Move 8.
+
+### Move 8 — Python bindings rewritten
+
+Scope: `apps/python/credence_bindings/`, `apps/python/credence_agents/`, `apps/python/credence_router/`, `apps/python/bayesian_if/`.
+
+Changes: every Python module that speaks to Credence speaks Prevision. Constructor surface:
+
+```python
+Prevision.beta(alpha, beta)
+Prevision.gaussian(mu, sigma)
+Prevision.categorical(log_weights)
+Prevision.mixture(components, log_weights)
+```
+
+Query surface:
+
+```python
+p.expect(f)      # f is a TestFunction handle
+p.mean()
+p.probability(event)
+p.condition(event)
+p.condition(kernel, obs)
+```
+
+The `weights`, `mean`, `variance` Python-side methods are one-liners over `expect`, mirroring the Julia stdlib.
+
+Python-side tests pass; the credence-proxy gateway Docker image rebuilds clean with the new surface.
+
+### Move 9 — Body work
+
+Scope: `apps/julia/body/` (new directory), plus minor updates to `src/persistence.jl` for production-state persistence.
+
+Components:
+
+- **Gmail connection.** Maildir via `mbsync`. A `Connection` with `extract(event) → Dict{Symbol, Float64}` and `execute!(action) → Outcome`. Reading emails is reading files; actions are filesystem operations.
+- **Feature extraction.** Ollama enrichment pipeline producing the named-feature Dict. The LLM is a prosthetic; it proposes structured descriptions of emails that the Bayesian layer treats as features.
+- **Telegram training loop.** Existing bot wired to send the agent's proposed action for user confirmation. 👍 / 👎 reactions encode cost tolerance; user reactions update the CIRL prior over utility parameters.
+- **Server loop.** Polling execution of active programs against the evolving feature dictionary. Per-step conditioning. Meta-actions where the agent modifies its own hypothesis space.
+- **Persistence.** Production state save/load. Under decision-log #4 of posture-3, the state was to be `MixtureMeasure` of `ProductMeasure` of `BetaMeasure`; under Posture 4 it is `MixturePrevision` of `ProductPrevision` of `BetaPrevision`. Persistence round-trip tested under canonical operating conditions.
+
+The body work is scoped to close the "email is the book" Amazon-analogy loop: first domain demonstrates the Connection abstraction; calendar, files, tasks follow on subsequent branches. Move 9 does not attempt to deliver calendar/files/tasks connections.
+
+### Move 10 — Documentation and paper reconciled
+
+Scope: `SPEC.md`, `CLAUDE.md`, `README.md`, `docs/` throughout, `docs/posture-3/paper-draft.md`.
+
+Changes:
+- `SPEC.md` §1 Foundations already prevision-first after Posture 3's Move 7; the rest of SPEC is updated to match.
+- `CLAUDE.md` frozen-types section: Space, Event, Kernel, Prevision, TestFunction (five frozen types; Measure concession removed). Forbidden-patterns entries updated: directly reading a Prevision's structural fields to compute a probabilistic property is a forbidden pattern, enforced by `expect-through-accessor`.
+- `README.md` updated for the Prevision-first surface.
+- `docs/posture-3/paper-draft.md` reconciled:
+  - Abstract: remove "We retain Measure as a thin wrapper" clause.
+  - §1.2: rewrite the "Two consequences of taking the prevision as primitive" paragraph — Measure is not retained, so the Kolmogorov-familiar surface is a set of named functions over `expect`, not a separate type.
+  - §2.1: the pre/post code snippet no longer needs the `BetaMeasure` wrapping on the post-refactor side.
+  - §4 Implementation: description updated to Posture 4 tip; "pragmatic impurity" concessions removed. Reference implementation pin updated from the Posture 3 SHA to the Posture 4 tip SHA.
+
+Move 10 lands last because it describes the completed state; landing it earlier would describe a state that does not yet exist.
+
+## Verification cadence
+
+End-to-end verification at the end of every code PR; never batched. The command set for each move lives in its design doc. Shared invariants:
+
+- Every behavioural assertion captured at Move 0 holds at the declared tolerance after each move.
+- `grep -r 'pragmatic impurity' src/ apps/ test/ docs/` returns nothing after Move 5.
+- `grep -rE 'struct (Categorical|Beta|Tagged|Gaussian|Dirichlet|Gamma|NormalGamma|Product|Mixture)Measure' src/` returns nothing after Move 5.
+- `credence-lint` passes with zero `expect-through-accessor` violations after Move 6.
+- Skin smoke test passes against the new wire format after Move 7.
+- Python bindings integration tests pass after Move 8.
+- Body-work end-to-end test passes after Move 9: email arrives at Maildir → feature extraction → Prevision update → action selection → user reaction → further Prevision update.
+
+## Risks
+
+### Move 5 as the point of no return
+
+Move 5 deletes the Measure types. Once merged, reverting requires a branch-level rollback, not a single-PR revert. The design doc for Move 5 must include an explicit pre-merge checklist that confirms Moves 1–4 are green and the Move 0 capture matches at all tolerances. Any open Stratum-2 deviation or unexplained Stratum-3 drift blocks the Move 5 merge.
+
+### Body work timing
+
+Move 9 is the largest individual move by line-count and by external-surface complexity (Maildir sync, Ollama prompting discipline, Telegram bot webhook handling, server loop). Budget accordingly. If Move 9 stretches beyond a reasonable window, consider splitting into 9a (Gmail + feature extraction + persistence) and 9b (Telegram + server loop + meta-actions) at a design-doc PR; the split should not reopen the foundational decisions.
+
+### Wire-format redesign debt (Move 7)
+
+Redesigning the JSON-RPC wire format is net positive — the current shape inherits Measure vocabulary — but it is a schema-design task in its own right and design-document time on Move 7 should reflect that. The Python bindings (Move 8) depend on the final wire shape; if Move 7's wire design is unsettled, Move 8's diff is rework waiting to happen.
+
+### Paper timing
+
+Move 10 is scheduled last. The AISTATS 2027 deadline and the NeurIPS 2026 workshop deadline both precede the realistic completion date for a ten-move branch if the cadence is reviewer-driven per Posture 3 precedent. If a submission deadline forces paper reconciliation before Move 9 closes, the paper lands in a state that describes the branch tip as of its submission rather than the final tip; this is acceptable provided the submission is clearly labelled against its branch SHA.
+
+## Prerequisites before any code lands
+
+- **Move 0 capture complete and checked in.** Nothing else starts until the invariance target exists on disk.
+- **Branch rebased onto current master.** Posture 3 Move 8 merged; the Posture 4 branch starts from that point.
+- **`docs/posture-4/README.md`, `decision-log.md`, `master-plan.md`, `DESIGN-DOC-TEMPLATE.md`, `move-0-design.md` land together as the opening docs-only PR.** This is the Posture 3 precedent applied; the substantive Move 0 plan is itself the opening shot.
+
+## Grounds-for-reopen
+
+Reviewers reopen PRs that:
+- Skip the design-doc step and land code without a matching design PR.
+- Omit the "Open design questions" section or fill it with answered questions.
+- Introduce a new Measure subtype or a new Prevision-held-Measure field under any justification.
+- Introduce a new `getproperty` shield on a Prevision subtype for any reason.
+- Add a presentation helper that reads a concrete Prevision's structural field outside the Prevision's own `expect` method body.
+- Leave a "pragmatic impurity" or "for backwards compatibility" docstring anywhere in `src/`, `apps/`, or `test/`.

--- a/docs/posture-4/move-0-design.md
+++ b/docs/posture-4/move-0-design.md
@@ -1,0 +1,139 @@
+# Move 0 — Pre-branch invariance capture
+
+## 0. Final-state alignment
+
+Move 0 is the only move that does not converge the current tip toward the final-state architecture. It captures the current tip as the behavioural invariance target against which every subsequent move asserts equivalence. The capture itself is a docs-plus-fixtures-only PR and leaves `src/`, `apps/`, and `test/` untouched. The transient state introduced is a new directory under `test/fixtures/posture-3-capture/` containing the captured assertion values; this directory is read-only throughout the branch and retires at the tip (Move 10) once the paper reconciliation confirms the final behaviour matches.
+
+## 1. Purpose
+
+Capture the behavioural output of every Stratum-1/2/3 assertion in the test suite, pinned at the current master SHA, so that Moves 1–9 can assert bit-exact or tolerance-bounded equivalence against a known ground truth throughout the migration. Without the capture, the ten-move sequence has no invariance anchor and the Move 5 "point of no return" deletion of Measure is taken on faith rather than evidence.
+
+## 2. Files touched
+
+Creates:
+- `docs/posture-4/move-0-design.md` — this file.
+- `test/fixtures/posture-3-capture/README.md` — capture protocol, SHA pin, tolerance classifications per assertion.
+- `test/fixtures/posture-3-capture/strata-1.jls` — Stratum-1 assertions (`==` and `1e-14` tolerances; closed-form posteriors, particle paths under seeded RNG, enumeration posteriors).
+- `test/fixtures/posture-3-capture/strata-2.jls` — Stratum-2 assertions (`1e-12` tolerance; numerically-sensitive closed-forms where arithmetic reassociation is legitimate).
+- `test/fixtures/posture-3-capture/strata-3.jls` — Stratum-3 assertions (`1e-10` floor; end-to-end integration, paper-claim-supporting numerics).
+- `test/fixtures/posture-3-capture/manifest.toml` — per-assertion metadata: test file, test name, assertion line, stratum, captured value, tolerance.
+
+Modifies: none.
+
+Deletes: none.
+
+## 3. Behaviour preserved
+
+Move 0 does not modify behaviour. It records behaviour. The assertion Move 0 makes is meta: "the capture files on disk are a faithful record of what the current master produces under the declared seed discipline."
+
+The meta-assertion is verified by re-running the capture script in a clean checkout immediately before the Move 0 PR lands. If the re-run produces identical fixtures, the capture is stable under the declared protocol. If it produces divergent fixtures, the protocol is under-specified and must be tightened before the capture is checked in.
+
+## 4. Worked end-to-end example
+
+Concrete capture protocol:
+
+```bash
+# Clean checkout at the pinned SHA
+git checkout <POSTURE-3-TIP-SHA>
+git clean -fdx
+
+# Julia version pinned
+julia --version  # must match the version recorded in the manifest
+
+# Run the capture script
+julia --project=. scripts/capture-invariance.jl \
+  --output test/fixtures/posture-3-capture/
+
+# Verify the capture is stable under a second run
+julia --project=. scripts/capture-invariance.jl \
+  --output /tmp/posture-3-capture-verify/
+diff -r test/fixtures/posture-3-capture/ /tmp/posture-3-capture-verify/
+# Zero output expected.
+```
+
+The capture script `scripts/capture-invariance.jl` walks every `test/test_*.jl` file, wraps each `@test` with an instrumentation hook that records the LHS and RHS of the assertion and the tolerance used, and serialises the result. Assertions marked with `@test_broken` or inside `@test_skip` blocks are captured as broken/skipped and not compared post-capture.
+
+For a single example trace:
+
+```
+test/test_prevision_conjugate.jl line 47:
+  assertion: @test posterior.alpha ≈ 3.0 atol=1e-14
+  stratum: 1 (atol=1e-14 → Stratum 1 by the strata-tolerance mapping)
+  captured LHS: 3.0 (exact)
+  captured RHS: 3.0
+  manifest entry:
+    file: test/test_prevision_conjugate.jl
+    line: 47
+    name: "Beta-Bernoulli conjugate update: two successes"
+    stratum: 1
+    captured: 3.0
+    tolerance: 1e-14
+```
+
+At Move 1 (and every subsequent move), the same test is re-run post-refactor; the assertion's LHS is compared against the captured 3.0 at tolerance 1e-14. If it deviates, Move 1 fails verification and does not proceed to the code PR merge.
+
+## 5. Open design questions
+
+1. **Assertion tolerance vs stratum mapping.** Currently the mapping is "tolerance declared in `@test ... atol=X` or `rtol=X` maps to stratum by magnitude." This covers explicit assertions. For `@test` assertions without an explicit tolerance — e.g. `@test length(programs) == 22` — the default is `==`, which is Stratum 1. Does this suffice, or do we need a third classification axis ("structural equality vs numerical equality")? Structural equality assertions (types, lengths, keys) are not affected by reassociation and belong in a separate class for clarity. Argue.
+
+2. **Particle-path seed capture.** The Posture 3 precedent `test/fixtures/particle_canonical_v1.jls` captures sample sequences under `Random.seed!(42)`. Posture 4's capture inherits this but must extend to every particle-consuming test, not just the canonical one. Does the capture protocol iterate every `Random.seed!(...)` call site in the test suite and capture the sample sequence downstream, or does it rely on per-test reseeding being stable across reruns? The conservative answer is the former (capture the sequences); the minimal answer is the latter (trust the reseed). The minimal answer fails silently if a refactor changes seed-consumption order.
+
+3. **Cross-platform reproducibility.** Julia's RNG is platform-independent for the default seed, but floating-point arithmetic in some of the numerically-sensitive paths may produce platform-dependent results at the 1e-15 level. Does the capture pin a platform (Linux x86_64, specific Julia version) as the canonical machine, or does it capture per-platform and compare within-platform? Pinning a canonical machine is simpler; per-platform is more robust. Argue.
+
+4. **What to do with assertions that currently fail or are flaky.** The current test suite has a small number of `@test_broken` and skip-on-RNG-drift assertions. Move 0 captures their state as-is. At Move 10, the paper-reconciliation PR may discover that one of these is now fixable under the cleaner foundation; at that point, the capture is updated and the assertion upgraded from broken to passing. The protocol for this upgrade should be stated in the Move 0 README so Move 10 does not invent it.
+
+## 6. Risk + mitigation
+
+**Risk.** The capture misses an assertion whose value is dependent on a global state the capture script does not control for (e.g. a module-level `const` that changes between the capture run and a later refactor). Later moves see a behavioural "regression" that is actually drift in the global state, and chase a phantom.
+
+**Mitigation.** The capture script records the set of Julia packages and their versions, the Julia version, and the pinned master SHA, all to the manifest. Any Move N verification that produces a tolerance violation first confirms the environment matches the capture environment; if it doesn't, the regression is attributed to environment drift, not the move.
+
+**Risk.** The capture protocol is under-specified and a re-run produces different fixtures.
+
+**Mitigation.** §3's double-run verification catches this before the capture is checked in. If the protocol is not stable under a double run, the fix is to tighten the protocol (e.g. add a missing `Random.seed!`) rather than to proceed with an unstable capture.
+
+**Risk.** The capture takes the full test suite to run, which means every subsequent move's verification also takes the full test suite to run, which slows the review cycle.
+
+**Mitigation.** Accept the cost. The alternative — capturing a subset — creates an under-specified invariance target. Ten moves under a tight invariance is faster in total than ten moves under a loose one.
+
+## 7. Verification cadence
+
+The Move 0 PR runs:
+
+```bash
+# Clean checkout at the Move 0 PR tip
+git clean -fdx
+
+# Run the capture
+julia --project=. scripts/capture-invariance.jl --output test/fixtures/posture-3-capture/
+
+# Verify stability
+julia --project=. scripts/capture-invariance.jl --output /tmp/verify/
+diff -r test/fixtures/posture-3-capture/ /tmp/verify/
+# Output: empty.
+
+# Verify the full test suite still passes (the capture instrumentation is wrap-only; it doesn't modify test behaviour)
+julia --project=. -e 'using Pkg; Pkg.test()'
+```
+
+The capture does not run on CI as a regular job; it runs once, captures, and is checked in. CI on subsequent moves compares against the captured fixtures.
+
+## 8. de Finettian discipline self-audit
+
+1. **Is every numerical query in this move routed through `expect`?** N/A — Move 0 introduces no new numerical queries. It records existing ones.
+
+2. **Does this move hold a Prevision inside a Measure, or a Measure inside a Prevision, for any reason?** No. Move 0 adds no types.
+
+3. **Does this move introduce an opaque closure where a declared structure would fit?** The capture instrumentation wraps `@test` macros, which involves closure capture of assertion expressions. This is a test-instrumentation concern, not a domain-logic concern; the closures live inside `scripts/capture-invariance.jl` and never enter `src/`. Acceptable.
+
+4. **Does this move add a `getproperty` override on any Prevision subtype?** No.
+
+---
+
+## Reviewer checklist
+
+- [ ] The SHA pinned is the current master tip (Posture 3 Move 8 merge).
+- [ ] The capture script is reproducible: a clean checkout at the SHA, run twice, produces identical fixtures.
+- [ ] The manifest lists every `@test` call site in `test/` with its stratum and tolerance.
+- [ ] The `test/fixtures/posture-3-capture/` directory is checked in as read-only and documented as the invariance target for Moves 1–10.
+- [ ] No modifications to `src/`, `apps/`, or `test/test_*.jl` themselves.


### PR DESCRIPTION
## Summary

Opens `de-finetti/complete`. Six documents land together per the Posture 3 precedent for substantive Move 0 PRs.

- `docs/posture-4/README.md` — branch charter, final-state architecture principle, scope
- `docs/posture-4/decision-log.md` — the five decisions settled pre-branch (Measure deleted; `expect` is the single query; no compatibility; body work on-branch; design-doc cadence)
- `docs/posture-4/master-plan.md` — the ten-move specification
- `docs/posture-4/DESIGN-DOC-TEMPLATE.md` — §0 final-state alignment + §8 de Finettian discipline self-audit added to the inherited Posture 3 template
- `docs/posture-4/move-0-design.md` — pre-branch invariance capture protocol (captures the current tip as behavioural ground truth)
- `docs/posture-4/claude-code-prompts.md` — one prompt per move (20 total, sequenced)

Nothing in \`src/\`, \`apps/\`, or \`test/\` changes in this PR. The Move 0 capture script and fixtures land in the next PR as code (per \`claude-code-prompts.md\` Prompt 0).

Ceremonial opener — establishes that the branch and plan exist as repo state, nothing more. Substantive reconciliation edits (prompts-file patches + master-plan Move 5 halting condition) follow in a separate Stage 2 PR.

See \`docs/posture-4/README.md\` for the charter, \`decision-log.md\` for the settled decisions, \`master-plan.md\` for the specification.

## Test plan

- [x] Documents-only; no code touched
- [x] Six files extracted from the zip; zip (untracked) removed locally
- [x] CI passes (docs-only changes don't break any test gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)