### PR TITLE
Move 4 sub-PR 4d: persistence — scalar shortcuts + CategoricalMeasure Prevision-in form

### DIFF
--- a/test/test_persistence.jl
+++ b/test/test_persistence.jl
@@ -13,6 +13,8 @@
 
 push!(LOAD_PATH, "src")
 using Credence
+using Credence: BetaPrevision, CategoricalPrevision  # Posture 4 Move 4
+using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 using Serialization
 
 function check(name, cond, detail="")
@@ -32,17 +34,17 @@ let path = tempname()
     # v3 save → load → observe
     rel_beliefs = MixtureMeasure(
         ProductSpace([Interval(0.0, 1.0), Interval(0.0, 1.0)]),
-        Measure[ProductMeasure(Measure[BetaMeasure(Interval(0.0, 1.0), 2.0, 3.0),
-                                        BetaMeasure(Interval(0.0, 1.0), 4.0, 1.0)])],
+        Measure[ProductMeasure(Measure[wrap_in_measure(BetaPrevision(2.0, 3.0)),
+                                        wrap_in_measure(BetaPrevision(4.0, 1.0))])],
         [0.0],
     )
     cov_beliefs = MixtureMeasure(
         ProductSpace([Interval(0.0, 1.0), Interval(0.0, 1.0)]),
-        Measure[ProductMeasure(Measure[BetaMeasure(Interval(0.0, 1.0), 2.0, 2.0),
-                                        BetaMeasure(Interval(0.0, 1.0), 2.0, 2.0)])],
+        Measure[ProductMeasure(Measure[wrap_in_measure(BetaPrevision(2.0, 2.0)),
+                                        wrap_in_measure(BetaPrevision(2.0, 2.0))])],
         [0.0],
     )
-    cat_belief = CategoricalMeasure(Finite([:a, :b]), [log(3.0), log(7.0)])
+    cat_belief = CategoricalMeasure(Finite([:a, :b]), CategoricalPrevision([log(3.0), log(7.0)]))
 
     save_state(path;
                rel_beliefs = rel_beliefs,


### PR DESCRIPTION
## Summary

Final sub-PR in Move 4. Migrates `test/test_persistence.jl`:

- 4 `BetaMeasure(Interval(0.0, 1.0), α, β)` → `wrap_in_measure(BetaPrevision(α, β))`
- 1 `CategoricalMeasure(Finite([...]), [logweights])` → `CategoricalMeasure(Finite([...]), CategoricalPrevision([logweights]))` per §5.2 Option A (Prevision-in 2-arg constructor).

**In-scope completeness: 5/5 = 100%**.

## Aggregate ratio — band-population mismatch (per §5.5.2)

Old aggregate count: 9/13 = **69% not-applicable**, outside §5.5's 4d band (15–35%) by 34pp.

This is the same pattern §5.5.2 (PR #59) names. `test_persistence.jl` is dominated by deep `MixtureMeasure(ProductMeasure(Beta…))` composition; the outer wrappers are Move 5 (MixturePrevision component-space) and Move 5/6 (ProductPrevision-primary) deferrals. In-scope migration ran to completion; the out-of-band aggregate is band-population mismatch, not category discovery.

## Remaining post-4d Measure references

| Site | Category | Resolved at |
|------|----------|-------------|
| 2 `MixtureMeasure(...)` constructors | composition deferral | Move 5 |
| 2 `ProductMeasure(...)` constructors | composition deferral | Move 5/6 |
| 2 `Measure[...]` parametric type uses | composition deferral | Move 5 |
| 1 `MixtureMeasure` type predicate over v3 fixture | not-applicable (loader return shape from Move-3-captured file) | retain |
| 2 `BetaMeasure` in check-name strings | not-applicable (string literal) | retain |

## Verification

- `julia test/test_persistence.jl` — ALL PERSISTENCE TESTS PASSED
- `julia --project=scripts scripts/capture-invariance.jl --verify` — 6124 tuples; ✓ Verified: manifests identical (modulo timestamp)

## Move 4 closure

This PR closes Move 4. Move 5 design doc is the next artefact — opens with §5.5.1's cadence claim as context, and inherits the not-applicable manifest from 4a/4b/4c/4d as the rewrite scope for MixturePrevision / ProductPrevision component-space + the `condition` rewrite that lands deferred in Move 2 Phase 4 pivot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)