### PR TITLE
Move 4 sub-PR 4c: domain apps — scalar Measure shortcuts migrated

### DIFF
--- a/test/test_email_agent.jl
+++ b/test/test_email_agent.jl
@@ -9,6 +9,8 @@ multi-user meta-learning, and meta-action EU evaluation.
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 using Credence: weights, mean, condition
 using Credence: TaggedBetaMeasure, MixtureMeasure, BetaMeasure
 using Credence: Interval, Finite, Kernel, Measure
@@ -473,7 +475,7 @@ let
     ck = CompiledKernel[]
     progs = Program[]
     for (pi, p) in enumerate(programs[1:min(20, length(programs))])
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, BetaMeasure(1.0, 1.0)))
+        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, wrap_in_measure(BetaPrevision(1.0, 1.0))))
         push!(log_prior, 0.0)
         push!(meta, (g.id, pi))
         push!(ck, compile_kernel(p, g, pi))
@@ -512,7 +514,7 @@ let
         # Simulate high observation count by using Beta(50, 50)
     end
     # Use a state where mean_observation_count is high
-    conc_comps = Measure[TaggedBetaMeasure(Interval(0.0, 1.0), i, BetaMeasure(50.0, 50.0))
+    conc_comps = Measure[TaggedBetaMeasure(Interval(0.0, 1.0), i, wrap_in_measure(BetaPrevision(50.0, 50.0)))
                          for i in 1:length(components)]
     conc_belief2 = MixtureMeasure(Interval(0.0, 1.0), conc_comps, conc_lw)
     conc_state2 = AgentState(conc_belief2, meta, ck, progs, grammar_dict, 2)
@@ -553,7 +555,7 @@ let
         programs = enumerate_programs(g, 2; action_space=DOMAIN_ACTIONS, min_log_prior=-15.0)
         for (pi, p) in enumerate(programs)
             idx += 1
-            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, BetaMeasure(1.0, 1.0)))
+            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, wrap_in_measure(BetaPrevision(1.0, 1.0))))
             push!(log_prior, -g.complexity * log(2) - p.complexity * log(2))
             push!(meta, (g.id, pi))
             push!(ck, compile_kernel(p, g, pi))
@@ -1036,7 +1038,7 @@ let
 
     for (pi, p) in enumerate(programs[1:min(30, length(programs))])
         # Use Beta(5,2) so mean≈0.71 — asymmetric, so correct/incorrect give different likelihoods
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, BetaMeasure(5.0, 2.0)))
+        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, wrap_in_measure(BetaPrevision(5.0, 2.0))))
         push!(log_prior, 0.0)
         push!(meta, (g.id, pi))
         push!(ck_list, compile_kernel(p, g, pi))

--- a/test/test_grid_world.jl
+++ b/test/test_grid_world.jl
@@ -8,6 +8,8 @@ full agent runs, regime change, meta-learning.
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 using Credence: expect, condition, weights, mean
 using Credence: BetaMeasure, TaggedBetaMeasure, MixtureMeasure, Finite, Interval, Kernel, Measure
 using Credence: prune, truncate
@@ -117,7 +119,7 @@ let
     idx = 0
     for (pi, p) in enumerate(p1)
         idx += 1
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, BetaMeasure(1.0, 1.0)))
+        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, wrap_in_measure(BetaPrevision(1.0, 1.0))))
         push!(log_prior, -g1.complexity * log(2) - p.complexity * log(2))
         push!(meta, (g1.id, pi))
         push!(ck, compile_kernel(p, g1, pi))
@@ -125,7 +127,7 @@ let
     end
     for (pi, p) in enumerate(p2)
         idx += 1
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, BetaMeasure(1.0, 1.0)))
+        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, wrap_in_measure(BetaPrevision(1.0, 1.0))))
         push!(log_prior, -g2.complexity * log(2) - p.complexity * log(2))
         push!(meta, (g2.id, pi))
         push!(ck, compile_kernel(p, g2, pi))
@@ -176,7 +178,7 @@ let
     progs = Program[]
 
     for (pi, p) in enumerate(programs)
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, BetaMeasure(1.0, 1.0)))
+        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, wrap_in_measure(BetaPrevision(1.0, 1.0))))
         push!(log_prior, -g.complexity * log(2) - p.complexity * log(2))
         push!(meta, (g.id, pi))
         push!(ck, compile_kernel(p, g, pi))
@@ -279,8 +281,8 @@ let
     @assert correct_prog !== nothing "Should find a program that predicts :enemy for red"
     @assert incorrect_prog !== nothing "Should find a program that predicts :food for red"
 
-    comp1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure(1.0, 1.0))
-    comp2 = TaggedBetaMeasure(Interval(0.0, 1.0), 2, BetaMeasure(1.0, 1.0))
+    comp1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, wrap_in_measure(BetaPrevision(1.0, 1.0)))
+    comp2 = TaggedBetaMeasure(Interval(0.0, 1.0), 2, wrap_in_measure(BetaPrevision(1.0, 1.0)))
     belief = MixtureMeasure(Interval(0.0, 1.0), Measure[comp1, comp2], [0.0, 0.0])
 
     ck_vec = [correct_prog[3], incorrect_prog[3]]

--- a/test/test_rss.jl
+++ b/test/test_rss.jl
@@ -8,6 +8,8 @@ include(joinpath(@__DIR__, "..", "apps", "julia", "rss", "host.jl"))
 
 using Dates
 using Random
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 
 passed = 0
 failed = 0
@@ -128,8 +130,8 @@ end
 # With Beta(1,1), mean=0.5=base_rate → no discrimination. Use a reliable Beta
 # to test that Plackett-Luce correctly favours programs that fire on the chosen article.
 if discriminating_idx !== nothing && wrong_idx !== nothing
-    reliable_disc = TaggedBetaMeasure(Interval(0.0, 1.0), discriminating_idx, BetaMeasure(5.0, 1.0))
-    reliable_wrong = TaggedBetaMeasure(Interval(0.0, 1.0), wrong_idx, BetaMeasure(5.0, 1.0))
+    reliable_disc = TaggedBetaMeasure(Interval(0.0, 1.0), discriminating_idx, wrap_in_measure(BetaPrevision(5.0, 1.0)))
+    reliable_wrong = TaggedBetaMeasure(Interval(0.0, 1.0), wrong_idx, wrap_in_measure(BetaPrevision(5.0, 1.0)))
 
     ll_disc = k_read.log_density(reliable_disc, 1.0)
     ll_wrong = k_read.log_density(reliable_wrong, 1.0)
@@ -152,7 +154,7 @@ k_dismiss = build_dismiss_kernel(state.compiled_kernels, fa, ts)
 # With reliable Beta, program that fires on dismissed article should be penalized more
 if discriminating_idx !== nothing
     # discriminating_idx fires on A — if A is dismissed, this is BAD
-    reliable_fires = TaggedBetaMeasure(Interval(0.0, 1.0), discriminating_idx, BetaMeasure(5.0, 1.0))
+    reliable_fires = TaggedBetaMeasure(Interval(0.0, 1.0), discriminating_idx, wrap_in_measure(BetaPrevision(5.0, 1.0)))
     ll_dismiss_fires = k_dismiss.log_density(reliable_fires, 0.0)
 
     # Find a program that doesn't fire on A
@@ -165,7 +167,7 @@ if discriminating_idx !== nothing
     end
 
     if neutral_idx !== nothing
-        reliable_neutral = TaggedBetaMeasure(Interval(0.0, 1.0), neutral_idx, BetaMeasure(5.0, 1.0))
+        reliable_neutral = TaggedBetaMeasure(Interval(0.0, 1.0), neutral_idx, wrap_in_measure(BetaPrevision(5.0, 1.0)))
         ll_dismiss_neutral = k_dismiss.log_density(reliable_neutral, 0.0)
         @check "firing program penalized more than neutral" ll_dismiss_fires < ll_dismiss_neutral
         println("  Firing program dismiss ll: $(round(ll_dismiss_fires, digits=4))")


### PR DESCRIPTION
## Summary

Third of four sub-PRs in Move 4 (test-suite Measure → Prevision migration). Migrates scalar Measure shortcuts in the three domain test files — `test_email_agent.jl`, `test_grid_world.jl`, `test_rss.jl` — to `wrap_in_measure(…Prevision(…))`.

## Scalar-shortcut migration (per §5.5 discipline)

| File | Migrated | Remaining scalar | Notes |
|------|---------:|-----------------:|-------|
| `test_email_agent.jl` | 4 | 1 (import-only) | |
| `test_grid_world.jl`  | 5 | 1 (import-only) | |
| `test_rss.jl`         | 4 | 0 | |
| **Total**             | **13** | **2** (imports) | **87% completeness** |

Word-boundary counting, `\bBetaMeasure|\bGaussianMeasure|\bGammaMeasure|\bCategoricalMeasure|\bExponentialMeasure`.

## Old-counting-method ratio — flagging out-of-band

By the original substring-matching count used for sub-PR bands, 4c is **64% not-applicable (23/36)** — outside the §5.5 4c band of **25–40%**.

Structural explanation (not a calibration miss):

- Domain apps exercise **mixture routing over tagged components** — that is the core shape of email ranking, grid-world meta-learning, and RSS preference learning.
- Of the 36 pre-migration Measure-family references: **13 scalar shortcuts** (migrated this PR), **21 TaggedBetaMeasure constructions**, **17 MixtureMeasure / `Measure[…]` parametric type uses** (the last two = 38 sites deferred).
- TaggedBetaMeasure construction sites await **Move 7** (TaggedBetaPrevision-primary construction); MixtureMeasure component-space routing awaits **Move 5** (MixturePrevision per-component spaces + `condition` rewrite).

This is the shape the Move 4 design doc's §5.5 amendment named "not-applicable — deferred to a later move" sub-category. 4a had 43 such sites (prevision unit tests); 4b had lower (core DSL tests less mixture-heavy); 4c has 38 (domains). 4d (persistence) should be close to 4a's shape.

If this is expected, the band was calibrated on 4a/4b structure rather than anticipating 4c's domain-app shape. Worth a §5.5 amendment note for the record; no code changes needed.

## Verification

- `julia test/test_email_agent.jl` — ALL EMAIL AGENT TESTS PASSED
- `julia test/test_grid_world.jl` — ALL GRID WORLD TESTS PASSED
- `julia test/test_rss.jl` — ALL TESTS PASSED (57540 checks)
- `julia test/test_{core,events,flat_mixture,host,program_space}.jl` — all pass
- `scripts/capture-invariance.jl --verify` — 6124 tuples; manifests identical mod timestamp

## Next

Sub-PR 4d (persistence) is the final Move 4 sub-PR; then Move 5 design doc opens (MixturePrevision component-space + `condition` rewrite — the pivot deferred from Move 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)