### PR TITLE
Posture 4 Move 4 sub-PR 4a: Prevision-first test files migrated

### DIFF
--- a/test/test_prevision_conjugate.jl
+++ b/test/test_prevision_conjugate.jl
@@ -21,6 +21,8 @@ push!(LOAD_PATH, "src")
 using Credence
 using Credence: ConjugatePrevision, maybe_conjugate, update, _dispatch_path
 using Credence: BetaPrevision, TaggedBetaPrevision
+using Credence: CategoricalPrevision, GaussianPrevision, GammaPrevision, DirichletPrevision, NormalGammaPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4: Measure-wrap helper
 
 function check(name, cond, detail="")
     if cond
@@ -42,7 +44,7 @@ println("="^60)
 # value assertion for the wrong reason.
 
 let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
-               h -> CategoricalMeasure(Finite([0, 1])),
+               h -> wrap_in_measure(CategoricalPrevision([0.0, 0.0]), Finite([0, 1])),
                (h, o) -> o == 1 ? log(max(h, 1e-300)) : log(max(1-h, 1e-300));
                likelihood_family = BetaBernoulli())
     p = BetaPrevision(2.0, 3.0)
@@ -85,7 +87,7 @@ end
 # registered conjugate entry (the update is the identity function).
 
 let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
-               h -> CategoricalMeasure(Finite([0, 1])),
+               h -> wrap_in_measure(CategoricalPrevision([0.0, 0.0]), Finite([0, 1])),
                (h, o) -> 0.0;  # flat log-density
                likelihood_family = Flat())
     p = BetaPrevision(2.0, 3.0)
@@ -118,7 +120,7 @@ end
 # for backward compat.
 
 let k_new = Kernel(Euclidean(1), Euclidean(1),
-                   h -> GaussianMeasure(Euclidean(1), h, 1.0),
+                   h -> wrap_in_measure(GaussianPrevision(h, 1.0)),
                    (h, o) -> -0.5 * (o - h)^2;
                    likelihood_family = NormalNormal(1.0))
     using Credence: GaussianPrevision
@@ -148,7 +150,7 @@ end
 # `params = Dict(:sigma_obs => σ)` + `likelihood_family = PushOnly()`.
 # maybe_conjugate must match this path too for backward compat.
 let k_legacy = Kernel(Euclidean(1), Euclidean(1),
-                      h -> GaussianMeasure(Euclidean(1), h, 1.0),
+                      h -> wrap_in_measure(GaussianPrevision(h, 1.0)),
                       (h, o) -> -0.5 * (o - h)^2;
                       params = Dict{Symbol,Any}(:sigma_obs => 1.0),
                       likelihood_family = PushOnly())
@@ -178,7 +180,7 @@ end
 
 let cats = Finite([:a, :b, :c])
     k = Kernel(Simplex(3), cats,
-               θ -> CategoricalMeasure(cats),
+               θ -> wrap_in_measure(CategoricalPrevision(fill(0.0, length(cats.values))), cats),
                (θ, o) -> log(max(θ[findfirst(==(o), cats.values)], 1e-300));
                likelihood_family = Categorical(cats))
     using Credence: DirichletPrevision
@@ -211,7 +213,7 @@ end
 # κ_n = κ+1; μ_n = (κμ+r)/κ_n; α_n = α+0.5; β_n = β + κ(r-μ)²/(2κ_n).
 
 let k_new = Kernel(ProductSpace(Space[Euclidean(1), PositiveReals()]), Euclidean(1),
-                   h -> GaussianMeasure(Euclidean(1), h[1], sqrt(h[2])),
+                   h -> wrap_in_measure(GaussianPrevision(h[1], sqrt(h[2]))),
                    (h, o) -> -0.5 * (o - h[1])^2 / h[2];
                    likelihood_family = NormalGammaLikelihood())
     using Credence: NormalGammaPrevision
@@ -237,7 +239,7 @@ end
 
 # Legacy params-based path for NormalGamma.
 let k_legacy = Kernel(ProductSpace(Space[Euclidean(1), PositiveReals()]), Euclidean(1),
-                      h -> GaussianMeasure(Euclidean(1), h[1], sqrt(h[2])),
+                      h -> wrap_in_measure(GaussianPrevision(h[1], sqrt(h[2]))),
                       (h, o) -> -0.5 * (o - h[1])^2 / h[2];
                       params = Dict{Symbol,Any}(:normal_gamma => true),
                       likelihood_family = PushOnly())
@@ -263,7 +265,7 @@ end
 # fell through to particle).
 
 let k = Kernel(PositiveReals(), PositiveReals(),
-               h -> GammaMeasure(PositiveReals(), 1.0, h),
+               h -> wrap_in_measure(GammaPrevision(1.0, h)),
                (h, o) -> log(h) - h * o;
                likelihood_family = Exponential())
     using Credence: GammaPrevision
@@ -302,10 +304,10 @@ end
 # break in hard-to-diagnose ways. The guard here catches it at Stratum-2.
 
 let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
-               h -> CategoricalMeasure(Finite([0, 1])),
+               h -> wrap_in_measure(CategoricalPrevision([0.0, 0.0]), Finite([0, 1])),
                (h, o) -> 0.0;
                likelihood_family = BetaBernoulli())
-    inner = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
+    inner = wrap_in_measure(BetaPrevision(2.0, 3.0))
     tbp = TaggedBetaPrevision(42, inner)
 
     check("TaggedBetaPrevision + BetaBernoulli → :particle (transitional scaffolding)",
@@ -329,7 +331,7 @@ end
 # assertion below catches it.
 
 let k = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
-               h -> CategoricalMeasure(Finite([0, 1])),
+               h -> wrap_in_measure(CategoricalPrevision([0.0, 0.0]), Finite([0, 1])),
                (h, o) -> 0.0;
                likelihood_family = BetaBernoulli())
     using Credence: GaussianPrevision, GammaPrevision, DirichletPrevision, NormalGammaPrevision

--- a/test/test_prevision_mixture.jl
+++ b/test/test_prevision_mixture.jl
@@ -19,8 +19,9 @@
 push!(LOAD_PATH, "src")
 using Credence
 using Credence: _dispatch_path
-using Credence.Ontology: _resolve_likelihood_family, _with_resolved_family
+using Credence.Ontology: _resolve_likelihood_family, _with_resolved_family, wrap_in_measure  # Posture 4 Move 4
 using Credence.Previsions: DirichletPrevision
+using Credence: BetaPrevision, GaussianPrevision  # Posture 4 Move 4
 
 function check(name, cond, detail="")
     if cond
@@ -39,9 +40,9 @@ println("="^60)
 
 let
     # Three tagged components with distinct α,β and distinct tags.
-    comp1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure(2.0, 3.0))
-    comp2 = TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaMeasure(5.0, 5.0))
-    comp3 = TaggedBetaMeasure(Interval(0.0, 1.0), 3, BetaMeasure(1.0, 4.0))
+    comp1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaPrevision(2.0, 3.0))
+    comp2 = TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaPrevision(5.0, 5.0))
+    comp3 = TaggedBetaMeasure(Interval(0.0, 1.0), 3, BetaPrevision(1.0, 4.0))
     mix = MixtureMeasure(Interval(0.0, 1.0), [comp1, comp2, comp3], [0.0, 0.0, 0.0])
 
     k = Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]),
@@ -109,8 +110,8 @@ end
 let
     # Mixture with one TaggedBetaMeasure (routes conjugate) and one
     # GaussianMeasure (no registered pair for Bernoulli kernel).
-    c1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure(2.0, 3.0))
-    c2 = GaussianMeasure(Euclidean(1), 0.0, 1.0)
+    c1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaPrevision(2.0, 3.0))
+    c2 = wrap_in_measure(GaussianPrevision(0.0, 1.0))
     mix = MixtureMeasure(Interval(0.0, 1.0), Measure[c1, c2], [0.0, 0.0])
 
     k = Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]),
@@ -130,7 +131,7 @@ end
 let
     # All log_weights at -Inf → MixturePrevision constructor errors.
     raised = try
-        MixturePrevision(Measure[BetaMeasure(1.0, 1.0)], [-Inf])
+        MixturePrevision(Measure[wrap_in_measure(BetaPrevision(1.0, 1.0))], [-Inf])
         false
     catch e
         occursin("zero total mass", sprint(showerror, e))
@@ -222,9 +223,9 @@ let
     # branching). TaggedBetaMeasure flattening is exercised by the
     # master-plan gate-4 MixtureMeasure flattening path, asserted
     # indirectly via test_flat_mixture.jl.
-    comp1 = BetaMeasure(2.0, 2.0)
-    inner_c1 = BetaMeasure(1.0, 1.0)
-    inner_c2 = BetaMeasure(3.0, 2.0)
+    comp1 = wrap_in_measure(BetaPrevision(2.0, 2.0))
+    inner_c1 = wrap_in_measure(BetaPrevision(1.0, 1.0))
+    inner_c2 = wrap_in_measure(BetaPrevision(3.0, 2.0))
     comp2 = MixtureMeasure(Interval(0.0, 1.0), Measure[inner_c1, inner_c2], [0.0, 0.0])
 
     outer = MixtureMeasure(Interval(0.0, 1.0), Measure[comp1, comp2], [0.0, 0.0])

--- a/test/test_prevision_particle.jl
+++ b/test/test_prevision_particle.jl
@@ -22,6 +22,8 @@
 
 push!(LOAD_PATH, "src")
 using Credence
+using Credence: BetaPrevision, GammaPrevision, GaussianPrevision  # Posture 4 Move 4: Prevision constructors
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4: Measure-wrap helper for Measure-dispatch consumers
 using Random
 using Serialization
 
@@ -51,7 +53,7 @@ println("Fixture SHA: $(CANONICAL[:source_sha]); Julia $(CANONICAL[:julia_versio
 
 let
     Random.seed!(42)
-    m = GammaMeasure(2.0, 3.0)
+    m = wrap_in_measure(GammaPrevision(2.0, 3.0))
     k = Kernel(PositiveReals(), Euclidean(1),
                λ -> error("generate not used"),
                (λ, o) -> -0.5 * (o - λ)^2;
@@ -74,7 +76,7 @@ end
 
 let
     Random.seed!(42)  # not strictly needed for grid, but keep canonical path identical
-    m = BetaMeasure(2.0, 3.0)
+    m = wrap_in_measure(BetaPrevision(2.0, 3.0))
     k = Kernel(Interval(0.0, 1.0), Euclidean(1),
                θ -> error("generate not used"),
                (θ, o) -> -0.5 * (o - θ)^2;
@@ -96,7 +98,7 @@ end
 
 let
     Random.seed!(42)
-    m = GaussianMeasure(Euclidean(1), 0.0, 1.0)
+    m = wrap_in_measure(GaussianPrevision(0.0, 1.0))
     k = Kernel(Euclidean(1), Euclidean(1),
                μ -> error("generate not used"),
                (μ, o) -> log(max(o, 1e-300));

--- a/test/test_prevision_unit.jl
+++ b/test/test_prevision_unit.jl
@@ -17,6 +17,8 @@
 
 push!(LOAD_PATH, "src")
 using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4: Measure-wrap helper
 using Random
 
 # Helper: println PASSED / halt on FAILED. Matches the codebase's house
@@ -35,7 +37,7 @@ println("Stratum 1 — closed-form methods (==)")
 println("="^60)
 
 # ── 1. BetaMeasure × Identity = α / (α+β) ──
-let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
+let m = wrap_in_measure(BetaPrevision(2.0, 3.0))
     expected = 2.0 / 5.0
     actual = expect(m, Identity())
     check("BetaMeasure(2, 3) × Identity = 2/5 (exact)",
@@ -43,7 +45,7 @@ let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
           "got $actual, expected $expected")
 end
 
-let m = BetaMeasure(Interval(0.0, 1.0), 1.0, 1.0)
+let m = wrap_in_measure(BetaPrevision(1.0, 1.0))
     expected = 0.5
     actual = expect(m, Identity())
     check("BetaMeasure(1, 1) × Identity = 1/2 (exact)",
@@ -51,7 +53,7 @@ let m = BetaMeasure(Interval(0.0, 1.0), 1.0, 1.0)
           "got $actual, expected $expected")
 end
 
-let m = BetaMeasure(Interval(0.0, 1.0), 7.0, 2.0)
+let m = wrap_in_measure(BetaPrevision(7.0, 2.0))
     expected = 7.0 / 9.0
     actual = expect(m, Identity())
     check("BetaMeasure(7, 2) × Identity = 7/9 (exact)",
@@ -60,7 +62,7 @@ let m = BetaMeasure(Interval(0.0, 1.0), 7.0, 2.0)
 end
 
 # ── 2. TaggedBetaMeasure × Identity — delegates to .beta ──
-let beta = BetaMeasure(Interval(0.0, 1.0), 3.0, 4.0)
+let beta = wrap_in_measure(BetaPrevision(3.0, 4.0))
     m = TaggedBetaMeasure(Interval(0.0, 1.0), 42, beta)
     expected = 3.0 / 7.0
     actual = expect(m, Identity())
@@ -70,7 +72,7 @@ let beta = BetaMeasure(Interval(0.0, 1.0), 3.0, 4.0)
 end
 
 # ── 3. GammaMeasure × Identity = α / β ──
-let m = GammaMeasure(PositiveReals(), 2.0, 0.5)
+let m = wrap_in_measure(GammaPrevision(2.0, 0.5))
     expected = 2.0 / 0.5
     actual = expect(m, Identity())
     check("GammaMeasure(2, 0.5) × Identity = 4.0 (exact)",
@@ -78,7 +80,7 @@ let m = GammaMeasure(PositiveReals(), 2.0, 0.5)
           "got $actual, expected $expected")
 end
 
-let m = GammaMeasure(PositiveReals(), 3.0, 3.0)
+let m = wrap_in_measure(GammaPrevision(3.0, 3.0))
     expected = 1.0
     actual = expect(m, Identity())
     check("GammaMeasure(3, 3) × Identity = 1.0 (exact)",
@@ -87,7 +89,7 @@ let m = GammaMeasure(PositiveReals(), 3.0, 3.0)
 end
 
 # ── 4. GaussianMeasure × Identity = μ ──
-let m = GaussianMeasure(Euclidean(1), 0.0, 1.0)
+let m = wrap_in_measure(GaussianPrevision(0.0, 1.0))
     expected = 0.0
     actual = expect(m, Identity())
     check("GaussianMeasure(0, 1) × Identity = 0 (exact)",
@@ -95,7 +97,7 @@ let m = GaussianMeasure(Euclidean(1), 0.0, 1.0)
           "got $actual, expected $expected")
 end
 
-let m = GaussianMeasure(Euclidean(1), 2.5, 0.3)
+let m = wrap_in_measure(GaussianPrevision(2.5, 0.3))
     expected = 2.5
     actual = expect(m, Identity())
     check("GaussianMeasure(2.5, 0.3) × Identity = 2.5 (exact)",
@@ -104,7 +106,7 @@ let m = GaussianMeasure(Euclidean(1), 2.5, 0.3)
 end
 
 # ── 5. CategoricalMeasure × Identity = Σ w_i · v_i ──
-let m = CategoricalMeasure(Finite([0.0, 1.0, 2.0, 3.0]))  # uniform over 4 atoms
+let m = CategoricalMeasure(Finite([0.0, 1.0, 2.0, 3.0]), CategoricalPrevision(fill(0.0, 4)))  # uniform over 4 atoms
     expected = (0.0 + 1.0 + 2.0 + 3.0) / 4.0
     actual = expect(m, Identity())
     check("CategoricalMeasure(uniform over [0,1,2,3]) × Identity = 1.5 (exact)",
@@ -114,7 +116,7 @@ end
 
 # Non-uniform: log-weights [log(1), log(2), log(3)] over [10.0, 20.0, 30.0].
 # Normalised: w = [1/6, 2/6, 3/6]. Mean = 10/6 + 40/6 + 90/6 = 140/6 = 70/3.
-let m = CategoricalMeasure(Finite([10.0, 20.0, 30.0]), [log(1.0), log(2.0), log(3.0)])
+let m = CategoricalMeasure(Finite([10.0, 20.0, 30.0]), CategoricalPrevision([log(1.0), log(2.0), log(3.0)]))
     expected = 70.0 / 3.0
     actual = expect(m, Identity())
     check("CategoricalMeasure(weighted [10,20,30] with w=[1/6,2/6,3/6]) × Identity = 70/3",
@@ -125,8 +127,8 @@ end
 # ── 6. ProductMeasure × Projection — selects factor's Identity ──
 let m = ProductMeasure(
     ProductSpace([Interval(0.0, 1.0), PositiveReals()]),
-    Measure[BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0),
-            GammaMeasure(PositiveReals(), 4.0, 2.0)]
+    Measure[wrap_in_measure(BetaPrevision(2.0, 3.0)),
+            wrap_in_measure(GammaPrevision(4.0, 2.0))]
 )
     # factor 1 is Beta(2,3): mean 2/5
     # factor 2 is Gamma(4,2): mean 4/2 = 2
@@ -143,8 +145,8 @@ end
 # ── 7. ProductMeasure × NestedProjection — single-level == Projection ──
 let m = ProductMeasure(
     ProductSpace([Interval(0.0, 1.0), Interval(0.0, 1.0)]),
-    Measure[BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0),
-            BetaMeasure(Interval(0.0, 1.0), 5.0, 5.0)]
+    Measure[wrap_in_measure(BetaPrevision(2.0, 3.0)),
+            wrap_in_measure(BetaPrevision(5.0, 5.0))]
 )
     actual_1 = expect(m, NestedProjection([1]))
     actual_2 = expect(m, NestedProjection([2]))
@@ -157,13 +159,13 @@ end
 # ── 8. ProductMeasure × NestedProjection — two levels, nested products ──
 let inner1 = ProductMeasure(
         ProductSpace([Interval(0.0, 1.0), Interval(0.0, 1.0)]),
-        Measure[BetaMeasure(Interval(0.0, 1.0), 1.0, 3.0),
-                BetaMeasure(Interval(0.0, 1.0), 2.0, 2.0)]
+        Measure[wrap_in_measure(BetaPrevision(1.0, 3.0)),
+                wrap_in_measure(BetaPrevision(2.0, 2.0))]
     )
     inner2 = ProductMeasure(
         ProductSpace([Interval(0.0, 1.0), Interval(0.0, 1.0)]),
-        Measure[BetaMeasure(Interval(0.0, 1.0), 4.0, 1.0),
-                BetaMeasure(Interval(0.0, 1.0), 1.0, 1.0)]
+        Measure[wrap_in_measure(BetaPrevision(4.0, 1.0)),
+                wrap_in_measure(BetaPrevision(1.0, 1.0))]
     )
     m = ProductMeasure(
         ProductSpace([ProductSpace([Interval(0.0, 1.0), Interval(0.0, 1.0)]),
@@ -181,7 +183,7 @@ let inner1 = ProductMeasure(
 end
 
 # ── 9. CategoricalMeasure × Projection — vector-valued atoms ──
-let m = CategoricalMeasure(Finite([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]))  # uniform
+let m = CategoricalMeasure(Finite([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]), CategoricalPrevision(fill(0.0, 3)))  # uniform
     # uniform over 3 atoms; Projection(1) gives E[first component] = (1+3+5)/3 = 3.0
     actual_1 = expect(m, Projection(1))
     actual_2 = expect(m, Projection(2))
@@ -192,7 +194,7 @@ let m = CategoricalMeasure(Finite([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]))  # unif
 end
 
 # ── 10. CategoricalMeasure × Tabular ──
-let m = CategoricalMeasure(Finite([:a, :b, :c]))  # uniform over 3 symbols
+let m = CategoricalMeasure(Finite([:a, :b, :c]), CategoricalPrevision(fill(0.0, 3)))  # uniform over 3 symbols
     # Tabular([10, 20, 30]) with uniform weights = (10+20+30)/3 = 20
     t = Tabular([10.0, 20.0, 30.0])
     actual = expect(m, t)
@@ -201,7 +203,7 @@ let m = CategoricalMeasure(Finite([:a, :b, :c]))  # uniform over 3 symbols
 end
 
 # ── 11. LinearCombination — linearity of expectation ──
-let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
+let m = wrap_in_measure(BetaPrevision(2.0, 3.0))
     # 3 * Identity + 5 = 3 * 0.4 + 5 = 6.2
     lc = LinearCombination(Tuple{Float64, TestFunction}[(3.0, Identity())], 5.0)
     actual = expect(m, lc)
@@ -210,7 +212,7 @@ let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
           actual == expected, "got $actual, expected $expected")
 end
 
-let m = BetaMeasure(Interval(0.0, 1.0), 1.0, 1.0)
+let m = wrap_in_measure(BetaPrevision(1.0, 1.0))
     # 2 * Identity - 1 * Identity + 0.3 = (2-1) * 0.5 + 0.3 = 0.8
     lc = LinearCombination(
         Tuple{Float64, TestFunction}[(2.0, Identity()), (-1.0, Identity())],
@@ -224,8 +226,8 @@ let m = BetaMeasure(Interval(0.0, 1.0), 1.0, 1.0)
 end
 
 # ── 12. MixtureMeasure recursion — weighted sum over components ──
-let c1 = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)  # mean 0.4
-    c2 = BetaMeasure(Interval(0.0, 1.0), 5.0, 5.0)  # mean 0.5
+let c1 = wrap_in_measure(BetaPrevision(2.0, 3.0))  # mean 0.4
+    c2 = wrap_in_measure(BetaPrevision(5.0, 5.0))  # mean 0.5
     m = MixtureMeasure(Interval(0.0, 1.0), [c1, c2], [log(1.0), log(3.0)])
     # w = [1/4, 3/4]; E[X] = 0.25 * 0.4 + 0.75 * 0.5 = 0.475
     actual = expect(m, Identity())
@@ -245,7 +247,7 @@ println("="^60)
 # alias entry sends `expect(m, OpaqueClosure(f))` through the generic
 # `::Function` overload with different kwargs defaults.
 
-let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
+let m = wrap_in_measure(BetaPrevision(2.0, 3.0))
     f = x -> x  # identity-as-function
     direct = expect(m, f)  # uses default n=64 quadrature
     wrapped = expect(m, OpaqueClosure(f))
@@ -254,7 +256,7 @@ let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
           "direct=$direct wrapped=$wrapped")
 end
 
-let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
+let m = wrap_in_measure(BetaPrevision(2.0, 3.0))
     f = x -> x^2
     direct = expect(m, f; n=128)  # explicit non-default kwarg
     wrapped = expect(m, OpaqueClosure(f); n=128)
@@ -263,7 +265,7 @@ let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
           "direct=$direct wrapped=$wrapped")
 end
 
-let m = CategoricalMeasure(Finite([1.0, 2.0, 3.0, 4.0]))
+let m = CategoricalMeasure(Finite([1.0, 2.0, 3.0, 4.0]), CategoricalPrevision(fill(0.0, 4)))
     f = x -> x * 2
     direct = expect(m, f)
     wrapped = expect(m, OpaqueClosure(f))
@@ -274,8 +276,8 @@ end
 
 # Mixture has a separate `expect(::MixtureMeasure, ::OpaqueClosure)` method
 # (ontology.jl:770) specifically to resolve dispatch ambiguity. Test it.
-let c1 = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
-    c2 = BetaMeasure(Interval(0.0, 1.0), 5.0, 5.0)
+let c1 = wrap_in_measure(BetaPrevision(2.0, 3.0))
+    c2 = wrap_in_measure(BetaPrevision(5.0, 5.0))
     m = MixtureMeasure(Interval(0.0, 1.0), [c1, c2], [log(1.0), log(1.0)])
     f = x -> x
     direct = expect(m, f)
@@ -294,7 +296,7 @@ println("="^60)
 # The ::Function signature for BetaMeasure uses 64-point grid quadrature.
 # Call twice; results must match to reassociation tolerance.
 
-let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
+let m = wrap_in_measure(BetaPrevision(2.0, 3.0))
     f = x -> x^2
     v1 = expect(m, f; n=64)
     v2 = expect(m, f; n=64)
@@ -302,7 +304,7 @@ let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
           v1 == v2, "v1=$v1 v2=$v2")
 end
 
-let m = GaussianMeasure(Euclidean(1), 0.5, 1.0)
+let m = wrap_in_measure(GaussianPrevision(0.5, 1.0))
     f = x -> x^2
     v1 = expect(m, f; n=64)
     v2 = expect(m, f; n=64)
@@ -310,7 +312,7 @@ let m = GaussianMeasure(Euclidean(1), 0.5, 1.0)
           v1 == v2, "v1=$v1 v2=$v2")
 end
 
-let m = GammaMeasure(PositiveReals(), 3.0, 1.0)
+let m = wrap_in_measure(GammaPrevision(3.0, 1.0))
     f = x -> log(x + 1.0)
     v1 = expect(m, f; n=64)
     v2 = expect(m, f; n=64)
@@ -351,8 +353,8 @@ end
 
 let m = ProductMeasure(
     ProductSpace([Interval(0.0, 1.0), PositiveReals()]),
-    Measure[BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0),
-            GammaMeasure(PositiveReals(), 4.0, 2.0)]
+    Measure[wrap_in_measure(BetaPrevision(2.0, 3.0)),
+            wrap_in_measure(GammaPrevision(4.0, 2.0))]
 )
     f = x -> x[1] * x[2]
     Random.seed!(42)
@@ -372,7 +374,7 @@ println("="^60)
 # Move 3 refactors BetaMeasure to wrap BetaPrevision; consumer reads of
 # `m.alpha` and `m.beta` are forwarded via Base.getproperty. These tests
 # assert the forwarding preserves the underlying values bit-exactly.
-let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
+let m = wrap_in_measure(BetaPrevision(2.0, 3.0))
     check("BetaMeasure.alpha forwards via shield",
           m.alpha === 2.0, "got $(m.alpha) of type $(typeof(m.alpha))")
     check("BetaMeasure.beta forwards via shield",
@@ -391,7 +393,7 @@ end
 # The method bodies `mean(m::BetaMeasure) = m.alpha / (m.alpha + m.beta)`
 # (src/ontology.jl:129) continue to work unchanged; the shield is
 # invisible to them.
-let m = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
+let m = wrap_in_measure(BetaPrevision(2.0, 3.0))
     check("mean(BetaMeasure) uses shield reads, bit-exact",
           mean(m) == 2.0 / 5.0, "got $(mean(m))")
     check("variance(BetaMeasure) uses shield reads",
@@ -414,8 +416,8 @@ end
 # the test, test asserts the invariant; breaking either breaks both).
 
 function test_shared_reference_contract()
-    c1 = BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0)
-    c2 = BetaMeasure(Interval(0.0, 1.0), 5.0, 5.0)
+    c1 = wrap_in_measure(BetaPrevision(2.0, 3.0))
+    c2 = wrap_in_measure(BetaPrevision(5.0, 5.0))
     m = MixtureMeasure(Interval(0.0, 1.0), Measure[c1, c2], [log(1.0), log(1.0)])
 
     # Read .components through the shield.
@@ -424,7 +426,7 @@ function test_shared_reference_contract()
           length(comps) == 2, "got $(length(comps))")
 
     # Mutate in place — push! a new component.
-    push!(comps, BetaMeasure(Interval(0.0, 1.0), 1.0, 1.0))
+    push!(comps, wrap_in_measure(BetaPrevision(1.0, 1.0)))
 
     # Read .components through the shield again; mutation must be visible.
     check("MixtureMeasure.components shows the push!'d component (shared-reference contract)",


### PR DESCRIPTION
## Summary

First of four sub-PRs per \`docs/posture-4/move-4-design.md\` §2 (merged \`81e4d2d\`). Prevision-first test files — the 4 files whose names already flagged them as Prevision-testing surface but which still used Measure constructors in their test fixtures.

## Files migrated

| File | Pre | Post | Reduction |
|---|---|---|---|
| \`test_prevision_unit.jl\` | 66 | 32 | 34 rewrites |
| \`test_prevision_conjugate.jl\` | 11 | 0 | 11 rewrites |
| \`test_prevision_mixture.jl\` | 13 | 8 | 5 rewrites |
| \`test_prevision_particle.jl\` | 6 | 3 | 3 rewrites |
| **Total** | 96 | 43 | 53 rewrites |

## Remaining \`Measure\\(\` hits are legitimate Measure-level composition

- \`TaggedBetaMeasure(Interval, tag, BetaPrevision(...))\` — Prevision-in constructor (Move 2 Phase 4's outer constructor makes this work).
- \`CategoricalMeasure(Finite(...), CategoricalPrevision(...))\` — Prevision-in constructor; atom type stays on Finite-side per §5.2 Option A.
- \`ProductMeasure(...)\`, \`MixtureMeasure(...)\` — Measure-level composition, stays until Move 5.
- \`DirichletMeasure\` / \`NormalGammaMeasure\` — context-dependent types; direct constructor per §5.2.
- \`CategoricalMeasure(Finite(...), particle_prevision)\` — wrap ParticlePrevision / QuadraturePrevision / EnumerationPrevision.

## Migration pattern

- Scalar → Measure shortcuts (\`BetaMeasure(I, α, β)\`, \`GaussianMeasure(E, μ, σ)\`, \`GammaMeasure(PR, α, β)\`): rewritten to \`wrap_in_measure(PrevisionType(args))\`.
- Default-uniform CategoricalMeasure: rewritten to \`CategoricalMeasure(Finite, CategoricalPrevision(fill(0.0, N)))\`.
- Kernel generator lambdas that produce a Measure: rewritten to \`h -> wrap_in_measure(PrevisionType(h_args))\` for consistency.

## Test-oracle pragma invariant (§5.4)

Pragma count across 4a's 4 files: **0** — these files didn't have any \`test-oracle\` pragma sites. Global count stays at 42 (4a affects 0 of them). Invariant holds.

## Verification

- ✅ All 4 files pass individually
- ✅ \`scripts/capture-invariance.jl --verify\`: manifests identical (modulo timestamp)

## Test plan

- [x] Per-file tests pass
- [x] \`--verify\` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)