### PR TITLE
Trim CLAUDE.md under 40k threshold by extracting precedent prose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,208 +235,93 @@ Second example: weights. Measures store weights in log-space internally (`logw` 
 
 ## Precedents
 
-Case law. Each entry names which invariant it follows from and why. Weight is on grey-zone cases — the bright-line violations are caught by the constitution and (eventually) by CI; what merits human-readable reasoning are the judgement calls where mechanical enforcement can't distinguish causal from non-causal.
-
-Every precedent carries a stable **slug** — a short identifier used by the lint escape-hatch pragma. When a grey-zone case sanctions code that would otherwise violate the invariants, the author marks the line with:
+Case law. Each precedent has a stable **slug** used by the lint escape-hatch pragma:
 
 ```
 # credence-lint: allow — precedent:<slug> — <one-line reason>
 ```
 
-Both the slug and the reason are mandatory. The pragma is recognised on the same line as the violation or on the immediately preceding comment-only line — whichever reads better at the call site. Unknown slugs and missing reasons fail the lint. Novel cases unblock via a new precedent entry in this document (with its own slug) in the same PR — new escape hatches are constitutional amendments, not inline concessions. `grep -r 'credence-lint:' .` is a usable audit surface.
+Both slug and reason are mandatory. The pragma is recognised on the same line as the violation or on the immediately preceding comment-only line. Unknown slugs and missing reasons fail the lint. Novel cases unblock via a new precedent entry — in this slug index AND in `docs/precedents.md` — in the same PR. `grep -r 'credence-lint:' .` is the audit surface.
 
-### Grey zones
+The slug index below is the lint's source of truth for valid slugs (regex `^\*\*Slug:\*\*\s*\`...\``). Full prose for each precedent — Legal/Illegal cases, failure modes, escape-hatch templates, specific derivations, and historical rejections — lives in `docs/precedents.md`. Read that file before invoking a slug you haven't used before, or before proposing a new one.
 
-#### Reading vs. computing on weights
-**Slug:** `compute-on-weights`.
-**Legal:** `weights(m)` for logging, telemetry, display. `mean(m)` passed to a non-causal dashboard.
-**Illegal:** any arithmetic on the result that feeds back into a decision or belief — summation, multiplication, comparison-in-branch, threshold checks that gate behaviour.
-**Follows from Invariant 1** because the public accessor is sanctioned access; what makes it a violation is the subsequent causal arithmetic. `weights()` itself does no reasoning; what you do with the return value can. There is no escape hatch — arithmetic that needs the posterior must flow through `expect` with a declared Functional. The slug exists for cross-referencing.
+### Slug index
 
-#### Sort-for-display vs. compare-to-branch
-**Slug:** `sort-for-display`.
-**Legal:** `sort(pairs, by=last)` for a top-K log line. The ordering is non-causal — the display is read by a human, not by the agent.
-**Illegal:** `if w1 > w2 then action_a else action_b` — that comparison *is* the decision, and it lives outside `optimise`.
-**Follows from Invariant 1 (topological face)** because action selection must flow through EU-max. A weight comparison in application code is a parallel decision mechanism. Escape hatch with this slug permits comparison/sort when the author can assert the result is consumed only by display/logging, not by subsequent logic.
+**Slug:** `compute-on-weights` — Reading `weights(m)` is sanctioned; arithmetic on the result that feeds a decision is not. No escape hatch; route through `expect` with a Functional. (Invariant 1)
 
-#### Display arithmetic
-**Slug:** `display-arithmetic`.
-**Legal with escape hatch:** `f"{round(w * 100, 1)}%"` for a progress bar or report.
-**Required pragma:** `# credence-lint: allow — precedent:display-arithmetic — <reason>` on the line, reviewed per commit.
-**Follows from Invariant 1** because the rule binds causal arithmetic; display arithmetic is non-causal by construction. CI cannot distinguish display from causation mechanically, so the author carries the burden of marking it.
+**Slug:** `sort-for-display` — Sort/compare weights for a human-read log line is fine; comparing weights to branch action selection is not. Escape hatch sanctions display/logging only. (Invariant 1, topological)
 
-#### Stdlib compositions calling each other
-**Slug:** `stdlib-composition`.
-**Legal:** `voi` calls `expect`; `optimise` calls `expect` + `argmax`; `model`/`problem` constructors compose kernels and priors; `perturb_grammar` takes posterior analysis as input.
-**Follows from Invariant 1 (topological face)** because the canalised path is the axiom-constrained functions **and their stdlib compositions**. Stdlib members calling each other stays on the sanctioned path. New stdlib operations are added by composing existing ones plus ordinary computation, not by creating a new arithmetic path. Slug is documentation-only — stdlib code lives in `src/`, which is out of scope for the lint.
+**Slug:** `display-arithmetic` — Arithmetic for display strings (percentages, progress bars). Pragma required per line; CI cannot tell display from causation. (Invariant 1)
 
-#### Application constructing a `Problem`
-**Slug:** `declarative-construction`.
-**Legal.** `Problem(state, actions, preference)` is a struct constructor — declarative data. `initial_rel_state(...)`, `CategoricalMeasure(Finite(vals))`, `Kernel(H, O, gen, likelihood_family=…)` — all declarative.
-**Contrast with:** a DSL wrapper like `(defun solve-email (state) (optimise state email-actions email-pref))` — that is a callable re-exporting an axiom-constrained op with hidden structure (see Invariant 2 violation in the Historical rejections). Slug is documentation-only — constructors don't trigger the lint in the first place.
+**Slug:** `stdlib-composition` — Stdlib functions calling each other (`voi`→`expect`, `optimise`→`expect`+`argmax`) stay on the canalised path. Documentation-only; `src/` is out of lint scope. (Invariant 1, topological)
 
-#### Iterating a posterior's support
-**Slug:** `posterior-iteration`.
-**Almost always illegal in consumer code.** If you're writing a loop over `zip(support(m), weights(m))` — or over a mixture's components to sum weighted quantities — the "something" is probability arithmetic.
-**Rewrite:** declare the computation as a `Functional` (`Projection`, `NestedProjection`, `Tabular`, composed via `LinearCombination`) and call `expect(m, f)`. If the loop is a conditional aggregation ("sum over components where predicate fires"), the right primitive is *event-conditioning*: `expect(condition(m, TagSet(fires)), inner)` or a typed `FeatureEquals` / `FeatureInterval`. See the `event-conditioning` precedent below.
-**Last-resort escape for deferred rewrites.** Inline iteration that predates the Functional / Event invariants may be kept via `# credence-lint: allow — precedent:posterior-iteration — tracked in issue #<N>`. The reason must reference a tracking issue for the rewrite; the pragma lives until the rewrite lands. Reach for this only when neither a Functional nor an Event constructor fits — now that events are first-class, most mixture-filter cases have a declarative path.
-**Follows from Invariant 1 and Invariant 2** jointly: the spatial rule rejects the loop; the declared-structure rule points to the rewrite.
+**Slug:** `declarative-construction` — Struct constructors that build declarative data (`Problem`, `Kernel(..., likelihood_family=…)`, `CategoricalMeasure(Finite(vals))`) are legal. Documentation-only. (Invariant 2)
 
-#### Event-conditioning
-**Slug:** `event-conditioning`.
-**Preferred idiom when the conditioning object is an event.** `condition(m, e::Event)` is provably equivalent to `condition(m, indicator_kernel(e), true)` for deterministic events (Di Lavore–Román–Sobociński Prop. 4.9). The sibling form is the natural shape when the conditioning object is a declared predicate (`TagSet`, `FeatureEquals`, `FeatureInterval`, or Boolean compositions thereof); the parametric form remains primary for genuine observation-with-likelihood conditioning.
-**Mechanical bridge.** Every `Event` constructor witnesses an `indicator_kernel` into a Boolean Space. That witness is how Invariant 2 is preserved at the axiom layer: events reach `condition` through declared kernels, not opaque predicate closures.
-**Follows from Invariants 1 and 2.** The topological face is preserved — `condition(m, e)` is on the canalised path, just through the event surface syntax. Declared structure is preserved because every Event carries its data in typed fields. No escape hatch; this is the legal path.
+**Slug:** `posterior-iteration` — Looping over a mixture's support to do weighted arithmetic is almost always wrong; rewrite as a `Functional` + `expect`, or as event-conditioning. Last-resort escape requires a tracking issue for the rewrite. (Invariants 1 + 2)
 
-#### Prevision, not Measure, is primitive
-**Slug:** `prevision-not-measure`.
-**Rule.** Prevision is the frozen primitive (Move 7 elevation); Measure is a declared view over Prevision (Move 3 wrapping; Move 7 constitutional). Beliefs are coherent linear functionals on a declared test function space — what `expect` realises — not probability mass distributions over a measurable space. The Measure surface is preserved for consumer-facing API; internally, belief-changing operations work with Prevision.
-**When it applies.** Code that extends axiom-constrained functions with new beliefs (new conjugate pairs, new mixture routing, new fallback strategies) should declare its work at the Prevision level. `maybe_conjugate` dispatches on (Prior, Likelihood) type pairs where Prior is a Prevision subtype; `_dispatch_path`, `condition`, `update` are all Prevision-level. The Measure-level methods stay as thin facades delegating to the Prevision primary.
-**Failure mode.** Code that patches Measure-specific behaviour (e.g. `condition(m::SomeMeasure, …)` with arithmetic inline) without extending the corresponding Prevision surface creates a dispatch surface that bypasses Move 4's registry and Move 5's routing. Post-Move-7 the Measure surface is a view; arithmetic lives on the prevision side. Inline arithmetic at the Measure level silently forks behaviour.
-**Follows from Invariant 2** (declared structure: Prevision is the dispatch target for axiom-constrained functions) and Move 7's frozen-types edit.
+**Slug:** `event-conditioning` — `condition(m, e::Event)` is the preferred form when the conditioning object is a declared predicate. Provably equivalent to `condition(m, indicator_kernel(e), true)` on deterministic events (DLRS Prop. 4.9). No escape hatch; this is the legal path. (Invariants 1 + 2)
 
-#### Event-form `condition` is a primary, not sugar
-**Slug:** `event-primary-condition`.
-**Rule.** `condition(p::Prevision, e::Event)` is a primary primitive at the Prevision level (Move 7 §5.1 Option B). It is NOT sugar for `condition(p, k::Kernel, obs)` via a synthesised `ObservationEvent(k, obs)`. The two forms are peer primary primitives; neither derives from the other.
-**When it applies.** When the conditioning object is a declared structural predicate over a Space — `TagSet`, `FeatureEquals`, `FeatureInterval`, or Boolean compositions (`Conjunction`, `Disjunction`, `Complement`). Each Event witnesses an `indicator_kernel` into BOOLEAN_SPACE; deterministic-event equivalence to the parametric form is DLRS Prop. 4.9 (arXiv:2502.03477).
-**Failure mode.** Attempting to derive the event-form from the parametric-form via `ObservationEvent(k, obs)` at the axiom layer. This requires `p(1_e) > 0` for the event `{k emits exactly obs}`; continuous observation spaces violate this (Lebesgue measure zero), requiring disintegration which is out of scope per the master plan. Sugar over an undefined reduction is the exact failure mode Option B was committed to avoid.
-**Follows from Invariants 1 and 2.** Topologically, `condition(p, e::Event)` is on the canalised path as a primary form. Declared structure: the Event hierarchy carries typed data in fields; `ObservationEvent` would carry a kernel and observation — a likelihood-structured object, categorically different. No escape hatch; this is the legal path.
+**Slug:** `prevision-not-measure` — Prevision is the frozen primitive; Measure is a declared view. Extensions (new conjugate pairs, mixture routing) declare at the Prevision level; Measure-level methods are thin facades. (Invariant 2)
 
-#### Parametric-form `condition` is a sibling primary, not derived
-**Slug:** `parametric-form-sibling`.
-**Rule.** `condition(p::Prevision, k::Kernel, obs)` is a peer primary at the Prevision level alongside the event-form (Move 7 §5.1 Option B). It is NOT derived from event-form via any `ObservationEvent` construction. Parametric Bayes update — the familiar `p(θ | o) ∝ p(o | θ) p(θ)` shape — has its own mathematically-well-defined semantics for continuous observation kernels that event-form conditioning cannot cover without disintegration.
-**When it applies.** When the conditioning object is a kernel–observation pair, especially for continuous observation spaces (GaussianMeasure + NormalNormal kernel; BetaMeasure + grid-quadrature kernel; anything Move 6 routes through `_condition_particle` or `_condition_by_grid`). Move 4's conjugate registry dispatches through this form.
-**Failure mode.** Framing parametric-form as "the real condition" with event-form as a sibling-that-expands-to-parametric, OR framing event-form as primary with parametric-form as sugar. Both framings mask the peer-primary structure. Downstream consumers reading such a framing misunderstand whether `condition(p, e::Event)` is a first-class primitive (it is, under Option B) or a derived form (it is not).
-**Follows from Invariants 1 and 2** jointly with the §1.0 continuous-kernel measure-zero constraint. The topological face treats both forms as on the canalised path; the declared-structure face keeps `Event` and `Kernel` as structurally-distinct frozen types (Move 7 promoted both). Provable equivalence on deterministic events (DLRS Prop. 4.9) is a bridge, not a reduction.
+**Slug:** `event-primary-condition` — `condition(p::Prevision, e::Event)` is a primary primitive (Move 7 §5.1 Option B), NOT sugar for parametric-form via `ObservationEvent(k, obs)`. No escape hatch. (Invariants 1 + 2)
 
-#### Baseline comparison
-**Slug:** `baseline-comparison`.
-**Legal with escape hatch.** Research baselines deliberately implement non-Bayesian decision mechanisms — argmax-of-means, fixed-threshold, cheapest-first — to empirically contrast against the principled EU-max agent. The paper depends on having these baselines; they are not bugs to be fixed.
-**Required pragma:** `# credence-lint: allow — precedent:baseline-comparison — <which baseline, why non-Bayesian>`. Each baseline's violation is tagged so `grep -r 'baseline-comparison'` produces an inventory of what the paper compares against.
-**Follows from Invariant 1 (topological face)** being scoped to the agent. The invariant forbids parallel decision mechanisms *that the agent uses*; a baseline is, by construction, not the agent. This precedent makes that distinction explicit.
+**Slug:** `parametric-form-sibling` — `condition(p::Prevision, k::Kernel, obs)` is a peer primary alongside event-form, NOT derived from it. Required for continuous observation spaces where event-form needs disintegration. (Invariants 1 + 2)
 
-#### Test code computing expected values manually
-**Slug:** `test-oracle`.
-**Legal with escape hatch.** Tests *of* the reasoner legitimately need an independent oracle: `assert expect(m, f) == pytest.approx(0.7)  # computed by hand from Beta(3,7)`.
-**Required pragma:** `# credence-lint: allow — precedent:test-oracle — <reason>` on the comparison line. The manual computation is the test's ground truth; it is causal *within the test*, but the test is non-causal with respect to the agent (it doesn't feed back into agent behaviour).
+**Slug:** `baseline-comparison` — Research baselines (argmax-of-means, fixed-threshold) deliberately implement non-Bayesian decision mechanisms for empirical contrast. Pragma names the baseline. Scope of Invariant 1 is the agent, not its baselines. (Invariant 1, topological)
 
-### Specific derivations
-
-#### Indifference implies exploration
-When `EU(interact) == EU(wait)` (both zero), interact. `select_action` threshold is `>= 0`, not `> 0`. Follows from correct EU accounting: at indifference, VOI from the interaction outcome is still positive (you'll learn something), which is part of EU. If the threshold is strict, a correct EU computation will have already broken the tie. Listed here because it's the kind of edge case that gets "fixed" back to strict inequality under perceived instability, and the fix is wrong.
-
-#### Non-firing predicates predict the base rate
-Programs whose predicates don't fire return `log(0.5)`, not `0.0`. A non-firing program is implicitly predicting "I don't know, 50/50"; that prediction is scored against the observation. Ranking: *informed-and-right* > *uninformed* > *informed-and-wrong*. Returning `0.0` makes non-firing programs unbeatable (no information → no penalty), creating weight rigidity after regime changes. Listed here because the bug manifests long after the change (the posterior stops adapting) and the fix looks like a tunable constant; it is not — it is scoring-rule calibration.
-
-### Historical rejections
-
-#### PROPOSED: `(sample measure)` in the DSL for Thompson sampling.
-**REJECTED.** Sampling is randomness; randomness is a side effect; the DSL is pure. Construct the posterior in the DSL; call `draw()` in the host. **Invariant 1 (spatial)** — DSL stays non-executing.
-
-#### PROPOSED: `host_decide()` / `host_optimise()` in host drivers.
-**REJECTED.** `optimise` and `value` belong in the ontology alongside `expect` and `condition`. One implementation per operation. The host driver is pure orchestration — it calls ontology functions. **Invariant 1 (topological)** — one canonical path per operation.
-
-#### PROPOSED: `(thompson-sample m actions pref)` in stdlib that calls sample.
-**REJECTED.** Compounds both errors above. Thompson sampling is `draw` (host) + `argmax` (ordinary computation on the drawn value). The DSL constructs the posterior; its job is done. **Invariant 1 (both faces).**
-
-#### PROPOSED: Bare lambda as a kernel's likelihood.
-**REJECTED.** Kernels declare `likelihood_family` at construction; bare lambdas defeat conjugate dispatch and force probing. **Invariant 2.**
-
-#### PROPOSED: Flat coefficient arrays for `LinearCombination` instead of `Vector{Tuple{Float64, Functional}}`.
-**REJECTED.** Flat indexing encodes stride conventions invisible to the type system. Each sub-functional must navigate its own structure. **Invariant 2** — composition is part of structure.
-
-#### PROPOSED: Inferring kernel family by probing `log_density == 0.0` for flat likelihoods.
-**REJECTED.** Legitimate kernels can return zero log-density at specific points without being flat; the probe misfires and hides the assumption from the type system. **Invariant 2** — declared at construction, not dispatch.
-
-#### PROPOSED: DSL wrapper functions in domain files (e.g., `(defun choose-email (s) (optimise s email-actions email-pref))`).
-**REJECTED.** Wrappers force the preference through an opaque closure that defeats Functional dispatch AND hide the causal arithmetic path from CI. A domain file contains data; axiom-constrained ops are called at the protocol level, not wrapped. **Invariants 1 and 2** jointly.
+**Slug:** `test-oracle` — Tests of the reasoner need an independent manual oracle (`assert expect(m, f) == approx(0.7)`). Pragma marks the comparison line. Causal within the test, non-causal w.r.t. the agent. (Invariant 1)
 
 ## Development commands
 
-Run tests:
-    julia test/test_core.jl                 # Core DSL tests
-    julia test/test_flat_mixture.jl         # Flat mixture tests
-    julia test/test_host.jl                 # Host helper tests
-    julia test/test_program_space.jl        # Program-space tests (grammars, enumeration, perturbation)
-    julia test/test_grid_world.jl           # Grid-world domain tests
-    julia test/test_email_agent.jl          # Email agent domain tests
-    julia test/test_rss.jl                  # RSS domain tests
-    julia test/test_events.jl               # Event hierarchy + indicator_kernel
-    julia test/test_persistence.jl          # Serialisation fixtures
-    julia test/test_prevision_unit.jl       # Prevision primitive unit tests
-    julia test/test_prevision_conjugate.jl  # Conjugate dispatch via maybe_conjugate
-    julia test/test_prevision_mixture.jl    # MixturePrevision routing
-    julia test/test_prevision_particle.jl   # Particle/grid backends
+Julia tests (one file at a time; `ls test/test_*.jl` for the catalogue):
+    julia test/test_core.jl                         # canonical pattern
 
-Run POMDP agent tests:
+POMDP agent (separate package):
     cd apps/julia/pomdp_agent && julia --project=. -e 'using Pkg; Pkg.test()'
 
-Run the Jericho IF agent:
-    cd apps/julia/pomdp_agent && julia --project=. examples/jericho_agent.jl /path/to/game.z3
-
-Run an example:
-    julia -e 'push!(LOAD_PATH, "src"); using Credence; run_dsl(read("examples/coin.bdsl", String))'
-
-Run the grid-world agent:
-    julia apps/julia/grid_world/host.jl
-
-Run the credence agent (host-driven):
-    julia examples/host_credence_agent.jl
-
-Use the module from Julia REPL:
-    push!(LOAD_PATH, "src")
-    using Credence
-
-Load DSL and get callable closures (host-driver pattern):
+Host-driver pattern (load DSL, extract callable closures):
     env = load_dsl(read("examples/credence_agent.bdsl", String))
     agent_step = env[Symbol("agent-step")]
 
-Requires Julia >=1.9 (stdlib only for the DSL core). CI pins Julia 1.11.
-External deps (for full workspace): HTTP, JSON3, Serialization.
+Requires Julia >=1.9 (stdlib only for the DSL core); CI pins 1.11. Full
+workspace deps: HTTP, JSON3, Serialization.
 
-Python workspace:
+Python workspace (uv):
     uv sync                                         # install all 4 packages
     uv sync --extra server --extra search           # what CI installs
     PYTHON_JULIACALL_HANDLE_SIGNALS=yes uv run pytest apps/python/
 
-Run a single Python test file (example):
-    PYTHON_JULIACALL_HANDLE_SIGNALS=yes \
-      uv run pytest apps/python/credence_router/tests/test_routing.py -x
-
 `apps/python/credence_router/tests/test_live.py` is excluded from CI (hits
-real provider APIs); run it manually when changing live paths.
+real provider APIs); run manually when changing live paths.
 
-Skin server (language-agnostic host interface — JSON-RPC wire layer):
-    julia apps/skin/server.jl                       # holds Measures, evaluates DSL via JSON-RPC
-    python -m skin.test_skin                        # smoke tests (from repo root)
+Skin server (JSON-RPC wire layer):
+    julia apps/skin/server.jl
+    python -m skin.test_skin                        # smoke tests from repo root
 
 credence-proxy (production gateway):
     PYTHON_JULIACALL_HANDLE_SIGNALS=yes credence-router serve
-    docker build -t credence-proxy .                # same image CI publishes
+    docker build -t credence-proxy .
 
-CI: `.github/workflows/publish-image.yml` has three jobs.
-**unit-tests** instantiates the Credence Julia project (`Pkg.instantiate` +
-`Pkg.precompile` — no `julia test/…` invocation), runs
-`uv sync --extra server --extra search --no-dev`, runs the credence-lint
-corpus self-test and `check apps/` pass, then runs `credence_router` +
-`credence_agents` pytest (excluding test_live.py).
-**smoke-build** builds the amd64 image and curls `/ready` against a
-running container before anything ships.
-**publish** (master + version-tag pushes only) builds multi-arch and
-pushes to GHCR.
-**Julia tests are NOT gated by CI** — run the `test/*.jl` files locally
-before pushing DSL-core changes.
+CI (`.github/workflows/publish-image.yml`) runs three jobs.
+**unit-tests** instantiates the Julia project (`Pkg.instantiate` +
+`Pkg.precompile` — no `julia test/…`), runs `uv sync --extra server --extra
+search --no-dev`, then the credence-lint corpus self-test and `check
+apps/` pass, then `credence_router` + `credence_agents` pytest (excluding
+test_live.py).
+**smoke-build** builds amd64 and curls `/ready` against a running container
+before anything ships.
+**publish** (master + version-tag) builds multi-arch and pushes to GHCR.
+**Julia tests are NOT CI-gated** — run `test/*.jl` locally before pushing
+DSL-core changes.
 
-The lint tool lives at `tools/credence-lint/credence_lint.py` and is what
-mechanically enforces the precedent slugs
-(`# credence-lint: allow — precedent:<slug> — <reason>`).
-It runs two passes per file. Pass one is a same-line regex over the DSL
-return-value names. Pass two is taint analysis: Python files via stdlib
-`ast`, Julia files via a stateful line scanner that propagates taint
-through assignments, tuple unpacking, and `for`-loop targets (with `zip`
-positional precision). Both passes share the seed rule (DSL call returns
-are tainted) and stop at opaque function boundaries. `apps/julia/pomdp_agent/`
-is excluded — that package has its own `src/` and its own invariants.
+Lint at `tools/credence-lint/credence_lint.py` enforces the precedent
+slugs. Two passes per file: pass one is a same-line regex over DSL
+return-value names; pass two is taint analysis (Python via stdlib `ast`,
+Julia via a stateful line scanner that propagates taint through
+assignments, tuple unpacking, and `for`-loop targets with `zip` positional
+precision). Both passes share the seed rule (DSL call returns are tainted)
+and stop at opaque function boundaries. `apps/julia/pomdp_agent/` is
+excluded (own `src/`, own invariants).
 
 ## Repo conventions for Claude Code sessions
 
@@ -474,90 +359,56 @@ Inline `# credence-lint: allow — precedent:<slug> — <reason>` pragmas sancti
 
 ## Project structure
 
+The full file tree is discoverable by `ls` / `find`. The annotations below
+are the architecturally load-bearing facts that aren't obvious from
+filenames.
+
     src/                          Tier 1: DSL core
-      Credence.jl                 Module entry point
-      parse.jl                    S-expression parser
       ontology.jl                 Space / Measure / Event / Kernel types +
-                                  axiom-constrained functions (condition, expect, push, density)
-      prevision.jl                Prevision primitive + TestFunction hierarchy
-                                  (de Finettian; dispatch target of Move 4–7 routing)
-      eval.jl                     Evaluator / compiler (DSL → Julia calls)
-      stdlib.bdsl                 Standard library (optimise, value, eu, voi, net-voi, etc.)
-      persistence.jl              Save/load agent state across sessions
-      host_helpers.jl             Host-level reliability/coverage helpers
-      program_space/              Program-space extensions (grouped for cohesion;
-                                  loaded directly from Credence.jl — no separate
-                                  module entry point)
-        types.jl                  AST types, Grammar, Program, CompiledKernel
-        enumeration.jl            Bottom-up enumeration, complexity scoring
-        compilation.jl            AST → closure compilation
-        perturbation.jl           Posterior subtree analysis, grammar perturbation
-        agent_state.jl            AgentState, sync_prune!, sync_truncate!
-    examples/                     Runnable DSL programs
-      coin.bdsl                   Biased coin learning
-      credence_agent.bdsl         Agent DSL (pure functions, host-driven)
-      grid_agent.bdsl             Grid agent DSL
-      router.bdsl                 Bayesian LLM/search routing (drives credence-proxy)
-      host_credence_agent.jl      Julia host driver for credence agent
-      openclaw/                   OpenClaw evaluation integration (docker-compose)
-    test/
-      test_core.jl                Core DSL tests
-      test_flat_mixture.jl        Flat mixture conditioning tests
-      test_host.jl                Host helper tests
-      test_program_space.jl       Program-space tests (enumeration, compilation, perturbation)
-      test_grid_world.jl          Grid-world tests (full agent, regime change, meta-learning)
-      test_email_agent.jl         Email agent domain tests
-      test_rss.jl                 RSS domain tests
-      test_events.jl              Event hierarchy + indicator_kernel equivalence
-      test_persistence.jl         Serialisation + schema-version fixtures
-      test_prevision_unit.jl      Prevision primitive unit tests
-      test_prevision_conjugate.jl Conjugate dispatch (maybe_conjugate registry)
-      test_prevision_mixture.jl   MixturePrevision routing
-      test_prevision_particle.jl  Particle / grid backends
-      fixtures/                   Commit-pinned reference fixtures (see README.md
-                                  for SHA provenance protocol)
-    apps/                         Everything built on top of the DSL — three sub-layers:
-      julia/                      Brain-side applications (in-process DSL callers)
-        DOMAIN_INTERFACE.md       Contract for apps/julia domains
-        grid_world/               Grid-world domain (simulation, host, terminals, metrics)
-        email_agent/              Email domain (JMAP integration, LLM prosthetic)
-        qa_benchmark/             QA benchmark domain (LLM comparison harness)
-        rss/                      RSS article ranking domain (Postgres-backed)
-        pomdp_agent/              POMDP agent package (MCTS, factored models)
-          Project.toml            Separate Julia package depending on Credence
-          src/, examples/, test/, CLAUDE.md
-      skin/                       JSON-RPC translation layer (opaque Measure handles)
-        protocol.md               JSON-RPC protocol spec
-        server.jl                 Julia server (holds Measures, evaluates DSL)
-        client.py                 Python client (spawns subprocess, sends RPC)
-        test_skin.py              Smoke tests
-      python/                     Body — user-facing surfaces, prosthetics, connections (uv workspace; Python >=3.11)
-        credence_bindings/        Low-level Python bindings
-        credence_agents/          Agent library + Julia bridge + benchmark
-        credence_router/          credence-proxy (LLM/search routing gateway)
-        bayesian_if/              Interactive fiction agent
-    docs/                         Additional documentation
-      rss-preference-learning.md  RSS preference learning design
-      posture-3/                  De-Finettian migration: master-plan.md,
-                                  DESIGN-DOC-TEMPLATE.md, move-0…move-8 design docs,
-                                  paper-draft.md
-    papers/                       Publication drafts (paper1–4/, ablation/, drift/,
-                                  stationary/) + PAPERS-STRATEGY.md + RESULTS.md
-    tools/                        Repo-internal tooling
-      credence-lint/              Precedent-slug lint (enforces Invariants 1 & 2;
-                                  corpus self-test + `check apps/` pass in CI)
-    data/                         Eval output artefacts (gitignored)
-    Dockerfile                    credence-proxy container (published by CI)
-    docker-compose.yml            Local credence-proxy stack
-    SPEC.md                       Authoritative architecture spec
-    pyproject.toml                uv workspace root (4 members under apps/python/)
-    .github/workflows/            CI: publish-image.yml (unit-tests + smoke-build + publish)
+                                  axiom-constrained functions (condition,
+                                  expect, push, density)
+      prevision.jl                Prevision primitive + TestFunction
+                                  hierarchy. Dispatch target of Move 4–7
+                                  routing — extensions go here, not at
+                                  Measure level.
+      stdlib.bdsl                 optimise, value, eu, voi, net-voi, etc.
+      program_space/              Folder grouping (loaded directly from
+                                  Credence.jl). NOT a separate module
+                                  entry point.
+    examples/                     Runnable DSL programs.
+      router.bdsl                 Drives credence-proxy.
+    test/                         `julia test/test_*.jl` to run any one.
+      fixtures/                   Commit-pinned; see README.md for SHA
+                                  provenance protocol. Never regenerate
+                                  to fix a loading bug — fix the load code.
+    apps/                         Tier 2 — see Architecture section for
+                                  the brain/skin/body sub-layer split.
+      julia/                      Brain-side; per-domain CLAUDE.md inside.
+        DOMAIN_INTERFACE.md       Contract for apps/julia domains.
+        pomdp_agent/              Separate Julia package (own Project.toml,
+                                  own src/test/CLAUDE.md) — depends on
+                                  Credence.
+      skin/                       JSON-RPC; protocol.md is the spec.
+      python/                     Body; uv workspace, Python >=3.11. Per-
+                                  package CLAUDE.md for the three with one.
+    docs/
+      precedents.md               Full prose for every precedent slug
+                                  named in the slug index above.
+      posture-3/, posture-4/      Per-branch master-plan.md +
+                                  DESIGN-DOC-TEMPLATE.md + per-move docs.
+    papers/                       Publication drafts + PAPERS-STRATEGY.md.
+    tools/credence-lint/          Precedent-slug lint; corpus self-test
+                                  + `check apps/` pass run in CI.
+    data/                         Eval output artefacts (gitignored).
+    SPEC.md                       Authoritative architecture spec.
+    pyproject.toml                uv workspace root (4 members under
+                                  apps/python/).
 
 DSL source files use the `.bdsl` extension.
 
 Weights are stored in log-space internally (`logw` field). Use
-`weights(m)` to get normalized probabilities. This is a cross-file
-invariant — never exponentiate manually.
+`weights(m)` to get normalised probabilities. Cross-file invariant —
+never exponentiate manually.
 
 Constructors: `CategoricalMeasure(Finite(vals))` for uniform prior,
 `CategoricalMeasure{T}(Finite{T}(vals), logw)` for explicit log-weights

--- a/docs/precedents.md
+++ b/docs/precedents.md
@@ -1,0 +1,119 @@
+# Precedents
+
+Constitutional case law for Credence. Each entry names which invariant it follows from and why. Weight is on grey-zone cases — the bright-line violations are caught by the constitution and (eventually) by CI; what merits human-readable reasoning are the judgement calls where mechanical enforcement can't distinguish causal from non-causal.
+
+Every precedent carries a stable **slug** — a short identifier used by the lint escape-hatch pragma. When a grey-zone case sanctions code that would otherwise violate the invariants, the author marks the line with:
+
+```
+# credence-lint: allow — precedent:<slug> — <one-line reason>
+```
+
+Both the slug and the reason are mandatory. The pragma is recognised on the same line as the violation or on the immediately preceding comment-only line — whichever reads better at the call site. Unknown slugs and missing reasons fail the lint. Novel cases unblock via a new precedent entry in this document (with its own slug) in the same PR — new escape hatches are constitutional amendments, not inline concessions. `grep -r 'credence-lint:' .` is a usable audit surface.
+
+The compact slug index lives in `CLAUDE.md` — that's what the lint reads to discover valid slugs. Full prose for each precedent (Legal/Illegal cases, failure modes, escape-hatch templates) is below.
+
+## Grey zones
+
+### Reading vs. computing on weights
+**Slug:** `compute-on-weights`.
+**Legal:** `weights(m)` for logging, telemetry, display. `mean(m)` passed to a non-causal dashboard.
+**Illegal:** any arithmetic on the result that feeds back into a decision or belief — summation, multiplication, comparison-in-branch, threshold checks that gate behaviour.
+**Follows from Invariant 1** because the public accessor is sanctioned access; what makes it a violation is the subsequent causal arithmetic. `weights()` itself does no reasoning; what you do with the return value can. There is no escape hatch — arithmetic that needs the posterior must flow through `expect` with a declared Functional. The slug exists for cross-referencing.
+
+### Sort-for-display vs. compare-to-branch
+**Slug:** `sort-for-display`.
+**Legal:** `sort(pairs, by=last)` for a top-K log line. The ordering is non-causal — the display is read by a human, not by the agent.
+**Illegal:** `if w1 > w2 then action_a else action_b` — that comparison *is* the decision, and it lives outside `optimise`.
+**Follows from Invariant 1 (topological face)** because action selection must flow through EU-max. A weight comparison in application code is a parallel decision mechanism. Escape hatch with this slug permits comparison/sort when the author can assert the result is consumed only by display/logging, not by subsequent logic.
+
+### Display arithmetic
+**Slug:** `display-arithmetic`.
+**Legal with escape hatch:** `f"{round(w * 100, 1)}%"` for a progress bar or report.
+**Required pragma:** `# credence-lint: allow — precedent:display-arithmetic — <reason>` on the line, reviewed per commit.
+**Follows from Invariant 1** because the rule binds causal arithmetic; display arithmetic is non-causal by construction. CI cannot distinguish display from causation mechanically, so the author carries the burden of marking it.
+
+### Stdlib compositions calling each other
+**Slug:** `stdlib-composition`.
+**Legal:** `voi` calls `expect`; `optimise` calls `expect` + `argmax`; `model`/`problem` constructors compose kernels and priors; `perturb_grammar` takes posterior analysis as input.
+**Follows from Invariant 1 (topological face)** because the canalised path is the axiom-constrained functions **and their stdlib compositions**. Stdlib members calling each other stays on the sanctioned path. New stdlib operations are added by composing existing ones plus ordinary computation, not by creating a new arithmetic path. Slug is documentation-only — stdlib code lives in `src/`, which is out of scope for the lint.
+
+### Application constructing a `Problem`
+**Slug:** `declarative-construction`.
+**Legal.** `Problem(state, actions, preference)` is a struct constructor — declarative data. `initial_rel_state(...)`, `CategoricalMeasure(Finite(vals))`, `Kernel(H, O, gen, likelihood_family=…)` — all declarative.
+**Contrast with:** a DSL wrapper like `(defun solve-email (state) (optimise state email-actions email-pref))` — that is a callable re-exporting an axiom-constrained op with hidden structure (see Invariant 2 violation in the Historical rejections). Slug is documentation-only — constructors don't trigger the lint in the first place.
+
+### Iterating a posterior's support
+**Slug:** `posterior-iteration`.
+**Almost always illegal in consumer code.** If you're writing a loop over `zip(support(m), weights(m))` — or over a mixture's components to sum weighted quantities — the "something" is probability arithmetic.
+**Rewrite:** declare the computation as a `Functional` (`Projection`, `NestedProjection`, `Tabular`, composed via `LinearCombination`) and call `expect(m, f)`. If the loop is a conditional aggregation ("sum over components where predicate fires"), the right primitive is *event-conditioning*: `expect(condition(m, TagSet(fires)), inner)` or a typed `FeatureEquals` / `FeatureInterval`. See the `event-conditioning` precedent below.
+**Last-resort escape for deferred rewrites.** Inline iteration that predates the Functional / Event invariants may be kept via `# credence-lint: allow — precedent:posterior-iteration — tracked in issue #<N>`. The reason must reference a tracking issue for the rewrite; the pragma lives until the rewrite lands. Reach for this only when neither a Functional nor an Event constructor fits — now that events are first-class, most mixture-filter cases have a declarative path.
+**Follows from Invariant 1 and Invariant 2** jointly: the spatial rule rejects the loop; the declared-structure rule points to the rewrite.
+
+### Event-conditioning
+**Slug:** `event-conditioning`.
+**Preferred idiom when the conditioning object is an event.** `condition(m, e::Event)` is provably equivalent to `condition(m, indicator_kernel(e), true)` for deterministic events (Di Lavore–Román–Sobociński Prop. 4.9). The sibling form is the natural shape when the conditioning object is a declared predicate (`TagSet`, `FeatureEquals`, `FeatureInterval`, or Boolean compositions thereof); the parametric form remains primary for genuine observation-with-likelihood conditioning.
+**Mechanical bridge.** Every `Event` constructor witnesses an `indicator_kernel` into a Boolean Space. That witness is how Invariant 2 is preserved at the axiom layer: events reach `condition` through declared kernels, not opaque predicate closures.
+**Follows from Invariants 1 and 2.** The topological face is preserved — `condition(m, e)` is on the canalised path, just through the event surface syntax. Declared structure is preserved because every Event carries its data in typed fields. No escape hatch; this is the legal path.
+
+### Prevision, not Measure, is primitive
+**Slug:** `prevision-not-measure`.
+**Rule.** Prevision is the frozen primitive (Move 7 elevation); Measure is a declared view over Prevision (Move 3 wrapping; Move 7 constitutional). Beliefs are coherent linear functionals on a declared test function space — what `expect` realises — not probability mass distributions over a measurable space. The Measure surface is preserved for consumer-facing API; internally, belief-changing operations work with Prevision.
+**When it applies.** Code that extends axiom-constrained functions with new beliefs (new conjugate pairs, new mixture routing, new fallback strategies) should declare its work at the Prevision level. `maybe_conjugate` dispatches on (Prior, Likelihood) type pairs where Prior is a Prevision subtype; `_dispatch_path`, `condition`, `update` are all Prevision-level. The Measure-level methods stay as thin facades delegating to the Prevision primary.
+**Failure mode.** Code that patches Measure-specific behaviour (e.g. `condition(m::SomeMeasure, …)` with arithmetic inline) without extending the corresponding Prevision surface creates a dispatch surface that bypasses Move 4's registry and Move 5's routing. Post-Move-7 the Measure surface is a view; arithmetic lives on the prevision side. Inline arithmetic at the Measure level silently forks behaviour.
+**Follows from Invariant 2** (declared structure: Prevision is the dispatch target for axiom-constrained functions) and Move 7's frozen-types edit.
+
+### Event-form `condition` is a primary, not sugar
+**Slug:** `event-primary-condition`.
+**Rule.** `condition(p::Prevision, e::Event)` is a primary primitive at the Prevision level (Move 7 §5.1 Option B). It is NOT sugar for `condition(p, k::Kernel, obs)` via a synthesised `ObservationEvent(k, obs)`. The two forms are peer primary primitives; neither derives from the other.
+**When it applies.** When the conditioning object is a declared structural predicate over a Space — `TagSet`, `FeatureEquals`, `FeatureInterval`, or Boolean compositions (`Conjunction`, `Disjunction`, `Complement`). Each Event witnesses an `indicator_kernel` into BOOLEAN_SPACE; deterministic-event equivalence to the parametric form is DLRS Prop. 4.9 (arXiv:2502.03477).
+**Failure mode.** Attempting to derive the event-form from the parametric-form via `ObservationEvent(k, obs)` at the axiom layer. This requires `p(1_e) > 0` for the event `{k emits exactly obs}`; continuous observation spaces violate this (Lebesgue measure zero), requiring disintegration which is out of scope per the master plan. Sugar over an undefined reduction is the exact failure mode Option B was committed to avoid.
+**Follows from Invariants 1 and 2.** Topologically, `condition(p, e::Event)` is on the canalised path as a primary form. Declared structure: the Event hierarchy carries typed data in fields; `ObservationEvent` would carry a kernel and observation — a likelihood-structured object, categorically different. No escape hatch; this is the legal path.
+
+### Parametric-form `condition` is a sibling primary, not derived
+**Slug:** `parametric-form-sibling`.
+**Rule.** `condition(p::Prevision, k::Kernel, obs)` is a peer primary at the Prevision level alongside the event-form (Move 7 §5.1 Option B). It is NOT derived from event-form via any `ObservationEvent` construction. Parametric Bayes update — the familiar `p(θ | o) ∝ p(o | θ) p(θ)` shape — has its own mathematically-well-defined semantics for continuous observation kernels that event-form conditioning cannot cover without disintegration.
+**When it applies.** When the conditioning object is a kernel–observation pair, especially for continuous observation spaces (GaussianMeasure + NormalNormal kernel; BetaMeasure + grid-quadrature kernel; anything Move 6 routes through `_condition_particle` or `_condition_by_grid`). Move 4's conjugate registry dispatches through this form.
+**Failure mode.** Framing parametric-form as "the real condition" with event-form as a sibling-that-expands-to-parametric, OR framing event-form as primary with parametric-form as sugar. Both framings mask the peer-primary structure. Downstream consumers reading such a framing misunderstand whether `condition(p, e::Event)` is a first-class primitive (it is, under Option B) or a derived form (it is not).
+**Follows from Invariants 1 and 2** jointly with the §1.0 continuous-kernel measure-zero constraint. The topological face treats both forms as on the canalised path; the declared-structure face keeps `Event` and `Kernel` as structurally-distinct frozen types (Move 7 promoted both). Provable equivalence on deterministic events (DLRS Prop. 4.9) is a bridge, not a reduction.
+
+### Baseline comparison
+**Slug:** `baseline-comparison`.
+**Legal with escape hatch.** Research baselines deliberately implement non-Bayesian decision mechanisms — argmax-of-means, fixed-threshold, cheapest-first — to empirically contrast against the principled EU-max agent. The paper depends on having these baselines; they are not bugs to be fixed.
+**Required pragma:** `# credence-lint: allow — precedent:baseline-comparison — <which baseline, why non-Bayesian>`. Each baseline's violation is tagged so `grep -r 'baseline-comparison'` produces an inventory of what the paper compares against.
+**Follows from Invariant 1 (topological face)** being scoped to the agent. The invariant forbids parallel decision mechanisms *that the agent uses*; a baseline is, by construction, not the agent. This precedent makes that distinction explicit.
+
+### Test code computing expected values manually
+**Slug:** `test-oracle`.
+**Legal with escape hatch.** Tests *of* the reasoner legitimately need an independent oracle: `assert expect(m, f) == pytest.approx(0.7)  # computed by hand from Beta(3,7)`.
+**Required pragma:** `# credence-lint: allow — precedent:test-oracle — <reason>` on the comparison line. The manual computation is the test's ground truth; it is causal *within the test*, but the test is non-causal with respect to the agent (it doesn't feed back into agent behaviour).
+
+## Specific derivations
+
+### Indifference implies exploration
+When `EU(interact) == EU(wait)` (both zero), interact. `select_action` threshold is `>= 0`, not `> 0`. Follows from correct EU accounting: at indifference, VOI from the interaction outcome is still positive (you'll learn something), which is part of EU. If the threshold is strict, a correct EU computation will have already broken the tie. Listed here because it's the kind of edge case that gets "fixed" back to strict inequality under perceived instability, and the fix is wrong.
+
+### Non-firing predicates predict the base rate
+Programs whose predicates don't fire return `log(0.5)`, not `0.0`. A non-firing program is implicitly predicting "I don't know, 50/50"; that prediction is scored against the observation. Ranking: *informed-and-right* > *uninformed* > *informed-and-wrong*. Returning `0.0` makes non-firing programs unbeatable (no information → no penalty), creating weight rigidity after regime changes. Listed here because the bug manifests long after the change (the posterior stops adapting) and the fix looks like a tunable constant; it is not — it is scoring-rule calibration.
+
+## Historical rejections
+
+### PROPOSED: `(sample measure)` in the DSL for Thompson sampling.
+**REJECTED.** Sampling is randomness; randomness is a side effect; the DSL is pure. Construct the posterior in the DSL; call `draw()` in the host. **Invariant 1 (spatial)** — DSL stays non-executing.
+
+### PROPOSED: `host_decide()` / `host_optimise()` in host drivers.
+**REJECTED.** `optimise` and `value` belong in the ontology alongside `expect` and `condition`. One implementation per operation. The host driver is pure orchestration — it calls ontology functions. **Invariant 1 (topological)** — one canonical path per operation.
+
+### PROPOSED: `(thompson-sample m actions pref)` in stdlib that calls sample.
+**REJECTED.** Compounds both errors above. Thompson sampling is `draw` (host) + `argmax` (ordinary computation on the drawn value). The DSL constructs the posterior; its job is done. **Invariant 1 (both faces).**
+
+### PROPOSED: Bare lambda as a kernel's likelihood.
+**REJECTED.** Kernels declare `likelihood_family` at construction; bare lambdas defeat conjugate dispatch and force probing. **Invariant 2.**
+
+### PROPOSED: Flat coefficient arrays for `LinearCombination` instead of `Vector{Tuple{Float64, Functional}}`.
+**REJECTED.** Flat indexing encodes stride conventions invisible to the type system. Each sub-functional must navigate its own structure. **Invariant 2** — composition is part of structure.
+
+### PROPOSED: Inferring kernel family by probing `log_density == 0.0` for flat likelihoods.
+**REJECTED.** Legitimate kernels can return zero log-density at specific points without being flat; the probe misfires and hides the assumption from the type system. **Invariant 2** — declared at construction, not dispatch.
+
+### PROPOSED: DSL wrapper functions in domain files (e.g., `(defun choose-email (s) (optimise s email-actions email-pref))`).
+**REJECTED.** Wrappers force the preference through an opaque closure that defeats Functional dispatch AND hide the causal arithmetic path from CI. A domain file contains data; axiom-constrained ops are called at the protocol level, not wrapped. **Invariants 1 and 2** jointly.


### PR DESCRIPTION
## Summary
- CLAUDE.md: 51,861 → 34,808 chars (−33%), comfortably under the harness's 40k performance threshold
- Full precedent prose (Legal/Illegal/Failure-mode sections, historical rejections, specific derivations) extracted to `docs/precedents.md`; a compact slug index stays in CLAUDE.md so the lint's `^\*\*Slug:\*\*` regex still finds all 12 slugs — no `credence_lint.py` change needed
- Also compressed Development commands (12-entry test file list → one canonical pattern) and Project structure (load-bearing annotations only, not a full file tree); removed the brain/skin/body restatement that duplicated the Architecture section

All constitutional content — axioms, frozen layer, axiom-constrained functions, three invariants, may/may-not-change, repo conventions, Architecture diagram, performance guardrail — stays in place verbatim.

## Test plan
- [x] `wc -c CLAUDE.md` returns 34,808 (< 40,000)
- [x] All 12 slugs present in CLAUDE.md's compact index (`grep -cE '^\*\*Slug:\*\*' CLAUDE.md` = 12)
- [x] All 12 slugs present in `docs/precedents.md` with full prose
- [x] `python tools/credence-lint/credence_lint.py test` — corpus self-test green
- [x] `python tools/credence-lint/credence_lint.py check apps/` — 144 files, 0 violations
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)