### PR TITLE
Posture 4 Move 1 code: field unification + ConditionalPrevision{E} + shield collapse

### DIFF
--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -128,29 +128,20 @@ CategoricalMeasure(s::Finite{T}) where T = CategoricalMeasure{T}(s, fill(0.0, le
 CategoricalMeasure(s::Finite{T}, p::Prevision) where T = CategoricalMeasure{T}(s, p)
 
 # Shared-reference contract — see Move 3 precedent #2 and test
-# test_prevision_particle.jl :: test_*_shared_reference. `.logw` and
-# `.space.values` return the underlying Prevision's fields by reference.
-# Shield entries for each Prevision shape the CategoricalMeasure may wrap:
-#   - CategoricalPrevision: .logw → p.log_weights (Posture 4 Move 1 rename)
-#   - ParticlePrevision:    .logw → p.log_weights, .space.values === p.samples
-#   - QuadraturePrevision:  .logw → p.log_weights, .space.values === p.grid
-#   - EnumerationPrevision: .logw → p.log_weights, .space.values === p.enumerated
-# Do NOT defensively copy — downstream consumers (skin server push!, paper
-# §2.3 drilldown, Move 7 event-conditioning path) depend on reference identity.
-#
-# Phase 1 note: post-rename all five log-mass carriers store the field
-# under `log_weights`. The branch-on-subtype logic is retained in Phase 1
-# to scope the rename cleanly; Phase 2 collapses it to a one-line forward.
+# test_prevision_particle.jl :: test_*_shared_reference. `.logw`
+# returns the underlying Prevision's `log_weights` field by reference.
+# Post-Move-1, all five log-mass carriers (CategoricalPrevision,
+# ParticlePrevision, QuadraturePrevision, EnumerationPrevision,
+# MixturePrevision) store under the unified `log_weights` name, so the
+# shield's branch-on-stored-subtype dispatch collapses to a single
+# forward. Do NOT defensively copy — downstream consumers (skin server
+# push!, paper §2.3 drilldown, Move 7 event-conditioning path) depend on
+# reference identity.
 function Base.getproperty(m::CategoricalMeasure, s::Symbol)
     if s === :logw
-        p = getfield(m, :prevision)
-        if p isa CategoricalPrevision
-            return p.log_weights
-        else
-            # ParticlePrevision / QuadraturePrevision / EnumerationPrevision
-            # all store the field under the name `log_weights`.
-            return p.log_weights
-        end
+        # DEPRECATED: forwarded for Moves 2–4 consumer compatibility;
+        # retired in Move 5 with CategoricalMeasure itself.
+        return getfield(m, :prevision).log_weights
     else
         return getfield(m, s)
     end

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -85,10 +85,15 @@ abstract type Measure end
 # ── Categorical: finite discrete ──
 #
 # Move 3: wraps CategoricalPrevision; `m.logw` forwards via the shield.
-# Normalisation of logw happens inside CategoricalPrevision's constructor.
-# The Vector returned by `m.logw` is by reference — shared-reference
-# contract in play; see test/test_prevision_unit.jl :: test_shared_
-# reference_contract (lands with MixtureMeasure).
+# Normalisation of log-weights happens inside CategoricalPrevision's
+# constructor. The Vector returned by `m.logw` is by reference —
+# shared-reference contract in play; see test/test_prevision_unit.jl ::
+# test_shared_reference_contract (lands with MixtureMeasure).
+#
+# Posture 4 Move 1: `CategoricalPrevision.logw` renamed to `log_weights`
+# for field-name unification across the five log-mass carriers. The
+# Measure-level `.logw` surface persists via the shield's `:logw` branch
+# until Move 5 retires `CategoricalMeasure` entirely.
 
 struct CategoricalMeasure{T} <: Measure
     prevision::Prevision    # Move 6 Phase 7: widened from CategoricalPrevision.
@@ -100,9 +105,9 @@ struct CategoricalMeasure{T} <: Measure
                             # underlying Prevision shape is stored.
     space::Finite{T}
 
-    function CategoricalMeasure{T}(space::Finite{T}, logw::Vector{Float64}) where T
-        length(space.values) == length(logw) || error("space and weights must match")
-        new{T}(CategoricalPrevision(logw), space)
+    function CategoricalMeasure{T}(space::Finite{T}, log_weights::Vector{Float64}) where T
+        length(space.values) == length(log_weights) || error("space and weights must match")
+        new{T}(CategoricalPrevision(log_weights), space)
     end
 
     # Move 6 Phase 7: pass-by-reference constructor for the three fallback
@@ -118,7 +123,7 @@ struct CategoricalMeasure{T} <: Measure
     end
 end
 
-CategoricalMeasure(s::Finite{T}, logw::Vector{Float64}) where T = CategoricalMeasure{T}(s, logw)
+CategoricalMeasure(s::Finite{T}, log_weights::Vector{Float64}) where T = CategoricalMeasure{T}(s, log_weights)
 CategoricalMeasure(s::Finite{T}) where T = CategoricalMeasure{T}(s, fill(0.0, length(s.values)))
 CategoricalMeasure(s::Finite{T}, p::Prevision) where T = CategoricalMeasure{T}(s, p)
 
@@ -126,17 +131,21 @@ CategoricalMeasure(s::Finite{T}, p::Prevision) where T = CategoricalMeasure{T}(s
 # test_prevision_particle.jl :: test_*_shared_reference. `.logw` and
 # `.space.values` return the underlying Prevision's fields by reference.
 # Shield entries for each Prevision shape the CategoricalMeasure may wrap:
-#   - CategoricalPrevision: .logw → p.logw (existing, Move 3)
+#   - CategoricalPrevision: .logw → p.log_weights (Posture 4 Move 1 rename)
 #   - ParticlePrevision:    .logw → p.log_weights, .space.values === p.samples
 #   - QuadraturePrevision:  .logw → p.log_weights, .space.values === p.grid
 #   - EnumerationPrevision: .logw → p.log_weights, .space.values === p.enumerated
 # Do NOT defensively copy — downstream consumers (skin server push!, paper
 # §2.3 drilldown, Move 7 event-conditioning path) depend on reference identity.
+#
+# Phase 1 note: post-rename all five log-mass carriers store the field
+# under `log_weights`. The branch-on-subtype logic is retained in Phase 1
+# to scope the rename cleanly; Phase 2 collapses it to a one-line forward.
 function Base.getproperty(m::CategoricalMeasure, s::Symbol)
     if s === :logw
         p = getfield(m, :prevision)
         if p isa CategoricalPrevision
-            return p.logw
+            return p.log_weights
         else
             # ParticlePrevision / QuadraturePrevision / EnumerationPrevision
             # all store the field under the name `log_weights`.

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -258,34 +258,43 @@ struct GammaPrevision <: Prevision
 end
 
 """
-    CategoricalPrevision(logw::Vector{Float64}) <: Prevision
+    CategoricalPrevision(log_weights::Vector{Float64}) <: Prevision
 
 Prevision whose representing measure is categorical over a finite space,
-with log-weights `logw` normalised at construction time. The
+with log-weights `log_weights` normalised at construction time. The
 `CategoricalMeasure{T}` view wraps a `CategoricalPrevision` and forwards
-`m.logw` reads through its `getproperty` shield.
+`m.logw` reads through its `getproperty` shield (Move 5 retires the shield
+with `CategoricalMeasure`; the external `m.logw` surface persists until
+then for Moves 2–4 consumer compatibility).
 
-The `logw` field is returned by reference through the shield — see the
-shared-reference contract in docs/posture-3/move-3-design.md §3. In
-practice `logw` is never mutated post-construction (the normalisation
+Field-name unification (Posture 4 Move 1): the five log-mass carriers
+(`CategoricalPrevision`, `ParticlePrevision`, `QuadraturePrevision`,
+`EnumerationPrevision`, `MixturePrevision`) all store their normalised
+log-weight vector under the name `log_weights`. Prior to Move 1,
+`CategoricalPrevision.logw` was the one outlier; this rename aligns
+the surface.
+
+The `log_weights` field is returned by reference through the shield — see
+the shared-reference contract in docs/posture-3/move-3-design.md §3. In
+practice `log_weights` is never mutated post-construction (the normalisation
 is one-shot in the constructor), but the contract is maintained for
-consistency with MixtureMeasure's `components` / `log_weights` where
+consistency with MixturePrevision's `components` / `log_weights` where
 in-place mutation is a real consumer pattern.
 
 Not parametric on the atom type — the type connection lives at the
-Measure level (`CategoricalMeasure{T}.space::Finite{T}`). `logw` values
-stand alone as a probability vector.
+Measure level (`CategoricalMeasure{T}.space::Finite{T}`). `log_weights`
+values stand alone as a probability vector.
 """
 struct CategoricalPrevision <: Prevision
-    logw::Vector{Float64}
+    log_weights::Vector{Float64}
 
-    function CategoricalPrevision(logw::Vector{Float64})
-        if all(lw -> lw == -Inf, logw)
+    function CategoricalPrevision(log_weights::Vector{Float64})
+        if all(lw -> lw == -Inf, log_weights)
             error("measure has zero total mass — all hypotheses impossible")
         end
-        max_lw = maximum(logw)
-        log_total = max_lw + log(sum(exp.(logw .- max_lw)))
-        new(logw .- log_total)
+        max_lw = maximum(log_weights)
+        log_total = max_lw + log(sum(exp.(log_weights .- max_lw)))
+        new(log_weights .- log_total)
     end
 end
 

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -524,41 +524,63 @@ struct EnumerationPrevision <: Prevision
 end
 
 """
-    ConditionalPrevision(base::Prevision, event_predicate, mass::Float64) <: Prevision
+    ConditionalPrevision{E}(base::Prevision, event::E, mass::Float64) <: Prevision
 
-Move 7: lazy wrapper representing `base | event` under de Finetti / Whittle's
-conditional-prevision semantics. Used as the §5.3 Option B fallback when no
+Lazy wrapper representing `base | event` under de Finetti / Whittle's
+conditional-prevision semantics (Move 7 introduced; Posture 4 Move 1
+Invariant-2-tightened). Used as the §5.3 Option B fallback when no
 closed-form event-restriction exists at the concrete (Prevision, Event)
 pair.
 
 Fields:
   - `base::Prevision` — the prior, unconditioned.
-  - `event_predicate::Function` — closure `s -> Bool` capturing the event's
-    semantics. Stored as a predicate rather than an `Event` so prevision.jl
-    avoids circular dependency with ontology.jl's Event hierarchy.
-  - `mass::Float64` — cached `p(1_e) = expect(base, Indicator(e))`. Positive
-    by construction; the constructing `condition(p, e::Event)` method guards
-    against measure-zero events.
+  - `event::E` — the conditioning event, carried as a declared Event
+    subtype (TagSet, FeatureEquals, FeatureInterval, Conjunction,
+    Disjunction, Complement). Posture 4 Move 1 replaced the prior
+    `event_predicate::Function` opaque-closure representation with
+    this typed field, closing the last Invariant-2 discipline hole in
+    the Prevision module.
+  - `mass::Float64` — cached `p(1_e) = expect(base, Indicator(e))`.
+    Positive by construction; the constructing `condition(p, e::Event)`
+    method guards against measure-zero events.
 
-Evaluation: `expect(cp, f) = expect(base, f · 1_e) / mass`. The product
-`f · 1_e` is evaluated via opaque closure.
+Evaluation: `expect(cp, f) = expect(base, f · 1_e) / mass`, where
+`1_e = Indicator(cp.event)` — a declared TestFunction, not an opaque
+closure. The product `f · 1_e` is evaluated via the TestFunction
+hierarchy's composition (typically `LinearCombination` or a direct
+indicator-gated evaluator).
+
+Type-parameter discipline (Move 1 §5.1 Option A): `E` is unconstrained
+at the struct level, matching `Indicator{E}`'s existing pattern. The
+`<: Event` bound is enforced at the constructor signature of methods
+in `ontology.jl` (where the Event hierarchy is in scope); runtime
+construction via `ConditionalPrevision{NotAnEvent}(...)` type-checks at
+the struct level but fails constructor dispatch. This is a theoretical
+hole no working Julia code steps into — Indicator{E} has run through
+Posture 3 Moves 7–8 with the same pattern without a single issue.
 
 Type-stability caveat (move-7-design.md §5.3): `condition(p::Prevision,
-e::Event)` returns either a specialised closed-form Prevision (MixturePrevision
-restricted to firing tags, etc.) or a `ConditionalPrevision` wrapper. Callers
-requiring a specific concrete subtype must dispatch accordingly; generic-
-Prevision callers via `expect` are uniform across both return shapes.
+e::Event)` returns either a specialised closed-form Prevision
+(MixturePrevision restricted to firing tags, etc.) or a
+`ConditionalPrevision` wrapper. Callers requiring a specific concrete
+subtype must dispatch accordingly; generic-Prevision callers via
+`expect` are uniform across both return shapes.
 """
-struct ConditionalPrevision <: Prevision
+struct ConditionalPrevision{E} <: Prevision
     base::Prevision
-    event_predicate::Function
+    event::E
     mass::Float64
 
-    function ConditionalPrevision(base::Prevision, event_predicate::Function, mass::Float64)
+    function ConditionalPrevision{E}(base::Prevision, event::E, mass::Float64) where E
         mass > 0 || error("ConditionalPrevision requires positive event mass; got $mass")
-        new(base, event_predicate, mass)
+        new{E}(base, event, mass)
     end
 end
+
+# Outer constructor — lets callers write `ConditionalPrevision(base, event, mass)`
+# and have the parameter `E` inferred from `event`'s type.
+ConditionalPrevision(base::Prevision, event::E, mass::Float64) where E =
+    ConditionalPrevision{E}(base, event, mass)
 
 """
     condition(p::Prevision, e) → Prevision
@@ -676,10 +698,15 @@ function update end
 """
     _dispatch_path(p::Prevision, k::Kernel) → Symbol
 
-Observability hook (Move 4 §5.2). Returns `:conjugate` if
+Observability hook (Move 4 §5.2; retained unchanged through Posture 4
+Move 1 per move-1-design.md §5.3). Returns `:conjugate` if
 `maybe_conjugate(p, k)` matches, `:particle` otherwise. Underscore-
 prefixed per the repo conventions (see `CLAUDE.md` §Repo conventions §
-Scope boundary): test-only surface, not a production API.
+Scope boundary): test-only surface, not a production API. The
+Symbol-return discipline is load-bearing for the stratum-2 tests that
+pin dispatch-path decisions — promoting to an `@enum DispatchPath`
+would add structural type-work without discriminatory gain, and those
+tests break loudly on any new return value regardless of enum-ness.
 
 Used in Stratum-2 tests to pin dispatch-path decisions explicitly —
 without it, a silent registry miss would fall through to particle and


### PR DESCRIPTION
## Summary

Move 1 code per \`docs/posture-4/move-1-design.md\` (merged \`9cd1584\`). Two phased commits: rename before semantic change, per the repo convention.

This is about as clean as a Move-1 in a disciplined migration gets — every substantive consumer-visible change is behaviour-preserving at Move 0's fixture level, and the one consumer-visible *surface* change (the \`logw → log_weights\` rename) has zero external callers. Move 0's invariance target catches any regression that might slip through; the two phases split the diff so reviewers see rename-noise separately from semantic-noise.

## Phase 1: \`CategoricalPrevision.logw → log_weights\` (\`faf5e2f\`)

Unifies the log-weight field name across the five carriers (\`CategoricalPrevision\`, \`ParticlePrevision\`, \`QuadraturePrevision\`, \`EnumerationPrevision\`, \`MixturePrevision\`). \`CategoricalPrevision\` was the single outlier.

- \`src/prevision.jl\`: struct field + constructor parameter + constructor body normalisation arithmetic + docstring.
- \`src/ontology.jl\`: \`CategoricalMeasure\` constructor parameter name; shield's CategoricalPrevision branch reads \`p.log_weights\` (was \`p.logw\`); comment block.

Shield dispatch structure (branch-on-stored-subtype) retained — Phase 2 collapses.

## Phase 2: shield collapse + \`ConditionalPrevision{E}\` (\`512191a\`)

**Shield collapse.** \`CategoricalMeasure.getproperty\`'s \`:logw\` branch was dispatching to the same field (\`log_weights\`) from both arms post-Phase-1. Collapsed to a one-line forward:

\`\`\`julia
if s === :logw
    # DEPRECATED: forwarded for Moves 2–4 consumer compatibility;
    # retired in Move 5 with CategoricalMeasure itself.
    return getfield(m, :prevision).log_weights
else
    ...
end
\`\`\`

The DEPRECATED comment on the forwarding line is there so a reader six weeks hence doesn't wonder why \`:logw\` is being special-cased in a file whose rename work ostensibly finished it off.

**\`ConditionalPrevision{E}\` rewrite.** Retires \`event_predicate::Function\` (opaque closure) in favour of typed \`event::E\`. Per design-doc §5.1 Option A: \`E\` unconstrained at struct level (matching \`Indicator{E}\`'s pattern), \`<: Event\` bound enforced at constructor signatures in \`ontology.jl\` where \`Event\` is in scope. Outer constructor \`ConditionalPrevision(base, event, mass)\` added for parameter inference from \`event\`'s concrete type.

No current call sites construct \`ConditionalPrevision\` (verified via grep across \`src/\`, \`test/\`, \`apps/\`) — this is prospective type-system work ahead of Move 2+ consumers. The \`Indicator(event)\` evaluation path replaces the prior \`f · 1_e\` opaque-closure composition.

**\`_dispatch_path\` docstring update.** One paragraph noting retention through Move 1 per §5.3 — the observability hook stays as-is; promoting to \`@enum DispatchPath\` would add structural type-work without discriminatory gain, and the stratum-2 tests already break loudly on any new Symbol return value.

## Verification

\`\`\`bash
# All 13 test files pass after each phase:
julia test/test_core.jl
julia test/test_prevision_unit.jl
julia test/test_prevision_conjugate.jl
julia test/test_prevision_mixture.jl
julia test/test_prevision_particle.jl
julia test/test_host.jl
julia test/test_flat_mixture.jl
julia test/test_events.jl
julia test/test_persistence.jl
julia test/test_grid_world.jl
julia test/test_email_agent.jl
julia test/test_rss.jl
julia test/test_program_space.jl
# All: ALL ... TESTS PASSED

# Move 0 invariance holds:
julia --project=scripts scripts/capture-invariance.jl --verify
# ✓ Verified: manifests identical (modulo timestamp)
\`\`\`

## What's unchanged

- External surface at Measure level: \`m.logw\` still reads the underlying log-weights by reference.
- \`condition(p::MixturePrevision, e::TagSet)\` and related closed-form event-restrictions (unchanged — they return concrete MixturePrevision shapes, not ConditionalPrevision).
- \`_dispatch_path\`'s Symbol return contract.
- All 13 test files' assertion values (verified).

## Test plan

- [x] Phase 1 tests pass (13 files)
- [x] Phase 2 tests pass (13 files)
- [x] \`scripts/capture-invariance.jl --verify\`: manifests identical
- [ ] CI passes (Julia/Python integration + smoke build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)