### PR TITLE
Posture 4 Move 4 sub-PR 4b: core DSL + event tests migrated

### DIFF
--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -9,6 +9,8 @@ Verifies: type constructors, axiom-constrained functions
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 
 println("=" ^ 60)
 println("TEST 1: Spaces are first-class typed objects")
@@ -415,7 +417,7 @@ using Random
 let
     Random.seed!(123)
     # BetaMeasure with a non-Bernoulli kernel (Interval → Finite with 3 outcomes)
-    m = BetaMeasure(2.0, 5.0)  # mean = 2/7 ≈ 0.286
+    m = wrap_in_measure(BetaPrevision(2.0, 5.0))  # mean = 2/7 ≈ 0.286
     obs_space = Finite([:low, :mid, :high])
     k = Kernel(Interval(0.0, 1.0), obs_space,
         θ -> (o -> begin
@@ -450,8 +452,8 @@ println("=" ^ 60)
 
 let
     Random.seed!(42)
-    beta = BetaMeasure(2.0, 3.0)  # mean = 0.4
-    cat = CategoricalMeasure(Finite([:a, :b, :c]))
+    beta = wrap_in_measure(BetaPrevision(2.0, 3.0))  # mean = 0.4
+    cat = CategoricalMeasure(Finite([:a, :b, :c]), CategoricalPrevision(fill(0.0, 3)))
     pm = ProductMeasure(Measure[beta, cat])
 
     s = draw(pm)
@@ -471,9 +473,9 @@ println("=" ^ 60)
 
 let
     Random.seed!(42)
-    cat = CategoricalMeasure(Finite([0, 1]))  # uniform over {0, 1}
-    theta0 = BetaMeasure(2.0, 2.0)  # mean = 0.5
-    theta1 = BetaMeasure(2.0, 2.0)  # mean = 0.5
+    cat = CategoricalMeasure(Finite([0, 1]), CategoricalPrevision(fill(0.0, 2)))  # uniform over {0, 1}
+    theta0 = wrap_in_measure(BetaPrevision(2.0, 2.0))  # mean = 0.5
+    theta1 = wrap_in_measure(BetaPrevision(2.0, 2.0))  # mean = 0.5
     pm = ProductMeasure(Measure[cat, theta0, theta1])
 
     # Kernel: if cat=0, Bernoulli(θ₀); if cat=1, Bernoulli(θ₁)
@@ -508,8 +510,8 @@ println("=" ^ 60)
 
 let
     Random.seed!(42)
-    b1 = BetaMeasure(3.0, 1.0)  # skewed high
-    b2 = BetaMeasure(1.0, 3.0)  # skewed low
+    b1 = wrap_in_measure(BetaPrevision(3.0, 1.0))  # skewed high
+    b2 = wrap_in_measure(BetaPrevision(1.0, 3.0))  # skewed low
     mix = MixtureMeasure(Interval(0.0, 1.0), Measure[b1, b2], [0.0, 0.0])  # equal weights
 
     # Bernoulli kernel on [0,1]
@@ -538,8 +540,8 @@ println("=" ^ 60)
 
 let
     Random.seed!(42)
-    b1 = BetaMeasure(4.0, 2.0)  # mean = 2/3
-    b2 = BetaMeasure(2.0, 4.0)  # mean = 1/3
+    b1 = wrap_in_measure(BetaPrevision(4.0, 2.0))  # mean = 2/3
+    b2 = wrap_in_measure(BetaPrevision(2.0, 4.0))  # mean = 1/3
     mix = MixtureMeasure(Interval(0.0, 1.0), Measure[b1, b2], [log(0.7), log(0.3)])
 
     # E[θ] = 0.7 * 2/3 + 0.3 * 1/3 ≈ 0.567
@@ -556,9 +558,9 @@ println("TEST 23: MixtureMeasure prune")
 println("=" ^ 60)
 
 let
-    b1 = BetaMeasure(5.0, 2.0)
-    b2 = BetaMeasure(1.0, 1.0)
-    b3 = BetaMeasure(2.0, 5.0)
+    b1 = wrap_in_measure(BetaPrevision(5.0, 2.0))
+    b2 = wrap_in_measure(BetaPrevision(1.0, 1.0))
+    b3 = wrap_in_measure(BetaPrevision(2.0, 5.0))
     # b1 dominant, b2 and b3 negligible
     mix = MixtureMeasure(Interval(0.0, 1.0), Measure[b1, b2, b3],
                          [0.0, -25.0, -30.0])
@@ -580,8 +582,8 @@ println("=" ^ 60)
 
 let
     Random.seed!(42)
-    b1 = BetaMeasure(3.0, 3.0)
-    b2 = BetaMeasure(1.0, 1.0)
+    b1 = wrap_in_measure(BetaPrevision(3.0, 3.0))
+    b2 = wrap_in_measure(BetaPrevision(1.0, 1.0))
     mix = MixtureMeasure(Interval(0.0, 1.0), Measure[b1, b2], [0.0, 0.0])
 
     for _ in 1:100
@@ -598,7 +600,7 @@ println("TEST 25: BetaMeasure + non-Bernoulli kernel → grid fallback")
 println("=" ^ 60)
 
 let
-    prior = BetaMeasure(2.0, 2.0)
+    prior = wrap_in_measure(BetaPrevision(2.0, 2.0))
     # 3-outcome kernel: NOT conjugate (not binary)
     obs_space = Finite([:low, :mid, :high])
     k = Kernel(Interval(0.0, 1.0), obs_space,
@@ -626,7 +628,7 @@ println("TEST 26: BetaMeasure + Bernoulli kernel → conjugate (unchanged)")
 println("=" ^ 60)
 
 let
-    prior = BetaMeasure(1.0, 1.0)
+    prior = wrap_in_measure(BetaPrevision(1.0, 1.0))
     obs_space = Finite([0.0, 1.0])
     k = Kernel(Interval(0.0, 1.0), obs_space,
         θ -> (o -> o == 1.0 ? log(θ) : log(1.0 - θ)),
@@ -645,7 +647,7 @@ println("TEST 27: GaussianMeasure + Normal kernel → conjugate")
 println("=" ^ 60)
 
 let
-    prior = GaussianMeasure(Euclidean(1), 0.0, 1.0)
+    prior = wrap_in_measure(GaussianPrevision(0.0, 1.0))
     # Normal-Normal kernel: σ_obs = 1.0
     sigma_obs = 1.0
     k = Kernel(Euclidean(1), Euclidean(1),
@@ -667,7 +669,7 @@ println("TEST 28: Gaussian precision-weighted mean (strong prior dominates)")
 println("=" ^ 60)
 
 let
-    prior = GaussianMeasure(Euclidean(1), 10.0, 0.5)  # tight prior at 10
+    prior = wrap_in_measure(GaussianPrevision(10.0, 0.5))  # tight prior at 10
     sigma_obs = 2.0
     k = Kernel(Euclidean(1), Euclidean(1),
         h -> (o -> -0.5 * ((o - h) / sigma_obs)^2),
@@ -690,7 +692,7 @@ println("=" ^ 60)
 let
     configs = [(0.0, 1.0, 1.0, 0.0), (5.0, 2.0, 0.5, 3.0), (-1.0, 0.1, 10.0, 100.0)]
     for (mu0, sig0, sig_obs, x) in configs
-        prior = GaussianMeasure(Euclidean(1), mu0, sig0)
+        prior = wrap_in_measure(GaussianPrevision(mu0, sig0))
         k = Kernel(Euclidean(1), Euclidean(1),
             h -> (o -> -0.5 * ((o - h) / sig_obs)^2),
             (h, o) -> -0.5 * ((o - h) / sig_obs)^2;
@@ -709,7 +711,7 @@ println("TEST 30: GaussianMeasure + non-Gaussian kernel → grid fallback")
 println("=" ^ 60)
 
 let
-    prior = GaussianMeasure(Euclidean(1), 0.0, 1.0)
+    prior = wrap_in_measure(GaussianPrevision(0.0, 1.0))
     # Kernel to Finite target: NOT Normal-Normal
     obs_space = Finite([:a, :b])
     k = Kernel(Euclidean(1), obs_space,
@@ -728,7 +730,7 @@ println("=" ^ 60)
 
 let
     # Euclidean → Euclidean but no params → must fall through to grid
-    prior = GaussianMeasure(Euclidean(1), 0.0, 1.0)
+    prior = wrap_in_measure(GaussianPrevision(0.0, 1.0))
     k = Kernel(Euclidean(1), Euclidean(1),
         h -> (o -> -0.5 * ((o - h) / 1.0)^2),
         (h, o) -> -0.5 * ((o - h) / 1.0)^2;
@@ -1010,15 +1012,15 @@ println("=" ^ 60)
 println("TEST 44: Identity on leaf measures — closed form")
 println("=" ^ 60)
 
-v = expect(BetaMeasure(3.0, 2.0), Identity())
+v = expect(wrap_in_measure(BetaPrevision(3.0, 2.0)), Identity())
 @assert abs(v - 0.6) < 1e-12  "Beta(3,2) Identity should be 0.6, got $v"
 println("PASSED: expect(Beta(3,2), Identity()) = ", v)
 
-v = expect(GammaMeasure(4.0, 2.0), Identity())
+v = expect(wrap_in_measure(GammaPrevision(4.0, 2.0)), Identity())
 @assert abs(v - 2.0) < 1e-12  "Gamma(4,2) Identity should be 2.0, got $v"
 println("PASSED: expect(Gamma(4,2), Identity()) = ", v)
 
-v = expect(GaussianMeasure(Euclidean(1), -1.5, 2.0), Identity())
+v = expect(wrap_in_measure(GaussianPrevision(-1.5, 2.0)), Identity())
 @assert abs(v - (-1.5)) < 1e-12  "Gaussian(-1.5,2) Identity should be -1.5, got $v"
 println("PASSED: expect(Gaussian(-1.5,2), Identity()) = ", v)
 println()
@@ -1027,7 +1029,7 @@ println("=" ^ 60)
 println("TEST 45: Projection on flat ProductMeasure")
 println("=" ^ 60)
 
-pm_flat = ProductMeasure(Measure[BetaMeasure(3.0, 2.0), BetaMeasure(1.0, 1.0)])
+pm_flat = ProductMeasure(Measure[wrap_in_measure(BetaPrevision(3.0, 2.0)), wrap_in_measure(BetaPrevision(1.0, 1.0))])
 v = expect(pm_flat, Projection(1))
 @assert abs(v - 0.6) < 1e-12  "Projection(1) should give mean of first factor 0.6, got $v"
 println("PASSED: expect(PM[Beta(3,2), Beta(1,1)], Projection(1)) = ", v)
@@ -1041,8 +1043,8 @@ println("=" ^ 60)
 println("TEST 46: NestedProjection through nested ProductMeasure")
 println("=" ^ 60)
 
-inner_a = ProductMeasure(Measure[BetaMeasure(3.0, 2.0), GammaMeasure(2.0, 0.5)])
-inner_b = ProductMeasure(Measure[BetaMeasure(1.0, 1.0), GammaMeasure(2.0, 0.5)])
+inner_a = ProductMeasure(Measure[wrap_in_measure(BetaPrevision(3.0, 2.0)), wrap_in_measure(GammaPrevision(2.0, 0.5))])
+inner_b = ProductMeasure(Measure[wrap_in_measure(BetaPrevision(1.0, 1.0)), wrap_in_measure(GammaPrevision(2.0, 0.5))])
 pm_nested = ProductMeasure(Measure[inner_a, inner_b])
 
 v = expect(pm_nested, NestedProjection([1, 1]))
@@ -1090,8 +1092,8 @@ println("TEST 48: MixtureMeasure recursion for any Functional")
 println("=" ^ 60)
 
 mix = MixtureMeasure(pm_flat.space,
-    Measure[ProductMeasure(Measure[BetaMeasure(3.0, 2.0), BetaMeasure(1.0, 1.0)]),
-            ProductMeasure(Measure[BetaMeasure(1.0, 1.0), BetaMeasure(3.0, 2.0)])],
+    Measure[ProductMeasure(Measure[wrap_in_measure(BetaPrevision(3.0, 2.0)), wrap_in_measure(BetaPrevision(1.0, 1.0))]),
+            ProductMeasure(Measure[wrap_in_measure(BetaPrevision(1.0, 1.0)), wrap_in_measure(BetaPrevision(3.0, 2.0))])],
     [log(0.75), log(0.25)])
 v = expect(mix, Projection(1))
 # 0.75 * 0.6 + 0.25 * 0.5 = 0.575
@@ -1183,8 +1185,8 @@ println("TEST 50: OpaqueClosure fallback delegates to bare-function method")
 println("=" ^ 60)
 
 # On BetaMeasure: OpaqueClosure should give same result as bare lambda (quadrature)
-bare_v = expect(BetaMeasure(3.0, 2.0), x -> x * x)
-wrap_v = expect(BetaMeasure(3.0, 2.0), OpaqueClosure(x -> x * x))
+bare_v = expect(wrap_in_measure(BetaPrevision(3.0, 2.0)), x -> x * x)
+wrap_v = expect(wrap_in_measure(BetaPrevision(3.0, 2.0)), OpaqueClosure(x -> x * x))
 @assert abs(bare_v - wrap_v) < 1e-12  "OpaqueClosure should match bare function: $bare_v vs $wrap_v"
 println("PASSED: OpaqueClosure on BetaMeasure matches bare function: ", wrap_v)
 
@@ -1201,7 +1203,7 @@ println("=" ^ 60)
 println("TEST 51: LikelihoodFamily dispatch — BetaBernoulli explicit")
 println("=" ^ 60)
 let
-    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 7, BetaMeasure(2.0, 3.0))
+    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 7, wrap_in_measure(BetaPrevision(2.0, 3.0)))
     k = Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]),
         _ -> error("not used"),
         (h, o) -> o == 1.0 ? log(max(h isa TaggedBetaMeasure ? mean(h.beta) : h, 1e-300)) :
@@ -1223,7 +1225,7 @@ println("=" ^ 60)
 println("TEST 52: LikelihoodFamily dispatch — Flat explicit")
 println("=" ^ 60)
 let
-    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 42, BetaMeasure(4.0, 6.0))
+    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 42, wrap_in_measure(BetaPrevision(4.0, 6.0)))
     k = Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]),
         _ -> error("not used"),
         (h, o) -> log(0.5);
@@ -1249,8 +1251,8 @@ let
                               log(max(1 - (h isa TaggedBetaMeasure ? mean(h.beta) : h), 1e-300));
         likelihood_family = DispatchByComponent(classify))
 
-    tbm_even = TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaMeasure(1.0, 1.0))
-    tbm_odd  = TaggedBetaMeasure(Interval(0.0, 1.0), 3, BetaMeasure(1.0, 1.0))
+    tbm_even = TaggedBetaMeasure(Interval(0.0, 1.0), 2, wrap_in_measure(BetaPrevision(1.0, 1.0)))
+    tbm_odd  = TaggedBetaMeasure(Interval(0.0, 1.0), 3, wrap_in_measure(BetaPrevision(1.0, 1.0)))
 
     post_even = condition(tbm_even, k, 1.0)
     post_odd  = condition(tbm_odd,  k, 1.0)
@@ -1267,7 +1269,7 @@ println("=" ^ 60)
 println("TEST 54: Error pin — PushOnly likelihood_family errors at condition")
 println("=" ^ 60)
 let
-    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure(1.0, 1.0))
+    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 1, wrap_in_measure(BetaPrevision(1.0, 1.0)))
     k = Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]),
         _ -> error("not used"),
         (h, o) -> 0.0;
@@ -1291,7 +1293,7 @@ let
     # classify returns another DispatchByComponent → self-reference loop
     local k_ref
     classify(m) = k_ref.likelihood_family
-    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure(1.0, 1.0))
+    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 1, wrap_in_measure(BetaPrevision(1.0, 1.0)))
     k_ref = Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]),
         _ -> error("not used"),
         (h, o) -> 0.0;
@@ -1313,7 +1315,7 @@ let
     # that routes to yet another DispatchByComponent — the mutual recursion.
     local k_ref
     classify(m) = DispatchByComponent(classify)
-    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure(1.0, 1.0))
+    tbm = TaggedBetaMeasure(Interval(0.0, 1.0), 1, wrap_in_measure(BetaPrevision(1.0, 1.0)))
     k_ref = Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]),
         _ -> error("not used"),
         (h, o) -> 0.0;
@@ -1358,8 +1360,8 @@ println("=" ^ 60)
 let
     # Regression guard: without the explicit overload, dispatch was ambiguous
     # between expect(::MixtureMeasure, ::Functional) and expect(::Measure, ::OpaqueClosure).
-    b1 = BetaMeasure(3.0, 1.0)  # mean 0.75
-    b2 = BetaMeasure(1.0, 3.0)  # mean 0.25
+    b1 = wrap_in_measure(BetaPrevision(3.0, 1.0))  # mean 0.75
+    b2 = wrap_in_measure(BetaPrevision(1.0, 3.0))  # mean 0.25
     mix = MixtureMeasure(Interval(0.0, 1.0), Measure[b1, b2], [log(0.6), log(0.4)])
 
     f = θ -> θ^2
@@ -1378,7 +1380,7 @@ let
     # For Beta(2,4), E[Identity] = 2/6 = 1/3
     # inner EU = 2·(1/3) + 3 = 11/3
     # outer EU = 5·(11/3) + 1 = 58/3
-    b = BetaMeasure(2.0, 4.0)
+    b = wrap_in_measure(BetaPrevision(2.0, 4.0))
     inner = LinearCombination(Tuple{Float64, Functional}[(2.0, Identity())], 3.0)
     outer = LinearCombination(Tuple{Float64, Functional}[(5.0, inner)], 1.0)
     got = expect(b, outer)
@@ -1407,16 +1409,16 @@ println("=" ^ 60)
 println("TEST 59: ProductMeasure factor / replace_factor round-trip (Julia level)")
 println("=" ^ 60)
 let
-    b1 = BetaMeasure(3.0, 2.0)
-    b2 = BetaMeasure(1.0, 4.0)
-    b3 = BetaMeasure(5.0, 5.0)
+    b1 = wrap_in_measure(BetaPrevision(3.0, 2.0))
+    b2 = wrap_in_measure(BetaPrevision(1.0, 4.0))
+    b3 = wrap_in_measure(BetaPrevision(5.0, 5.0))
     pm = ProductMeasure(Measure[b1, b2, b3])
 
     @assert factor(pm, 1) === b1 "factor returns same object (identity)"
     @assert factor(pm, 2) === b2
     @assert factor(pm, 3) === b3
 
-    replacement = BetaMeasure(9.0, 1.0)
+    replacement = wrap_in_measure(BetaPrevision(9.0, 1.0))
     pm2 = replace_factor(pm, 2, replacement)
     @assert pm2 !== pm "replace_factor returns a new ProductMeasure"
     @assert factor(pm2, 2) === replacement

--- a/test/test_events.jl
+++ b/test/test_events.jl
@@ -14,6 +14,8 @@ themselves.
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 
 passed = 0
 failed = 0
@@ -46,9 +48,9 @@ let
     @check "target is BOOLEAN_SPACE" k.target === BOOLEAN_SPACE
     @check "likelihood_family is Flat" k.likelihood_family isa Flat
 
-    tbm_1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure())
-    tbm_2 = TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaMeasure())
-    tbm_3 = TaggedBetaMeasure(Interval(0.0, 1.0), 3, BetaMeasure())
+    tbm_1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaPrevision(1.0, 1.0))
+    tbm_2 = TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaPrevision(1.0, 1.0))
+    tbm_3 = TaggedBetaMeasure(Interval(0.0, 1.0), 3, BetaPrevision(1.0, 1.0))
 
     @check "log_density(tag=1, true) == 0.0  [tag in fires]" k.log_density(tbm_1, true) == 0.0
     @check "log_density(tag=1, false) == -Inf [tag in fires]" k.log_density(tbm_1, false) == -Inf
@@ -68,8 +70,8 @@ let
     ki = indicator_kernel(inner)
     ko = indicator_kernel(outer)
 
-    tbm_1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure())
-    tbm_2 = TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaMeasure())
+    tbm_1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaPrevision(1.0, 1.0))
+    tbm_2 = TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaPrevision(1.0, 1.0))
 
     @check "inner holds at tag 1" ki.log_density(tbm_1, true) == 0.0
     @check "complement does not hold at tag 1" ko.log_density(tbm_1, true) == -Inf
@@ -90,7 +92,7 @@ let
     both = Conjunction(a, b)
     k = indicator_kernel(both)
 
-    tbm(t) = TaggedBetaMeasure(Interval(0.0, 1.0), t, BetaMeasure())
+    tbm(t) = TaggedBetaMeasure(Interval(0.0, 1.0), t, BetaPrevision(1.0, 1.0))
     @check "tag 1 ∈ a, ∉ b → conjunction false" k.log_density(tbm(1), true) == -Inf
     @check "tag 2 ∈ both        → conjunction true"  k.log_density(tbm(2), true) == 0.0
     @check "tag 3 ∈ both        → conjunction true"  k.log_density(tbm(3), true) == 0.0
@@ -110,7 +112,7 @@ let
     either = Disjunction(a, b)
     k = indicator_kernel(either)
 
-    tbm(t) = TaggedBetaMeasure(Interval(0.0, 1.0), t, BetaMeasure())
+    tbm(t) = TaggedBetaMeasure(Interval(0.0, 1.0), t, BetaPrevision(1.0, 1.0))
     @check "tag 1 ∈ a        → disjunction true"  k.log_density(tbm(1), true) == 0.0
     @check "tag 3 ∈ b        → disjunction true"  k.log_density(tbm(3), true) == 0.0
     @check "tag 5 ∉ either  → disjunction false" k.log_density(tbm(5), true) == -Inf
@@ -129,7 +131,7 @@ let
     lhs = indicator_kernel(Complement(Conjunction(a, b)))
     rhs = indicator_kernel(Disjunction(Complement(a), Complement(b)))
 
-    tbm(t) = TaggedBetaMeasure(Interval(0.0, 1.0), t, BetaMeasure())
+    tbm(t) = TaggedBetaMeasure(Interval(0.0, 1.0), t, BetaPrevision(1.0, 1.0))
     all_match = all(t -> lhs.log_density(tbm(t), true) == rhs.log_density(tbm(t), true), 0:5)
     @check "De Morgan identity holds on tags 0..5" all_match
 end
@@ -161,7 +163,7 @@ println("=" ^ 60)
 
 let
     sp = Interval(0.0, 1.0)
-    components = [TaggedBetaMeasure(sp, t, BetaMeasure(2.0, 3.0)) for t in 1:4]
+    components = [TaggedBetaMeasure(sp, t, wrap_in_measure(BetaPrevision(2.0, 3.0))) for t in 1:4]
     m = MixtureMeasure(sp, components, Float64[0.0, 0.0, 0.0, 0.0])
 
     posterior = condition(m, TagSet(sp, Set([1, 3])))
@@ -180,7 +182,7 @@ println("=" ^ 60)
 
 let
     sp = Interval(0.0, 1.0)
-    components = [TaggedBetaMeasure(sp, t, BetaMeasure(1.0, 1.0)) for t in 1:3]
+    components = [TaggedBetaMeasure(sp, t, wrap_in_measure(BetaPrevision(1.0, 1.0))) for t in 1:3]
     m = MixtureMeasure(sp, components, Float64[0.0, 0.0, 0.0])
 
     threw = false

--- a/test/test_flat_mixture.jl
+++ b/test/test_flat_mixture.jl
@@ -9,6 +9,8 @@ that dispatches per-component.
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 using Random
 
 Random.seed!(42)
@@ -22,7 +24,7 @@ println("=" ^ 60)
 # Grammar 2: programs that predict enemy when sensor < 0.5
 let
     # 6 Beta(1,1) priors — one per (grammar, program)
-    components = Measure[BetaMeasure(1.0, 1.0) for _ in 1:6]
+    components = Measure[wrap_in_measure(BetaPrevision(1.0, 1.0)) for _ in 1:6]
     metadata = [(1,1), (1,2), (1,3), (2,1), (2,2), (2,3)]
 
     # Prior weights: 2^(-|G|) * 2^(-|P|)
@@ -99,7 +101,7 @@ println("=" ^ 60)
 # by building a kernel closure that dispatches on component index
 let
     n_components = 6
-    components = Measure[BetaMeasure(1.0, 1.0) for _ in 1:n_components]
+    components = Measure[wrap_in_measure(BetaPrevision(1.0, 1.0)) for _ in 1:n_components]
     metadata = [(1,1), (1,2), (1,3), (2,1), (2,2), (2,3)]
 
     # Equal prior weights for this test
@@ -110,12 +112,12 @@ let
     # We simulate this by having the BetaMeasure represent program confidence
     # and using different Beta priors
     components_diff = Measure[
-        BetaMeasure(8.0, 2.0),   # G1P1: high confidence enemy
-        BetaMeasure(6.0, 4.0),   # G1P2: moderate confidence
-        BetaMeasure(3.0, 7.0),   # G1P3: predicts food (wrong)
-        BetaMeasure(2.0, 8.0),   # G2P1: predicts food (wrong)
-        BetaMeasure(4.0, 6.0),   # G2P2: moderate, slightly food
-        BetaMeasure(1.0, 1.0),   # G2P3: no information
+        wrap_in_measure(BetaPrevision(8.0, 2.0)),   # G1P1: high confidence enemy
+        wrap_in_measure(BetaPrevision(6.0, 4.0)),   # G1P2: moderate confidence
+        wrap_in_measure(BetaPrevision(3.0, 7.0)),   # G1P3: predicts food (wrong)
+        wrap_in_measure(BetaPrevision(2.0, 8.0)),   # G2P1: predicts food (wrong)
+        wrap_in_measure(BetaPrevision(4.0, 6.0)),   # G2P2: moderate, slightly food
+        wrap_in_measure(BetaPrevision(1.0, 1.0)),   # G2P3: no information
     ]
     belief_diff = MixtureMeasure(Interval(0.0, 1.0), components_diff, log_prior)
 
@@ -150,8 +152,8 @@ println("=" ^ 60)
 
 let
     # Build a MixtureMeasure of BetaMeasures
-    b1 = BetaMeasure(3.0, 1.0)  # mean 0.75 — predicts enemy
-    b2 = BetaMeasure(1.0, 3.0)  # mean 0.25 — predicts food
+    b1 = wrap_in_measure(BetaPrevision(3.0, 1.0))  # mean 0.75 — predicts enemy
+    b2 = wrap_in_measure(BetaPrevision(1.0, 3.0))  # mean 0.25 — predicts food
     mix = MixtureMeasure(Interval(0.0, 1.0), Measure[b1, b2], [log(0.6), log(0.4)])
 
     k = Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]),
@@ -176,7 +178,7 @@ let
     println("PASSED: MixtureMeasure conditioned, weights = ", [round(wi, digits=4) for wi in w])
 
     # Test nested: MixtureMeasure inside MixtureMeasure
-    outer = MixtureMeasure(Interval(0.0, 1.0), Measure[mix, BetaMeasure(5.0, 1.0)], [0.0, 0.0])
+    outer = MixtureMeasure(Interval(0.0, 1.0), Measure[mix, wrap_in_measure(BetaPrevision(5.0, 1.0))], [0.0, 0.0])
     posterior_outer = condition(outer, k, 1.0)
     @assert posterior_outer isa MixtureMeasure
     println("PASSED: Nested MixtureMeasure conditioning works, $(length(posterior_outer.components)) components")
@@ -227,13 +229,13 @@ let
 
     # Different Beta priors: G1 programs predict well, G3 poorly
     components = Measure[
-        BetaMeasure(9.0, 1.0),   # G1P1: strong enemy predictor
-        BetaMeasure(7.0, 3.0),   # G1P2: good enemy predictor
-        BetaMeasure(5.0, 5.0),   # G2P1: neutral
-        BetaMeasure(4.0, 6.0),   # G2P2: slight food
-        BetaMeasure(6.0, 4.0),   # G2P3: slight enemy
-        BetaMeasure(2.0, 8.0),   # G3P1: strong food predictor
-        BetaMeasure(1.0, 9.0),   # G3P2: very strong food predictor
+        wrap_in_measure(BetaPrevision(9.0, 1.0)),   # G1P1: strong enemy predictor
+        wrap_in_measure(BetaPrevision(7.0, 3.0)),   # G1P2: good enemy predictor
+        wrap_in_measure(BetaPrevision(5.0, 5.0)),   # G2P1: neutral
+        wrap_in_measure(BetaPrevision(4.0, 6.0)),   # G2P2: slight food
+        wrap_in_measure(BetaPrevision(6.0, 4.0)),   # G2P3: slight enemy
+        wrap_in_measure(BetaPrevision(2.0, 8.0)),   # G3P1: strong food predictor
+        wrap_in_measure(BetaPrevision(1.0, 9.0)),   # G3P2: very strong food predictor
     ]
 
     belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior)
@@ -279,10 +281,10 @@ let
     # Programs 1,2 predicates "fire" (kernel returns Beta-Bernoulli ll)
     # Programs 3,4 predicates "don't fire" (kernel returns 0.0 — flat)
     comps = Measure[
-        TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure(1.0, 1.0)),
-        TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaMeasure(1.0, 1.0)),
-        TaggedBetaMeasure(Interval(0.0, 1.0), 3, BetaMeasure(1.0, 1.0)),
-        TaggedBetaMeasure(Interval(0.0, 1.0), 4, BetaMeasure(1.0, 1.0)),
+        TaggedBetaMeasure(Interval(0.0, 1.0), 1, wrap_in_measure(BetaPrevision(1.0, 1.0))),
+        TaggedBetaMeasure(Interval(0.0, 1.0), 2, wrap_in_measure(BetaPrevision(1.0, 1.0))),
+        TaggedBetaMeasure(Interval(0.0, 1.0), 3, wrap_in_measure(BetaPrevision(1.0, 1.0))),
+        TaggedBetaMeasure(Interval(0.0, 1.0), 4, wrap_in_measure(BetaPrevision(1.0, 1.0))),
     ]
     belief = MixtureMeasure(Interval(0.0, 1.0), comps, fill(0.0, 4))
 
@@ -371,10 +373,10 @@ println("=" ^ 60)
 let
     # Same setup as TEST 6: tags 1,2 fire; tags 3,4 don't.
     comps = Measure[
-        TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure(1.0, 1.0)),
-        TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaMeasure(1.0, 1.0)),
-        TaggedBetaMeasure(Interval(0.0, 1.0), 3, BetaMeasure(1.0, 1.0)),
-        TaggedBetaMeasure(Interval(0.0, 1.0), 4, BetaMeasure(1.0, 1.0)),
+        TaggedBetaMeasure(Interval(0.0, 1.0), 1, wrap_in_measure(BetaPrevision(1.0, 1.0))),
+        TaggedBetaMeasure(Interval(0.0, 1.0), 2, wrap_in_measure(BetaPrevision(1.0, 1.0))),
+        TaggedBetaMeasure(Interval(0.0, 1.0), 3, wrap_in_measure(BetaPrevision(1.0, 1.0))),
+        TaggedBetaMeasure(Interval(0.0, 1.0), 4, wrap_in_measure(BetaPrevision(1.0, 1.0))),
     ]
     belief = MixtureMeasure(Interval(0.0, 1.0), comps, fill(0.0, 4))
 
@@ -464,7 +466,7 @@ println("=" ^ 60)
 
 let
     comps = Measure[
-        TaggedBetaMeasure(Interval(0.0, 1.0), i, BetaMeasure(1.0, 1.0)) for i in 1:4
+        TaggedBetaMeasure(Interval(0.0, 1.0), i, wrap_in_measure(BetaPrevision(1.0, 1.0))) for i in 1:4
     ]
     belief = MixtureMeasure(Interval(0.0, 1.0), comps, fill(0.0, 4))
 
@@ -501,7 +503,7 @@ println("=" ^ 60)
 
 let
     comps = Measure[
-        TaggedBetaMeasure(Interval(0.0, 1.0), i, BetaMeasure(1.0, 1.0)) for i in 1:4
+        TaggedBetaMeasure(Interval(0.0, 1.0), i, wrap_in_measure(BetaPrevision(1.0, 1.0))) for i in 1:4
     ]
     belief = MixtureMeasure(Interval(0.0, 1.0), comps, fill(0.0, 4))
 

--- a/test/test_host.jl
+++ b/test/test_host.jl
@@ -6,6 +6,8 @@
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 using Credence: condition, weights, expect, draw, prune
 using Credence: CategoricalMeasure, BetaMeasure, MixtureMeasure, ProductMeasure
 using Credence: Finite, Interval, ProductSpace, Kernel, FactorSelector, Measure
@@ -17,8 +19,8 @@ println("=" ^ 60)
 # TEST: condition(ProductMeasure, kernel_with_active_factors, obs)
 # returns MixtureMeasure of ProductMeasures with only active factor updated
 let
-    cat = CategoricalMeasure(Finite([0.0, 1.0, 2.0]))  # 3 categories
-    betas = [BetaMeasure(3.0, 2.0), BetaMeasure(5.0, 5.0), BetaMeasure(2.0, 8.0)]
+    cat = CategoricalMeasure(Finite([0.0, 1.0, 2.0]), CategoricalPrevision(fill(0.0, 3)))  # 3 categories
+    betas = [wrap_in_measure(BetaPrevision(3.0, 2.0)), wrap_in_measure(BetaPrevision(5.0, 5.0)), wrap_in_measure(BetaPrevision(2.0, 8.0))]
     prod = ProductMeasure(Measure[cat, betas...])
 
     binary = Finite([0.0, 1.0])
@@ -62,8 +64,8 @@ println("HOST TEST 2: condition(ProductMeasure) on failure observation")
 println("=" ^ 60)
 
 let
-    cat = CategoricalMeasure(Finite([0.0, 1.0]))  # 2 categories
-    betas = [BetaMeasure(4.0, 3.0), BetaMeasure(2.0, 6.0)]
+    cat = CategoricalMeasure(Finite([0.0, 1.0]), CategoricalPrevision(fill(0.0, 2)))  # 2 categories
+    betas = [wrap_in_measure(BetaPrevision(4.0, 3.0)), wrap_in_measure(BetaPrevision(2.0, 6.0))]
     prod = ProductMeasure(Measure[cat, betas...])
 
     binary = Finite([0.0, 1.0])
@@ -102,8 +104,8 @@ println("=" ^ 60)
 using Random
 let
     Random.seed!(42)
-    cat = CategoricalMeasure(Finite([0, 1]))
-    theta = BetaMeasure(2.0, 2.0)
+    cat = CategoricalMeasure(Finite([0, 1]), CategoricalPrevision(fill(0.0, 2)))
+    theta = wrap_in_measure(BetaPrevision(2.0, 2.0))
     pm = ProductMeasure(Measure[cat, theta])
 
     obs_space = Finite([0, 1])
@@ -137,7 +139,7 @@ let
         prune(MixtureMeasure(Interval(0.0, 1.0), components, log_wts))
     end
 
-    betas = Measure[BetaMeasure(3.0, 2.0), BetaMeasure(5.0, 5.0), BetaMeasure(2.0, 8.0)]
+    betas = Measure[wrap_in_measure(BetaPrevision(3.0, 2.0)), wrap_in_measure(BetaPrevision(5.0, 5.0)), wrap_in_measure(BetaPrevision(2.0, 8.0))]
     prod = ProductMeasure(betas)
     rel_state = MixtureMeasure(prod.space, Measure[prod], [0.0])
     cat_w = [0.6, 0.3, 0.1]
@@ -163,9 +165,9 @@ println("=" ^ 60)
 let
     # Simulates the update_beta_state flow:
     # MixtureMeasure of ProductMeasures, each with [categorical, Beta, Beta]
-    cat = CategoricalMeasure(Finite([0.0, 1.0]))
-    b1 = BetaMeasure(2.0, 3.0)
-    b2 = BetaMeasure(4.0, 1.0)
+    cat = CategoricalMeasure(Finite([0.0, 1.0]), CategoricalPrevision(fill(0.0, 2)))
+    b1 = wrap_in_measure(BetaPrevision(2.0, 3.0))
+    b2 = wrap_in_measure(BetaPrevision(4.0, 1.0))
     prod = ProductMeasure(Measure[cat, b1, b2])
     joint = MixtureMeasure(prod.space, Measure[prod], [0.0])
 
@@ -198,7 +200,7 @@ println("=" ^ 60)
 
 let
     function _initial_cov_state(n_categories::Int, prior_coverage::Vector{Float64}; strength::Float64=10.0)
-        factors = Measure[BetaMeasure(max(p * strength, 0.01), max((1-p) * strength, 0.01))
+        factors = Measure[wrap_in_measure(BetaPrevision(max(p * strength, 0.01), max((1-p) * strength, 0.01)))
                           for p in prior_coverage]
         prod = ProductMeasure(factors)
         MixtureMeasure(prod.space, Measure[prod], [0.0])
@@ -275,7 +277,7 @@ let
                 cat_log_post[ci] = mx + log(exp(cat_log_post[ci] - mx) + exp(lw - mx))
             end
         end
-        new_cat_belief = CategoricalMeasure(cat_belief.space, cat_log_post)
+        new_cat_belief = CategoricalMeasure(cat_belief.space, CategoricalPrevision(cat_log_post))
 
         stripped = Measure[ProductMeasure(Measure[comp.factors[2:end]...])
                            for comp in posterior.components]
@@ -285,10 +287,10 @@ let
     end
 
     # Start with coverage Beta(8,2) and Beta(6,4) for 2 categories
-    factors = Measure[BetaMeasure(8.0, 2.0), BetaMeasure(6.0, 4.0)]
+    factors = Measure[wrap_in_measure(BetaPrevision(8.0, 2.0)), wrap_in_measure(BetaPrevision(6.0, 4.0))]
     prod = ProductMeasure(factors)
     cov_state = MixtureMeasure(prod.space, Measure[prod], [0.0])
-    cat_belief = CategoricalMeasure(Finite([0.0, 1.0]))
+    cat_belief = CategoricalMeasure(Finite([0.0, 1.0]), CategoricalPrevision(fill(0.0, 2)))
 
     # Responded (obs=1.0): alpha should increase for the active category
     (new_state, _) = _update_beta_state(cov_state, cat_belief, 1.0)
@@ -329,7 +331,7 @@ let
     end
 
     # Coverage state: Beta(8,2) for cat0, Beta(6,4) for cat1
-    factors = Measure[BetaMeasure(8.0, 2.0), BetaMeasure(6.0, 4.0)]
+    factors = Measure[wrap_in_measure(BetaPrevision(8.0, 2.0)), wrap_in_measure(BetaPrevision(6.0, 4.0))]
     prod = ProductMeasure(factors)
     cov_state = MixtureMeasure(prod.space, Measure[prod], [0.0])
 

--- a/test/test_program_space.jl
+++ b/test/test_program_space.jl
@@ -8,6 +8,8 @@ compression payoff, enforcement tests. No grid-world simulation needed.
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 using Credence: expect, condition, weights, mean
 using Credence: BetaMeasure, TaggedBetaMeasure, MixtureMeasure, Finite, Interval, Kernel, Measure
 using Credence: prune, truncate
@@ -271,13 +273,13 @@ let
     kernels = CompiledKernel[]
 
     for (pi, p) in enumerate(p1)
-        push!(components, BetaMeasure(1.0, 1.0))
+        push!(components, wrap_in_measure(BetaPrevision(1.0, 1.0)))
         push!(log_prior, -g1.complexity * log(2) - p.complexity * log(2))
         push!(metadata, (g1.id, pi))
         push!(kernels, compile_kernel(p, g1, pi))
     end
     for (pi, p) in enumerate(p2)
-        push!(components, BetaMeasure(1.0, 1.0))
+        push!(components, wrap_in_measure(BetaPrevision(1.0, 1.0)))
         push!(log_prior, -g2.complexity * log(2) - p.complexity * log(2))
         push!(metadata, (g2.id, pi))
         push!(kernels, compile_kernel(p, g2, pi))
@@ -320,7 +322,7 @@ println("TEST 9: Occam's Razor — simpler programs preferred with equal predict
 println("=" ^ 60)
 
 let
-    components = Measure[BetaMeasure(5.0, 2.0) for _ in 1:6]
+    components = Measure[wrap_in_measure(BetaPrevision(5.0, 2.0)) for _ in 1:6]
     complexities = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     log_prior = [-c * log(2) for c in complexities]
 
@@ -425,7 +427,7 @@ let
     for g in grammars[1:5]
         programs = enumerate_programs(g, 3; action_space=[:a, :b])
         for (pi, p) in enumerate(programs)
-            push!(components, BetaMeasure(1.0, 1.0))
+            push!(components, wrap_in_measure(BetaPrevision(1.0, 1.0)))
             push!(log_prior, -g.complexity * log(2) - p.complexity * log(2))
             push!(metadata, (g.id, pi))
             push!(compiled, compile_kernel(p, g, pi))
@@ -670,7 +672,7 @@ let
     progs = Program[]
 
     for (pi, p) in enumerate(programs)
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, BetaMeasure(1.0, 1.0)))
+        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, wrap_in_measure(BetaPrevision(1.0, 1.0))))
         push!(log_prior, -g.complexity * log(2) - p.complexity * log(2))
         push!(meta, (g.id, pi))
         push!(ck, compile_kernel(p, g, pi))
@@ -735,7 +737,7 @@ let
         programs = enumerate_programs(g, 2; action_space=[:food, :enemy])
         for (pi, p) in enumerate(programs[1:min(3, length(programs))])
             idx += 1
-            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, BetaMeasure(1.0, 1.0)))
+            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, wrap_in_measure(BetaPrevision(1.0, 1.0))))
             push!(log_prior, grammar_weights_target[g.id])
             push!(meta, (g.id, pi))
             push!(ck, compile_kernel(p, g, pi))


### PR DESCRIPTION
## Summary

Second of four sub-PRs per \`docs/posture-4/move-4-design.md\` §2 + §5.5 (merged \`ce10339\`). Core DSL + event tests.

## Migration counts (§5.5 reporting)

Using \`grep -oE 'Measure\\(' | wc -l\` (occurrences, not lines — see **Counting-method note** below).

| File | Pre | Post | Scalar-shortcut migrations |
|---|---|---|---|
| \`test_core.jl\` | 94 | 45 | 49 |
| \`test_events.jl\` | 22 | 12 | 10 |
| \`test_flat_mixture.jl\` | 48 | 20 | 28 |
| \`test_host.jl\` | 42 | 26 | 16 |
| \`test_program_space.jl\` | 13 | 7 | 6 |
| **Total** | **219** | **110** | **109** |

Plus **cat-4 default-uniform migrations** (CategoricalMeasure(Finite) → CategoricalMeasure(Finite, CategoricalPrevision(fill(0.0, N))) — keeps the Measure wrapper but converts to Prevision-in form): **7 migrations** (5 in \`test_host.jl\`, 2 in \`test_core.jl\`).

**Total 4b migrations: 116** (109 scalar-shortcut + 7 default-uniform).
**Total 4b not-applicable: 103** (the 110 post-grep occurrences minus the 7 now in Prevision-in form).
**Ratio: 103 / 219 = 47% not-applicable** — inside §5.5's 40-55% expected band for 4b. 4a baseline was 43% (re-derived via occurrence count). Pattern amplifies cleanly.

## Counting-method note

My initial mental model used \`grep -c\` (line count), which gave 60% not-applicable for 4b — an apparent outlier prompting halt. The correction: several lines contain multiple \`Measure\\(\` hits (e.g., \`TaggedBetaMeasure(Interval, tag, BetaMeasure(...))\` — two Measure( hits on one line). \`grep -c\` undercounts migrations that reduce multiple hits on the same line. Switching to \`grep -oE | wc -l\` (occurrences) gives the correct count. All §5.5 reporting uses occurrences from 4b onward.

If a future sub-PR reports line-count numbers and the ratio looks anomalous, suspect the counting method before concluding the migration went wrong. §5.5 could use a one-line clarification of this; folded into this PR body rather than a standalone amendment.

## Migration pattern applied

Identical to 4a's pattern:
- Scalar → Measure (\`BetaMeasure(α, β)\`, \`GaussianMeasure(Euclidean, μ, σ)\`, \`GammaMeasure(PR, α, β)\`) → \`wrap_in_measure(PrevisionType(args))\`.
- Default-uniform CategoricalMeasure → 2-arg form with CategoricalPrevision.
- \`BetaMeasure()\` default inside TaggedBetaMeasure → \`BetaPrevision(1.0, 1.0)\` directly (TaggedBetaMeasure accepts either; Move 2 Phase 4 outer constructor).

## Remaining 110 occurrences categorised (§5.5)

- **Cat 1 (Measure-level composition):** ProductMeasure, MixtureMeasure — deferred to Move 5 concurrent with condition rewrite.
- **Cat 2 (Prevision-in constructors):** TaggedBetaMeasure(Interval, tag, BetaPrevision); CategoricalMeasure(Finite, CategoricalPrevision) default-uniform post-migration form.
- **Cat 3 (context-dependent):** DirichletMeasure, NormalGammaMeasure.
- **Cat 5 (particle/quadrature wrapping):** none in 4b.

## Verification

- ✅ All 5 files pass individually
- ✅ \`scripts/capture-invariance.jl --verify\`: manifests identical (modulo timestamp)
- ✅ Pragma count invariant holds (0 in these files; global stays 42)

## One-line FYI for 4b per cadence

Pattern matches 4a's; 47% not-applicable sits mid-band; no surprises. 4c and 4d proceed silently unless something anomalous surfaces.

## Test plan

- [x] Per-file tests pass
- [x] \`--verify\` passes
- [x] Pragma count invariant holds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)