### PR TITLE
Posture 4 Move 2 code: TaggedBetaPrevision.beta tightening + Phase 1-3 surface APIs

### DIFF
--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -47,6 +47,7 @@ export Prevision, TestFunction, Indicator, apply
 export MixturePrevision, ExchangeablePrevision, decompose
 export ParticlePrevision, QuadraturePrevision, EnumerationPrevision
 export ConditionalPrevision
+export push_component!, replace_component!
 export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal
 export draw

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -47,7 +47,7 @@ export Prevision, TestFunction, Indicator, apply
 export MixturePrevision, ExchangeablePrevision, decompose
 export ParticlePrevision, QuadraturePrevision, EnumerationPrevision
 export ConditionalPrevision
-export push_component!, replace_component!
+export push_component!, replace_component!, FrozenVectorView
 export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal
 export draw

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -44,6 +44,80 @@ export factor, replace_factor
 export condition, expect, push_measure, density, log_predictive, log_marginal
 export draw
 export weights, mean, variance, log_density_at, prune, truncate, logsumexp
+export FrozenVectorView
+
+# ================================================================
+# Move 2 Phase 2: FrozenVectorView{T}
+# ================================================================
+#
+# Thin read-only wrapper around a Vector, produced by Measure-level
+# getproperty shields (from Phase 4 onward) when the shield reconstructs
+# a Measure-shaped view from the underlying Prevision-typed internal.
+#
+# Purpose: convert a silent-push!-through-shield hazard into a loud
+# runtime error. Per docs/posture-4/move-2-design.md §5.1, Move 2's
+# internal fields become Vector{Prevision}; the Measure-level shields
+# reconstruct Vector{Measure} by wrapping each element with
+# wrap_in_measure(p). Callers that then try `push!(m.components, ...)`
+# (pre-Move-7 apps/skin/server.jl:611-614 pattern) would silently push
+# into the reconstructed (ephemeral) Vector, never affecting the stored
+# Prevision's data. FrozenVectorView makes this fail loudly instead.
+#
+# Read methods delegate to the inner Vector; mutation methods throw
+# with a message pointing at push_component! / replace_component! as
+# the Prevision-level migration target.
+#
+# Phase 2 lands the type and its methods. Phase 4 wires it into the
+# MixtureMeasure / ProductMeasure / TaggedBetaMeasure shields.
+
+"""
+    FrozenVectorView{T}(inner::Vector{T})
+
+Read-only wrapper around `inner`. Delegates the read surface
+(`getindex`, `length`, `iterate`, `eachindex`, `firstindex`,
+`lastindex`, `size`, `axes`, `collect`, `isempty`) to `inner`. All
+mutation operations (`push!`, `setindex!`, `append!`, `pop!`,
+`resize!`, `empty!`, `deleteat!`, `insert!`) throw a Move-2-attributed
+error pointing at the Prevision-level mutation APIs.
+
+Used by the Measure-level `getproperty` shields on `MixtureMeasure`,
+`ProductMeasure`, `TaggedBetaMeasure` from Move 2 Phase 4 onward, to
+make shield-returned vectors self-describing as "read-only, fresh per
+access; use push_component! / replace_component! for mutation."
+"""
+struct FrozenVectorView{T}
+    inner::Vector{T}
+end
+
+# ── Read methods (delegate to inner) ──
+Base.getindex(v::FrozenVectorView, i::Int) = v.inner[i]
+Base.getindex(v::FrozenVectorView, idx) = v.inner[idx]
+Base.length(v::FrozenVectorView) = length(v.inner)
+Base.size(v::FrozenVectorView) = size(v.inner)
+Base.axes(v::FrozenVectorView) = axes(v.inner)
+Base.iterate(v::FrozenVectorView) = iterate(v.inner)
+Base.iterate(v::FrozenVectorView, state) = iterate(v.inner, state)
+Base.eachindex(v::FrozenVectorView) = eachindex(v.inner)
+Base.firstindex(v::FrozenVectorView) = firstindex(v.inner)
+Base.lastindex(v::FrozenVectorView) = lastindex(v.inner)
+Base.eltype(::Type{FrozenVectorView{T}}) where T = T
+Base.isempty(v::FrozenVectorView) = isempty(v.inner)
+Base.collect(v::FrozenVectorView) = copy(v.inner)  # explicit copy per read
+Base.show(io::IO, v::FrozenVectorView) = print(io, "FrozenVectorView(", v.inner, ")")
+
+# ── Mutation methods (throw with migration pointer) ──
+const _FROZEN_ERR = "FrozenVectorView is read-only (shield-reconstructed fresh per access). " *
+    "Use push_component!(::MixturePrevision, ...) or replace_component!(::MixturePrevision, ...) " *
+    "at the Prevision level. See docs/posture-4/move-2-design.md §5.1."
+
+Base.push!(v::FrozenVectorView, ::Any...) = error(_FROZEN_ERR)
+Base.setindex!(v::FrozenVectorView, ::Any, ::Any...) = error(_FROZEN_ERR)
+Base.append!(v::FrozenVectorView, ::Any...) = error(_FROZEN_ERR)
+Base.pop!(v::FrozenVectorView, ::Any...) = error(_FROZEN_ERR)
+Base.resize!(v::FrozenVectorView, ::Any...) = error(_FROZEN_ERR)
+Base.empty!(v::FrozenVectorView) = error(_FROZEN_ERR)
+Base.deleteat!(v::FrozenVectorView, ::Any...) = error(_FROZEN_ERR)
+Base.insert!(v::FrozenVectorView, ::Any...) = error(_FROZEN_ERR)
 
 # ================================================================
 # TYPE 1: Space

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -281,14 +281,26 @@ struct TaggedBetaMeasure <: Measure
     prevision::TaggedBetaPrevision
     space::Interval
 
+    # Posture 4 Move 2: TaggedBetaPrevision.beta is BetaPrevision (tightened
+    # from ::Any). Constructors accept either a BetaMeasure (extract its
+    # .prevision) or a BetaPrevision directly.
     function TaggedBetaMeasure(space::Interval, tag::Int, beta::BetaMeasure)
+        new(TaggedBetaPrevision(tag, getfield(beta, :prevision)), space)
+    end
+    function TaggedBetaMeasure(space::Interval, tag::Int, beta::BetaPrevision)
         new(TaggedBetaPrevision(tag, beta), space)
     end
 end
 
 function Base.getproperty(m::TaggedBetaMeasure, s::Symbol)
-    if s === :tag || s === :beta
-        return getproperty(getfield(m, :prevision), s)
+    if s === :tag
+        return getfield(m, :prevision).tag
+    elseif s === :beta
+        # Post-Move-2: internal .beta is BetaPrevision; reconstruct a BetaMeasure
+        # wrapper per access for consumers that expect Measure-shape (including
+        # `.space` and `.prevision` accessors). No FrozenVectorView here — single
+        # element, not a vector; the consumer doesn't push! into it.
+        return wrap_in_measure(getfield(m, :prevision).beta)
     else
         return getfield(m, s)
     end
@@ -300,6 +312,13 @@ mean(m::BetaMeasure) = m.alpha / (m.alpha + m.beta)
 variance(m::BetaMeasure) = m.alpha * m.beta / ((m.alpha + m.beta)^2 * (m.alpha + m.beta + 1))
 mean(m::TaggedBetaMeasure) = mean(m.beta)
 variance(m::TaggedBetaMeasure) = variance(m.beta)
+
+# Posture 4 Move 2: back-compat outer constructor for TaggedBetaPrevision.
+# The struct field .beta is now BetaPrevision; existing call sites that pass
+# a BetaMeasure get transparently unwrapped. Defined here in ontology.jl (after
+# BetaMeasure is defined) rather than in prevision.jl (which loads first).
+(::Type{TaggedBetaPrevision})(tag::Int, beta::BetaMeasure) =
+    TaggedBetaPrevision(tag, getfield(beta, :prevision))
 
 # ── Gaussian: continuous on interval ──
 #
@@ -1379,8 +1398,11 @@ for other Measures it's the component's own `.prevision`.
 Used by `_dispatch_path(p::MixturePrevision, k)` to query each
 component's dispatch path after resolving its LikelihoodFamily.
 """
-_conjugacy_prevision(m::TaggedBetaMeasure) = m.beta.prevision
+_conjugacy_prevision(m::TaggedBetaMeasure) = getfield(m, :prevision).beta
 _conjugacy_prevision(m::Measure) = m.prevision
+# Posture 4 Move 2: TaggedBetaPrevision.beta is BetaPrevision directly, so
+# this returns the inner BetaPrevision without shield round-trips.
+_conjugacy_prevision(p::TaggedBetaPrevision) = p.beta
 
 function condition(m::GaussianMeasure, k::Kernel, observation)
     # Move 4: try the ConjugatePrevision registry first. Covers both

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -508,6 +508,91 @@ function logsumexp(xs::AbstractVector{<:Real})::Float64
 end
 
 # ================================================================
+# Move 2 Phase 3: wrap_in_measure(p::Prevision) → Measure
+# ================================================================
+#
+# Reconstruction helper for the Measure-level shields. Given a concrete
+# Prevision subtype, produce its canonical Measure wrapper. Used by
+# Phase 4's shield-reconstruction path — when a MixtureMeasure whose
+# internal MixturePrevision holds Vector{Prevision} exposes its
+# `components` property, the shield maps `wrap_in_measure` over the
+# stored Previsions to produce the fresh Vector{Measure} the shield
+# returns (wrapped in FrozenVectorView).
+#
+# Covered subtypes: Beta, TaggedBeta, Gaussian, Gamma, Product, Mixture.
+# These are the Prevision subtypes that appear as components of
+# MixturePrevision or factors of ProductPrevision in the current
+# codebase (verified via grep over src/, test/, apps/). The remaining
+# subtypes (Categorical, Dirichlet, NormalGamma) do not appear nested
+# inside other Previsions in current usage — their wrap_in_measure
+# methods error loudly with a context-missing message, directing the
+# caller to construct the Measure wrapper explicitly with the required
+# space information.
+
+"""
+    wrap_in_measure(p::Prevision) → Measure
+
+Reconstruct the canonical Measure wrapper for `p`. Called by the
+Measure-level `getproperty` shields (Phase 4) during
+shield-reconstruction of `:components` / `:factors` reads. Uses
+canonical spaces where the Prevision subtype has one (BetaPrevision →
+Interval(0,1), GaussianPrevision → Euclidean(1), GammaPrevision →
+PositiveReals). For ProductPrevision / MixturePrevision, recurses
+through the nested structure, deriving the outer space from the first
+component's space.
+
+Errors for Prevision subtypes whose canonical space is context-dependent
+(Categorical, Dirichlet, NormalGamma) — these cannot be reconstructed
+without knowing the carrier's space, which the shield cannot supply
+generically. Such cases have not been observed in Move-2-relevant
+nesting patterns; if one arises, the failing stack trace points at this
+comment and the caller constructs the Measure wrapper manually.
+"""
+function wrap_in_measure end
+
+wrap_in_measure(p::BetaPrevision) = BetaMeasure(Interval(0.0, 1.0), p.alpha, p.beta)
+
+# TaggedBetaPrevision.beta post-Phase-4 holds a BetaPrevision (not a BetaMeasure).
+# We wrap that BetaPrevision into a BetaMeasure for the TaggedBetaMeasure constructor.
+# Pre-Phase-4 (this Phase 3) it still holds a BetaMeasure; the direct dispatch is
+# `TaggedBetaMeasure(space, tag, beta::BetaMeasure)`. To handle both transition states
+# symmetrically, we dispatch on the type of `p.beta`:
+function wrap_in_measure(p::TaggedBetaPrevision)
+    beta_measure = p.beta isa BetaPrevision ? wrap_in_measure(p.beta) : p.beta
+    TaggedBetaMeasure(Interval(0.0, 1.0), p.tag, beta_measure)
+end
+
+wrap_in_measure(p::GaussianPrevision) = GaussianMeasure(Euclidean(1), p.mu, p.sigma)
+wrap_in_measure(p::GammaPrevision) = GammaMeasure(PositiveReals(), p.alpha, p.beta)
+
+function wrap_in_measure(p::ProductPrevision)
+    # Recursively wrap each factor (which may be a Prevision post-Phase-4 or
+    # still a Measure pre-Phase-4; dispatch handles both)
+    factors_as_measures = Measure[f isa Prevision ? wrap_in_measure(f) : f for f in p.factors]
+    ProductMeasure(factors_as_measures)
+end
+
+function wrap_in_measure(p::MixturePrevision)
+    components_as_measures = Measure[c isa Prevision ? wrap_in_measure(c) : c for c in p.components]
+    MixtureMeasure(components_as_measures, copy(p.log_weights))
+end
+
+# Fallback for the three context-dependent types: error with migration pointer.
+wrap_in_measure(p::CategoricalPrevision) = error(
+    "wrap_in_measure(::CategoricalPrevision) requires carrier space context " *
+    "(Finite{T}); construct CategoricalMeasure(space, p) explicitly at the call site. " *
+    "See docs/posture-4/move-2-design.md §6 (wrap_in_measure coverage)."
+)
+wrap_in_measure(p::DirichletPrevision) = error(
+    "wrap_in_measure(::DirichletPrevision) requires Simplex+Finite space context; " *
+    "construct DirichletMeasure(space, categories, p.alpha) explicitly."
+)
+wrap_in_measure(p::NormalGammaPrevision) = error(
+    "wrap_in_measure(::NormalGammaPrevision) requires ProductSpace context; " *
+    "construct NormalGammaMeasure(space, p.κ, p.μ, p.α, p.β) explicitly."
+)
+
+# ================================================================
 # TYPE 3: Kernel
 # ================================================================
 

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -35,6 +35,7 @@ export ExchangeablePrevision, decompose
 export ParticlePrevision, QuadraturePrevision, EnumerationPrevision
 export ConditionalPrevision
 export ConjugatePrevision, maybe_conjugate, update, _dispatch_path
+export push_component!, replace_component!
 # At Move 2, `Ontology`'s `Functional` hierarchy is aliased onto these
 # types (`const Functional = TestFunction` plus `import ..Previsions:
 # Identity, …`), so both modules export the same bindings (they resolve
@@ -713,5 +714,64 @@ without it, a silent registry miss would fall through to particle and
 produce the correct value for the wrong reason.
 """
 _dispatch_path(p::Prevision, k) = maybe_conjugate(p, k) === nothing ? :particle : :conjugate
+
+# ── Prevision-level mutation APIs (Move 2 Phase 1) ────────────────────────
+#
+# Per docs/posture-4/move-2-design.md §2. Land ahead of Move 7's skin
+# rewrite as surface-ready migration targets. Not consumed by `src/`
+# internally today. The Move 5-7 rewrite of apps/skin/server.jl:611-614
+# migrates `push!(state.belief.components, ...)` to `push_component!`
+# and `push!(state.belief.log_weights, ...)` is subsumed by
+# push_component!'s atomic component+log_weight append.
+
+"""
+    push_component!(p::MixturePrevision, c::Prevision, log_weight::Float64)
+
+Append a component to a `MixturePrevision` atomically — appends `c` to
+`p.components` and `log_weight` to `p.log_weights`, then re-normalises
+`p.log_weights` in place via log-sum-exp. Mutates `p` (both fields);
+returns `p`.
+
+This is the canonical mutation API for Move 2+; direct `push!`-through-
+shield patterns on `m.components` fail loudly via `FrozenVectorView`
+guards at the Measure-level shield (see `src/ontology.jl`).
+
+Note: mutates `p.components` and `p.log_weights` in place. The prior's
+normalisation is recomputed from scratch after the append (not
+incrementally), so callers get a fresh normalised log-weight vector.
+"""
+function push_component!(p::MixturePrevision, c::Prevision, log_weight::Float64)
+    push!(getfield(p, :components), c)
+    push!(getfield(p, :log_weights), log_weight)
+    # Re-normalise in place
+    lws = getfield(p, :log_weights)
+    if all(lw -> lw == -Inf, lws)
+        error("mixture has zero total mass after push_component! — all components impossible")
+    end
+    max_lw = maximum(lws)
+    log_total = max_lw + log(sum(exp.(lws .- max_lw)))
+    for i in eachindex(lws)
+        lws[i] -= log_total
+    end
+    return p
+end
+
+"""
+    replace_component!(p::MixturePrevision, i::Int, c::Prevision)
+
+Replace the `i`-th component of `p` in place with `c`. Mutates `p.components[i]`;
+does not change `p.log_weights`. Returns `p`.
+
+Use this for Move 7's skin-server component-update paths where the
+existing pattern was `state.belief.components[i] = new_comp` — the
+`FrozenVectorView` guard rejects `setindex!` on the reconstructed shield
+vector, and this API is the migration target.
+"""
+function replace_component!(p::MixturePrevision, i::Int, c::Prevision)
+    components = getfield(p, :components)
+    1 <= i <= length(components) || error("replace_component!: index $i out of range [1, $(length(components))]")
+    components[i] = c
+    return p
+end
 
 end # module Previsions

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -226,7 +226,7 @@ nothing on access; a future cleanup pass can replace with BetaPrevision
 """
 struct TaggedBetaPrevision <: Prevision
     tag::Int
-    beta::Any  # BetaMeasure — forward declaration before BetaMeasure loads in ontology.jl
+    beta::BetaPrevision
 end
 
 """


### PR DESCRIPTION
## Summary

Move 2 code PR per the post-amendment narrowed scope (master plan at \`a7d0924\`). Four-commit phased landing:

| Commit | Scope |
|---|---|
| \`d224ef5\` Phase 1 | \`push_component!\` / \`replace_component!\` Prevision-level mutation APIs |
| \`0a514c4\` Phase 2 | \`FrozenVectorView{T}\` read-only wrapper type |
| \`99ac74f\` Phase 3 | \`wrap_in_measure(p::Prevision) → Measure\` helper |
| \`8cae1ec\` Phase 4 (narrowed) | \`TaggedBetaPrevision.beta::Any → ::BetaPrevision\` + outer constructor + shield reconstruction |

## Phase 4 scope (narrowed per master-plan amendment)

Per \`docs/posture-4/master-plan.md\` §Move 2 (amended in PR #49):

- \`TaggedBetaPrevision.beta::Any → ::BetaPrevision\` (single struct field; carries no per-component space).
- Outer constructor \`TaggedBetaPrevision(tag::Int, beta::BetaMeasure)\` that extracts \`.prevision\` — back-compat for existing call sites.
- \`TaggedBetaMeasure\` constructor accepts either \`BetaMeasure\` or \`BetaPrevision\`.
- \`TaggedBetaMeasure\` shield reconstructs \`BetaMeasure\` on \`m.beta\` read via \`wrap_in_measure\`. Single-element reconstruction, no \`FrozenVectorView\` (not a vector, no \`push!\`-through-shield hazard).
- \`_conjugacy_prevision(p::TaggedBetaPrevision)\` added for symmetric Prevision dispatch; the Measure-side \`_conjugacy_prevision(m::TaggedBetaMeasure)\` reads directly via \`getfield\` rather than through the reconstructing shield.

**Deferred to Move 5** (per the amendment): \`MixturePrevision.components::Vector{Prevision}\` and \`ProductPrevision.factors::Vector{Prevision}\`. The tightening is architecturally coupled to Move 5's rewrite of \`condition\` (producing concentrated Previsions rather than reduced-space Measures).

## Phases 1–3: unused surface for Move 5/7 consumers

These commits land APIs that aren't consumed in Move 2:

- **\`push_component!\`** and **\`replace_component!\`** become the Prevision-level mutation APIs. Move 7's skin rewrite migrates \`apps/skin/server.jl:611-614\`'s \`push!\`-through-shield pattern to these.
- **\`FrozenVectorView{T}\`** converts silent push!-through-shield breakage into loud runtime errors. Activated in Move 5 when \`MixturePrevision.components\` tightens.
- **\`wrap_in_measure(p::Prevision)\`** reconstructs Measure wrappers from Previsions. Used by the TaggedBetaMeasure shield in Phase 4; will be used by the MixtureMeasure / ProductMeasure shields in Move 5.

Landing this surface now rather than deferring to Move 5 keeps the Phase 1-3 work done; the APIs are self-contained and test independently.

## Verification

All 13 \`test/test_*.jl\` files pass locally after each phase commit:
- test_core.jl, test_prevision_unit.jl, test_prevision_conjugate.jl, test_prevision_mixture.jl, test_prevision_particle.jl, test_host.jl, test_flat_mixture.jl, test_events.jl, test_persistence.jl, test_grid_world.jl, test_email_agent.jl, test_rss.jl, test_program_space.jl

\`scripts/capture-invariance.jl --verify\`: manifests identical (modulo timestamp) at each phase.

No external surface change: tests that read \`m.tag\` / \`m.beta.alpha\` / \`m.beta.space\` on TaggedBetaMeasure work identically via the reconstructing shield.

## Provenance — the Phase 4 pivot

The original Move 2 design doc scoped Phase 4 to include \`MixturePrevision.components\` and \`ProductPrevision.factors\` element-type tightening with shield reconstruction of \`Vector{Measure}\` wrapped in FrozenVectorView. Mid-implementation, per-component space variation in posteriors surfaced as a blocker: shield reconstruction with \`m.space\` loses the reduced-space info that \`condition\` introduces (e.g., 1-element \`Finite\` on a conditioned category).

Three options considered (see \`docs/posture-4/move-2-design.md\` §5.1 — design-doc amendment follows this PR):
- **A:** tighten fields + shield reconstruction + accept test scope creep
- **B:** scope-expand Move 2 to migrate apps/skin
- **C:** partial Move 2 — defer MixturePrevision/ProductPrevision tightening to Move 5 concurrent with \`condition\` rewrite

Option C chosen. The per-component-space question isn't a testing artefact — it's a signal that Prevision-as-primary and \`condition\`-produces-concentrated-Previsions are architecturally inseparable. Move 5 absorbs the coupled work.

## Test plan

- [x] All 13 test files pass at each phase commit
- [x] \`scripts/capture-invariance.jl --verify\` passes (manifests identical)
- [ ] CI passes

## Next PR in the sequence

After this merges: Move 2 design-doc §5.1 amendment. Documents the Phase 4 pivot with the Prevision-primary reasoning, notes the master-plan amendment (#49) it's downstream of, and names the Move 5 coupling so future readers walking the provenance chain see the full story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)