### PR TITLE
Posture 4 Move 7: Prevision vocabulary through skin and all host files

### DIFF
--- a/apps/julia/email_agent/host.jl
+++ b/apps/julia/email_agent/host.jl
@@ -4,7 +4,7 @@
     host.jl — Host driver for the email program-space agent
 
 Orchestrates: grammar pool → program enumeration → kernel compilation →
-flat MixtureMeasure of TaggedBetaMeasures → action EU (domain + meta) →
+flat MixturePrevision of TaggedBetaPrevisions → action EU (domain + meta) →
 conditioning → repeat.
 
 Meta-actions (enumerate_more, perturb_grammar, deepen) are evaluated by
@@ -19,7 +19,7 @@ push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "src"))
 using Credence
 using Credence: expect, condition, push_measure, density, weights, mean
 using Credence: load_dsl
-using Credence: CategoricalMeasure, BetaPrevision, TaggedBetaMeasure, MixtureMeasure
+using Credence: CategoricalMeasure, BetaPrevision, TaggedBetaPrevision, MixturePrevision
 using Credence: Finite, Interval, Kernel, Measure, ProductSpace, Euclidean, PositiveReals, Space
 using Credence: prune, truncate
 using Credence: AgentState, sync_prune!, sync_truncate!
@@ -132,7 +132,7 @@ function build_predictive(
 
     for (j, comp) in enumerate(state.belief.components)
         haskey(rec_cache, j) || continue
-        tbm = comp::TaggedBetaMeasure
+        tbm = comp::TaggedBetaPrevision
         # E[θ_j] via credence's expect on the Beta component
         θ_mean = expect(tbm, identity)
         r_j = rec_cache[j]
@@ -214,7 +214,7 @@ function mean_observation_count(state::AgentState)::Float64
     isempty(state.belief.components) && return 0.0
     total = 0.0
     for comp in state.belief.components
-        tbm = comp::TaggedBetaMeasure
+        tbm = comp::TaggedBetaPrevision
         total += tbm.beta.alpha + tbm.beta.beta - 2.0  # credence-lint: allow — precedent:expect-through-accessor — pseudo-count sum (α+β−2) has no stdlib function
     end
     total / length(state.belief.components)
@@ -328,7 +328,7 @@ function compute_eu(
     for (j, comp) in enumerate(state.belief.components)
         haskey(rec_cache, j) || continue
         rec_cache[j] == action || continue
-        tbm = comp::TaggedBetaMeasure
+        tbm = comp::TaggedBetaPrevision
         w = component_weights[j]
         θ = mean(tbm.beta)
         weighted_eu += w * (θ * u_c + (1.0 - θ) * u_w)
@@ -356,7 +356,7 @@ The hand-rolled posterior iteration that previously lived here is
 now done inside the axiom layer — `_predictive_ll` propagates the
 indicator kernel's 0 / -Inf log-density as the weight multiplier,
 non-firing components drop to zero in the conditioned mixture, and
-`expect(MixtureMeasure, Identity)` aggregates. Semantically
+`expect(MixturePrevision, Identity)` aggregates. Semantically
 identical to the former hand-rolled `Σ w_j · mean(β_j) / Σ w_j` for
 firing components; numerically identical modulo reordered arithmetic.
 """
@@ -374,7 +374,7 @@ function compute_eu_primitive(
     fires = Set{Int}(j for (j, rec) in pairs(rec_cache) if rec == action)
     isempty(fires) && return 0.5  # domain base-rate when no program recommends
 
-    restricted = condition(state.belief, TagSet(state.belief.space, fires))
+    restricted = condition(state.belief, TagSet(Interval(0.0, 1.0), fires))
     expect(restricted, Identity())
 end
 
@@ -498,7 +498,7 @@ function build_email_observation_kernel(
     Kernel(Interval(0.0, 1.0), obs_space,
         _ -> error("generate not used in condition"),
         (m_or_θ, obs) -> begin
-            if m_or_θ isa TaggedBetaMeasure
+            if m_or_θ isa TaggedBetaPrevision
                 tag = m_or_θ.tag
                 recommended = get!(recommendation_cache, tag) do
                     ck = compiled_kernels[tag]
@@ -540,7 +540,7 @@ function build_step_kernel(
     Kernel(Interval(0.0, 1.0), obs_space,
         _ -> error("generate not used in condition"),
         (m_or_θ, obs) -> begin
-            if m_or_θ isa TaggedBetaMeasure
+            if m_or_θ isa TaggedBetaPrevision
                 tag = m_or_θ.tag
                 recommended = get(rec_cache, tag, :done)
                 correct = recommended in correct_actions
@@ -746,7 +746,7 @@ function run_agent(;
     end
 
     # Enumerate all (grammar, predicate, action) triples
-    components = Measure[]
+    components = Any[]
     log_prior_weights = Float64[]
     metadata = Tuple{Int, Int}[]
     compiled_kernels = CompiledKernel[]
@@ -759,7 +759,7 @@ function run_agent(;
                                        min_log_prior=min_log_prior)
         for (pi, p) in enumerate(programs)
             idx += 1
-            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, BetaPrevision(1.0, 1.0)))
+            push!(components, TaggedBetaPrevision(idx, BetaPrevision(1.0, 1.0)))
             lw = -g.complexity * log(2) - p.complexity * log(2)
             push!(log_prior_weights, lw)
             push!(metadata, (g.id, pi))
@@ -773,7 +773,7 @@ function run_agent(;
         println("Grammars: $(length(grammar_pool))")
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior_weights)
+    belief = MixturePrevision(components, log_prior_weights)
     grammar_dict = Dict{Int, Grammar}(g.id => g for g in grammar_pool)
     state = AgentState(belief, metadata, compiled_kernels, all_programs,
                        grammar_dict, program_max_depth)

--- a/apps/julia/email_agent/state_persistence.jl
+++ b/apps/julia/email_agent/state_persistence.jl
@@ -8,7 +8,7 @@ CostModel beliefs (NormalGammaMeasures) are fully serializable.
 """
 
 using Serialization
-using Credence: MixtureMeasure, TaggedBetaMeasure, Interval, Measure
+using Credence: MixturePrevision, TaggedBetaPrevision
 using Credence: NormalGammaMeasure
 using Credence: Grammar, Program, CompiledKernel, AgentState
 using Credence: compile_kernel
@@ -76,12 +76,11 @@ function load_email_state(filepath::String)
     n = length(alphas)
 
     # Reconstruct belief
-    components = Measure[
-        TaggedBetaMeasure(Interval(0.0, 1.0), i,
-            Credence.Ontology.BetaPrevision(alphas[i], betas[i]))
+    components = [
+        TaggedBetaPrevision(i, Credence.Ontology.BetaPrevision(alphas[i], betas[i]))
         for i in 1:n
     ]
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_weights)
+    belief = MixturePrevision(components, log_weights)
 
     # Recompile kernels from ASTs
     compiled_kernels = CompiledKernel[

--- a/apps/julia/grid_world/host.jl
+++ b/apps/julia/grid_world/host.jl
@@ -4,7 +4,7 @@
     host.jl — Host driver for the grid-world program-space agent
 
 Orchestrates: grammar pool → program enumeration → kernel compilation →
-flat MixtureMeasure of TaggedBetaMeasures → DSL inference → action selection →
+flat MixturePrevision of TaggedBetaPrevisions → DSL inference → action selection →
 world step → repeat.
 
 Meta-actions (enumerate_more, perturb_grammar, deepen) are evaluated before
@@ -18,7 +18,7 @@ Tier 3: grid-world-specific. Uses Tier 1 (Credence DSL) and Tier 2
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "src"))
 using Credence
 using Credence: expect, condition, draw, optimise, value, weights, mean
-using Credence: CategoricalMeasure, BetaPrevision, TaggedBetaMeasure, MixtureMeasure
+using Credence: CategoricalMeasure, BetaPrevision, TaggedBetaPrevision, MixturePrevision
 using Credence: Finite, Interval, Kernel, Measure
 using Credence: density, log_density_at, prune, truncate
 using Credence: AgentState, sync_prune!, sync_truncate!
@@ -53,7 +53,7 @@ const GW_DEEPEN_COST = 0.10
     build_observation_kernel(compiled_kernels, features, temporal_state, true_type)
 
 Build a single Kernel whose log_density dispatches per-component via
-TaggedBetaMeasure tags. Each program evaluates features → recommends an
+TaggedBetaPrevision tags. Each program evaluates features → recommends an
 action symbol (:food or :enemy). Recommendation is compared to true_type.
 
 Populates a correct_cache in kernel params for per-component Beta update
@@ -72,7 +72,7 @@ function build_observation_kernel(
     Kernel(Interval(0.0, 1.0), obs_space,
         _ -> error("generate not used in condition"),
         (m_or_θ, obs) -> begin
-            if m_or_θ isa TaggedBetaMeasure
+            if m_or_θ isa TaggedBetaPrevision
                 tag = m_or_θ.tag
                 recommended = get!(recommendation_cache, tag) do
                     ck = compiled_kernels[tag]
@@ -101,7 +101,7 @@ Estimate P(enemy) from program recommendations weighted by posterior confidence,
 then compute EU of interacting: P(enemy)*(-5) + P(food)*(+5).
 """
 function compute_eu_interact(
-    belief::MixtureMeasure,
+    belief::MixturePrevision,
     compiled_kernels::Vector{CompiledKernel},
     features::Dict{Symbol, Float64},
     temporal_state::Dict{Symbol, Any}
@@ -144,7 +144,7 @@ function mean_observation_count_gw(state::AgentState)::Float64
     isempty(state.belief.components) && return 0.0
     total = 0.0
     for comp in state.belief.components
-        tbm = comp::TaggedBetaMeasure
+        tbm = comp::TaggedBetaPrevision
         total += tbm.beta.alpha + tbm.beta.beta - 2.0  # credence-lint: allow — precedent:expect-through-accessor — pseudo-count sum (α+β−2) has no stdlib function
     end
     total / length(state.belief.components)
@@ -261,7 +261,7 @@ function run_agent(;
     end
 
     # Enumerate all (grammar, program) pairs
-    components = Measure[]
+    components = Any[]
     log_prior_weights = Float64[]
     metadata = Tuple{Int, Int}[]
     compiled_kernels = CompiledKernel[]
@@ -272,7 +272,7 @@ function run_agent(;
         programs = enumerate_programs(g, program_max_depth; include_temporal, action_space=[:food, :enemy])
         for (pi, p) in enumerate(programs)
             idx += 1
-            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, BetaPrevision(1.0, 1.0)))
+            push!(components, TaggedBetaPrevision(idx, BetaPrevision(1.0, 1.0)))
             lw = -g.complexity * log(2) - p.complexity * log(2)
             push!(log_prior_weights, lw)
             push!(metadata, (g.id, pi))
@@ -286,7 +286,7 @@ function run_agent(;
         println("Grammars: $(length(grammar_pool))")
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior_weights)
+    belief = MixturePrevision(components, log_prior_weights)
     grammar_dict = Dict{Int, Grammar}(g.id => g for g in grammar_pool)
     state = AgentState(belief, metadata, compiled_kernels, all_programs,
                        grammar_dict, program_max_depth)

--- a/apps/julia/rss/host.jl
+++ b/apps/julia/rss/host.jl
@@ -16,7 +16,7 @@
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "src"))
 using Credence
 using Credence: expect, condition, draw, weights, mean, logsumexp
-using Credence: CategoricalMeasure, BetaPrevision, TaggedBetaMeasure, MixtureMeasure
+using Credence: CategoricalMeasure, BetaPrevision, TaggedBetaPrevision, MixturePrevision
 using Credence: Finite, Interval, Kernel, Measure
 using Credence: FiringByTag, BetaBernoulli, Flat
 using Credence: AgentState, sync_prune!, sync_truncate!
@@ -40,7 +40,7 @@ using Dates
     init_rss_agent(feeds, categories, known_tags; ...) → (AgentState, FeatureRegistry)
 
 Build the initial agent state: feature registry, seed grammars, enumerated
-programs, flat MixtureMeasure of TaggedBetaMeasures.
+programs, flat MixturePrevision of TaggedBetaPrevisions.
 """
 function init_rss_agent(;
     feeds::Vector{Tuple{Int, String}},
@@ -55,7 +55,7 @@ function init_rss_agent(;
 
     verbose && println("Generated $(length(grammar_pool)) seed grammars, $(length(reg.feature_set)) features")
 
-    components = Measure[]
+    components = Any[]
     log_prior_weights = Float64[]
     metadata = Tuple{Int, Int}[]
     compiled_kernels = CompiledKernel[]
@@ -68,7 +68,7 @@ function init_rss_agent(;
                                        min_log_prior = min_log_prior)
         for (pi, p) in enumerate(programs)
             idx += 1
-            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, BetaPrevision(1.0, 1.0)))
+            push!(components, TaggedBetaPrevision(idx, BetaPrevision(1.0, 1.0)))
             lw = -g.complexity * log(2) - p.complexity * log(2)
             push!(log_prior_weights, lw)
             push!(metadata, (g.id, pi))
@@ -79,7 +79,7 @@ function init_rss_agent(;
 
     verbose && println("Total programs: $(length(components))")
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior_weights)
+    belief = MixturePrevision(components, log_prior_weights)
     grammar_dict = Dict{Int, Grammar}(g.id => g for g in grammar_pool)
     state = AgentState(belief, metadata, compiled_kernels, all_programs,
                        grammar_dict, program_max_depth)
@@ -122,7 +122,7 @@ function build_read_kernel(
     Kernel(Interval(0.0, 1.0), obs_space,
         _ -> error("generate not used"),
         (m_or_θ, obs) -> begin
-            if m_or_θ isa TaggedBetaMeasure
+            if m_or_θ isa TaggedBetaPrevision
                 tag = m_or_θ.tag
                 p = mean(m_or_θ.beta)
                 ck = compiled_kernels[tag]
@@ -170,7 +170,7 @@ function build_dismiss_kernel(
     Kernel(Interval(0.0, 1.0), obs_space,
         _ -> error("generate not used"),
         (m_or_θ, obs) -> begin
-            if m_or_θ isa TaggedBetaMeasure
+            if m_or_θ isa TaggedBetaPrevision
                 tag = m_or_θ.tag
                 fires = tag in fires_set
                 p = mean(m_or_θ.beta)
@@ -277,7 +277,7 @@ function rank_articles(
     for (entry_id, features) in article_features
         score = 0.0
         for (j, comp) in enumerate(state.belief.components)
-            tbm = comp::TaggedBetaMeasure
+            tbm = comp::TaggedBetaPrevision
             fires = state.compiled_kernels[j].evaluate(features, temporal_state) == :match
             p = mean(tbm.beta)
             score += w[j] * (fires ? p : 0.5)  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -17,9 +17,11 @@ using Credence: expect, condition, push_measure, draw, density
 using Credence: Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
 using Credence: _dispatch_path
 using Credence: weights, mean, variance, prune, truncate, logsumexp
-using Credence: CategoricalMeasure, BetaMeasure, TaggedBetaMeasure
-using Credence: GaussianMeasure, GammaMeasure, DirichletMeasure
-using Credence: NormalGammaMeasure, ProductMeasure, MixtureMeasure
+using Credence: CategoricalMeasure, ProductMeasure, MixtureMeasure
+using Credence: Prevision
+using Credence: BetaPrevision, TaggedBetaPrevision, GaussianPrevision
+using Credence: GammaPrevision, DirichletPrevision, NormalGammaPrevision
+using Credence: ProductPrevision, MixturePrevision, CategoricalPrevision
 using Credence: Finite, Interval, ProductSpace, Euclidean, PositiveReals, Simplex
 using Credence: Kernel, FactorSelector, support
 using Credence: Functional, Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure
@@ -143,8 +145,43 @@ function build_space(spec)
 end
 
 # ═══════════════════════════════════════
-# Measure construction from spec
+# State construction from spec
 # ═══════════════════════════════════════
+
+function build_prevision(spec)
+    t = spec["type"]
+    if t == "categorical"
+        space = build_space(spec["space"])
+        if haskey(spec, "log_weights")
+            CategoricalMeasure(space, collect(Float64, spec["log_weights"]))
+        else
+            CategoricalMeasure(space)
+        end
+    elseif t == "beta"
+        BetaPrevision(Float64(spec["alpha"]), Float64(spec["beta"]))
+    elseif t == "tagged_beta"
+        TaggedBetaPrevision(Int(spec["tag"]),
+                            BetaPrevision(Float64(spec["alpha"]), Float64(spec["beta"])))
+    elseif t == "gaussian"
+        GaussianPrevision(Float64(spec["mu"]), Float64(spec["sigma"]))
+    elseif t == "gamma"
+        GammaPrevision(Float64(spec["alpha"]), Float64(spec["beta"]))
+    elseif t == "dirichlet"
+        DirichletPrevision(collect(Float64, spec["alpha"]))
+    elseif t == "normal_gamma"
+        NormalGammaPrevision(Float64(spec["kappa"]), Float64(spec["mu"]),
+                             Float64(spec["alpha"]), Float64(spec["beta"]))
+    elseif t == "product"
+        factors = [build_measure(f) for f in spec["factors"]]
+        ProductMeasure(factors)
+    elseif t == "mixture"
+        components = [build_prevision(c) for c in spec["components"]]
+        lw = collect(Float64, spec["log_weights"])
+        MixturePrevision(components, lw)
+    else
+        error("unknown type: $t")
+    end
+end
 
 function build_measure(spec)
     t = spec["type"]
@@ -238,7 +275,7 @@ function build_kernel(spec, state_id::Union{String, Nothing}=nothing)
         Kernel(Interval(0.0, 1.0), obs_space,
             _ -> error("generate not used"),
             (m_or_θ, obs) -> begin
-                if m_or_θ isa TaggedBetaMeasure
+                if m_or_θ isa TaggedBetaPrevision
                     tag = m_or_θ.tag
                     recommended = get!(recommendation_cache, tag) do
                         ck = state.compiled_kernels[tag]
@@ -583,57 +620,38 @@ function handle_create_state(params)
             push!(grammar_pool, g)
         end
 
-        # Initialize empty AgentState
-        belief = MixtureMeasure(Interval(0.0, 1.0),
-            Measure[TaggedBetaMeasure(Interval(0.0, 1.0), 1, BetaMeasure())],
-            [0.0])
-        state = AgentState(belief,
-            Tuple{Int,Int}[(0, 0)],
-            CompiledKernel[],
-            Program[],
-            Dict{Int, Grammar}(),
-            max_depth)
+        # Build components from grammars
+        all_components = Any[]
+        all_lw = Float64[]
+        all_meta = Tuple{Int,Int}[]
+        all_ck = CompiledKernel[]
+        all_progs = Program[]
 
-        # Enumerate from each grammar
-        # First, fix the placeholder: remove the dummy component
-        state.belief = MixtureMeasure(Interval(0.0, 1.0),
-            Measure[], Float64[])
-
-        # Re-initialize properly after enumeration
-        total_added = 0
         for g in grammar_pool
-            state.grammars[g.id] = g
-            # Can't use add_programs_to_state! on empty state, so build manually
             programs = enumerate_programs(g, max_depth;
                 action_space=action_space, min_log_prior=-20.0)
             for (pi, p) in enumerate(programs)
-                tag = length(state.compiled_kernels) + 1
-                push!(state.belief.components,
-                    TaggedBetaMeasure(Interval(0.0, 1.0), tag, BetaMeasure()))
-                lw = -g.complexity * log(2) - p.complexity * log(2)
-                push!(state.belief.log_weights, lw)  # credence-lint: allow — precedent:expect-through-accessor — MixtureMeasure construction: appending log-weight for new component
-                push!(state.metadata, (g.id, pi))
-                push!(state.compiled_kernels, compile_kernel(p, g, pi))
-                push!(state.all_programs, p)
-                total_added += 1
+                tag = length(all_ck) + 1
+                push!(all_components, TaggedBetaPrevision(tag, BetaPrevision(1.0, 1.0)))
+                push!(all_lw, -g.complexity * log(2) - p.complexity * log(2))
+                push!(all_meta, (g.id, pi))
+                push!(all_ck, compile_kernel(p, g, pi))
+                push!(all_progs, p)
             end
         end
 
-        # Normalize weights
-        # credence-lint: allow — precedent:expect-through-accessor — MixtureMeasure reconstruction from existing components and log-weights
-        if !isempty(state.belief.log_weights)
-            state.belief = MixtureMeasure(Interval(0.0, 1.0),
-                state.belief.components, state.belief.log_weights)  # credence-lint: allow — precedent:expect-through-accessor — MixtureMeasure reconstruction
-        end
+        belief = MixturePrevision(all_components, all_lw)
+        grammar_dict = Dict{Int, Grammar}(g.id => g for g in grammar_pool)
+        state = AgentState(belief, all_meta, all_ck, all_progs, grammar_dict, max_depth)
 
         id = register_state(state)
         Dict("state_id" => id, "n_components" => length(state.belief.components))
     else
-        measure = build_measure(params)
-        id = register_state(measure)
+        state = build_prevision(params)
+        id = register_state(state)
         result = Dict{String, Any}("state_id" => id)
-        if measure isa MixtureMeasure
-            result["n_components"] = length(measure.components)
+        if state isa MixturePrevision || state isa MixtureMeasure
+            result["n_components"] = length(state.components)
         end
         result
     end
@@ -665,7 +683,8 @@ end
 function handle_factor(params)
     id = string(params["state_id"])
     state = get_state(id)
-    state isa ProductMeasure || error("factor requires a ProductMeasure, got $(typeof(state))")
+    state isa ProductMeasure || state isa ProductPrevision ||
+        error("factor requires a ProductMeasure or ProductPrevision, got $(typeof(state))")
     idx = Int(params["index"]) + 1  # 0-based → 1-based
     1 <= idx <= length(state.factors) || error("factor index out of range: $(idx-1)")
     new_id = register_state(factor(state, idx))
@@ -675,12 +694,15 @@ end
 function handle_replace_factor(params)
     id = string(params["state_id"])
     state = get_state(id)
-    state isa ProductMeasure || error("replace_factor requires a ProductMeasure, got $(typeof(state))")
+    state isa ProductMeasure || state isa ProductPrevision ||
+        error("replace_factor requires a ProductMeasure or ProductPrevision, got $(typeof(state))")
     idx = Int(params["index"]) + 1
     1 <= idx <= length(state.factors) || error("replace_factor index out of range: $(idx-1)")
     new_factor_id = string(params["new_factor_id"])
     new_factor = get_state(new_factor_id)
-    new_factor isa Measure || error("replace_factor new factor must be a Measure, got $(typeof(new_factor))")
+    if state isa ProductMeasure && new_factor isa Prevision
+        new_factor = wrap_in_measure(new_factor)
+    end
     new_state = replace_factor(state, idx, new_factor)
     new_id = register_state(new_state)
     Dict("state_id" => new_id)
@@ -689,7 +711,8 @@ end
 function handle_n_factors(params)
     id = string(params["state_id"])
     state = get_state(id)
-    state isa ProductMeasure || error("n_factors requires a ProductMeasure, got $(typeof(state))")
+    state isa ProductMeasure || state isa ProductPrevision ||
+        error("n_factors requires a ProductMeasure or ProductPrevision, got $(typeof(state))")
     Dict("n_factors" => length(state.factors))
 end
 
@@ -701,14 +724,15 @@ end
 # would fall through to particle and produce correct values for the wrong
 # reason without this hook.
 #
-# Accepts a Measure state; the shield forwards to the prevision-level
+# Accepts a Prevision or Measure state; forwards to the prevision-level
 # `_dispatch_path` declared in src/prevision.jl.
 
 function handle_dispatch_path(params)
     id = string(params["state_id"])
     state = get_state(id)
     kernel = build_kernel(params["kernel"])
-    path = _dispatch_path(state.prevision, kernel)
+    p = state isa Prevision ? state : state.prevision
+    path = _dispatch_path(p, kernel)
     Dict("path" => string(path))
 end
 
@@ -1106,10 +1130,10 @@ function handle_eu_interact(params)
         # p(rec is correct) = mean_j, p(rec is wrong) = 1 - mean_j
         for (label, _) in rewards
             p_label = if rec == label
-                w[j] * mean_j  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch
+                w[j] * mean_j  # credence-lint: allow — precedent:posterior-iteration — per-component compiled-kernel dispatch; reducible via per-component-dispatch Functional (post-Posture-4)
             else
                 # If there are only 2 labels, the other gets 1-mean_j
-                w[j] * (1.0 - mean_j) / max(length(rewards) - 1, 1)  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch
+                w[j] * (1.0 - mean_j) / max(length(rewards) - 1, 1)  # credence-lint: allow — precedent:posterior-iteration — per-component compiled-kernel dispatch; reducible via per-component-dispatch Functional (post-Posture-4)
             end
             label_probs[label] = get(label_probs, label, 0.0) + p_label
         end

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -721,7 +721,8 @@ def test_particle_snapshot():
         w_after = skin.weights(sid2)
         # Round-trip should preserve exact weights (Julia Serialization is
         # bit-exact for Float64 Vectors; JSON-RPC base64 is lossless).
-        assert w_after == w_before, \  # credence-lint: allow — precedent:test-oracle — no-op condition preserves bit-exact weights
+        # credence-lint: allow — precedent:test-oracle — no-op condition preserves bit-exact weights
+        assert w_after == w_before, \
             f"particle-path snapshot round-trip drifted: weights not ==; " \
             f"sums before={sum_before:.12f} after={sum(w_after):.12f}"  # credence-lint: allow — precedent:test-oracle — diagnostic message reports sum on no-op
 
@@ -835,7 +836,8 @@ def test_event_kernel_equivalence():
         skin.condition_on_event(sid_kernel, event={"type": "tag_set", "tags": [1, 3]})
         w_kernel = skin.weights(sid_kernel)
 
-        assert w_event == w_kernel, \  # credence-lint: allow — precedent:test-oracle — event-form and parametric-form condition agree exactly (DLRS Prop. 4.9)
+        # credence-lint: allow — precedent:test-oracle — event-form and parametric-form condition agree exactly (DLRS Prop. 4.9)
+        assert w_event == w_kernel, \
             f"event-form results diverged across identical states:\n" \
             f"  A: {w_event}\n  B: {w_kernel}"
 

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -425,10 +425,8 @@ wrap_in_measure(p::DirichletPrevision) = error(
     "wrap_in_measure(::DirichletPrevision) requires Simplex+Finite space context; " *
     "construct DirichletMeasure(space, categories, p.alpha) explicitly."
 )
-wrap_in_measure(p::NormalGammaPrevision) = error(
-    "wrap_in_measure(::NormalGammaPrevision) requires ProductSpace context; " *
-    "construct NormalGammaMeasure(space, p.κ, p.μ, p.α, p.β) explicitly."
-)
+wrap_in_measure(p::NormalGammaPrevision) =
+    NormalGammaMeasure(p.κ, p.μ, p.α, p.β)
 
 # ================================================================
 # TYPE 4: Event (extracted to events.jl)
@@ -584,6 +582,8 @@ expect(p::BetaPrevision, ::Identity) = p.alpha / (p.alpha + p.beta)
 expect(p::TaggedBetaPrevision, ::Identity) = expect(p.beta, Identity())
 expect(p::GaussianPrevision, ::Identity) = p.mu
 expect(p::GammaPrevision, ::Identity) = p.alpha / p.beta
+expect(p::DirichletPrevision, ::Identity) = p.alpha ./ sum(p.alpha)
+expect(p::NormalGammaPrevision, ::Identity) = p.μ
 
 # General-function expect on scalar Previsions via quadrature/delegation.
 function expect(p::BetaPrevision, f::Function; n::Int=64)
@@ -983,6 +983,14 @@ end
 
 function log_predictive(p::Prevision, k::Kernel, obs)
     log_predictive(wrap_in_measure(p), k, obs)
+end
+
+function log_predictive(p::DirichletPrevision, k::Kernel, obs)
+    lf = k.likelihood_family
+    lf isa Categorical || error("DirichletPrevision log_predictive requires Categorical kernel, got $(typeof(lf))")
+    idx = findfirst(==(obs), lf.categories.values)
+    idx !== nothing || error("observation $obs not in categories")
+    log(p.alpha[idx] / sum(p.alpha))
 end
 
 function log_predictive(m::DirichletMeasure, k::Kernel, obs)

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1136,12 +1136,12 @@ end
 function condition(p::MixturePrevision, e::TagSet)
     new_lws = copy(p.log_weights)
     for (i, comp) in enumerate(p.components)
-        if comp isa TaggedBetaMeasure
+        if comp isa TaggedBetaMeasure || comp isa TaggedBetaPrevision
             if !(comp.tag in e.tags)
                 new_lws[i] = -Inf
             end
         else
-            error("condition(::MixturePrevision, ::TagSet): expected TaggedBetaMeasure components; got $(typeof(comp)) at index $i")
+            error("condition(::MixturePrevision, ::TagSet): expected Tagged component; got $(typeof(comp)) at index $i")
         end
     end
     MixturePrevision(p.components, new_lws)

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -797,6 +797,66 @@ function condition(m::GammaMeasure, k::Kernel, observation)
     _condition_particle(m, k, observation)
 end
 
+# ── Prevision-level scalar condition methods (Move 7: Move 5 completion) ──
+
+function condition(p::BetaPrevision, k::Kernel, observation)
+    cp = maybe_conjugate(p, k)
+    if cp !== nothing
+        return update(cp, observation).prior
+    end
+    conditioned = condition(wrap_in_measure(p), k, observation)
+    conditioned.prevision
+end
+
+function condition(p::TaggedBetaPrevision, k::Kernel, observation)
+    fam = _resolve_likelihood_family(k.likelihood_family, p)
+    resolved_k = _with_resolved_family(k, fam)
+    k.log_density(p, observation)
+    new_beta = condition(p.beta, resolved_k, observation)
+    TaggedBetaPrevision(p.tag, new_beta)
+end
+
+function condition(p::GaussianPrevision, k::Kernel, observation)
+    cp = maybe_conjugate(p, k)
+    if cp !== nothing
+        return update(cp, observation).prior
+    end
+    conditioned = condition(wrap_in_measure(p), k, observation)
+    conditioned.prevision
+end
+
+function condition(p::GammaPrevision, k::Kernel, observation)
+    cp = maybe_conjugate(p, k)
+    if cp !== nothing
+        return update(cp, observation).prior
+    end
+    conditioned = condition(wrap_in_measure(p), k, observation)
+    conditioned.prevision
+end
+
+function condition(p::DirichletPrevision, k::Kernel, observation)
+    cp = maybe_conjugate(p, k)
+    if cp !== nothing
+        return update(cp, observation).prior
+    end
+    error("condition(::DirichletPrevision, ...) non-conjugate fallback requires " *
+          "categories/space context; use DirichletMeasure for non-conjugate kernels")
+end
+
+function condition(p::NormalGammaPrevision, k::Kernel, observation)
+    cp = maybe_conjugate(p, k)
+    if cp !== nothing
+        return update(cp, observation).prior
+    end
+    error("condition(::NormalGammaPrevision, ...) non-conjugate fallback requires " *
+          "space context; use NormalGammaMeasure for non-conjugate kernels")
+end
+
+function condition(p::ProductPrevision, k::Kernel, obs; kwargs...)
+    conditioned = condition(wrap_in_measure(p), k, obs; kwargs...)
+    conditioned isa MixtureMeasure ? conditioned.prevision : conditioned.prevision
+end
+
 function _condition_by_grid(m::BetaMeasure, k::Kernel, observation; n::Int=64)
     grid = collect(range(m.space.lo + 1e-10, m.space.hi - 1e-10, length=n))
     logw = Float64[]
@@ -896,11 +956,33 @@ function _predictive_ll(m::Measure, k::Kernel, obs; n_samples::Int=200)
     log(max(total / n_samples, 1e-300))
 end
 
+# ── Prevision-level _predictive_ll (Move 7: supports MixturePrevision condition) ──
+
+_predictive_ll(p::BetaPrevision, k::Kernel, obs) =
+    _predictive_ll(wrap_in_measure(p), k, obs)
+
+_predictive_ll(p::TaggedBetaPrevision, k::Kernel, obs) =
+    k.log_density(p, obs)
+
+_predictive_ll(p::GaussianPrevision, k::Kernel, obs) =
+    _predictive_ll(wrap_in_measure(p), k, obs)
+
+_predictive_ll(p::GammaPrevision, k::Kernel, obs) =
+    _predictive_ll(wrap_in_measure(p), k, obs)
+
+function _predictive_ll(p::Prevision, k::Kernel, obs)
+    _predictive_ll(wrap_in_measure(p), k, obs)
+end
+
 # ── log_predictive: log P(obs | beliefs) — single observation ──
 
 function log_predictive(m::Measure, k::Kernel, obs)
     pred = expect(m, h -> exp(density(k, h, obs)))
     log(max(pred, 1e-300))
+end
+
+function log_predictive(p::Prevision, k::Kernel, obs)
+    log_predictive(wrap_in_measure(p), k, obs)
 end
 
 function log_predictive(m::DirichletMeasure, k::Kernel, obs)
@@ -914,13 +996,13 @@ function log_predictive(m::CategoricalMeasure, k::Kernel, obs)
 end
 
 function condition(p::MixturePrevision, k::Kernel, obs)
-    new_components = Measure[]
+    new_components = Any[]
     new_log_wts = Float64[]
     for (i, comp) in enumerate(p.components)
         pred_ll = _predictive_ll(comp, k, obs)
         conditioned = condition(comp, k, obs)
         base_lw = p.log_weights[i] + pred_ll
-        if conditioned isa MixtureMeasure
+        if conditioned isa MixtureMeasure || conditioned isa MixturePrevision
             for (j, sub) in enumerate(conditioned.components)
                 push!(new_components, sub)
                 push!(new_log_wts, base_lw + conditioned.log_weights[j])
@@ -930,12 +1012,12 @@ function condition(p::MixturePrevision, k::Kernel, obs)
             push!(new_log_wts, base_lw)
         end
     end
-    MixturePrevision(Vector{Measure}(new_components), new_log_wts)
+    MixturePrevision(new_components, new_log_wts)
 end
 
 function condition(m::MixtureMeasure, k::Kernel, obs)
     new_p = condition(m.prevision, k, obs)
-    MixtureMeasure(m.space, new_p.components, new_p.log_weights)
+    MixtureMeasure(m.space, Vector{Measure}(new_p.components), new_p.log_weights)
 end
 
 function _dispatch_path(p::MixturePrevision, k::Kernel)
@@ -948,6 +1030,18 @@ function _dispatch_path(p::MixturePrevision, k::Kernel)
 end
 
 _dispatch_path(m::MixtureMeasure, k::Kernel) = _dispatch_path(m.prevision, k)
+
+function _dispatch_path(p::Prevision, k::Kernel)
+    maybe_conjugate(p, k) !== nothing ? :conjugate : :particle
+end
+
+factor(p::ProductPrevision, i::Int) = p.factors[i]
+
+function replace_factor(p::ProductPrevision, i::Int, new_factor)
+    new_factors = [f for f in p.factors]
+    new_factors[i] = new_factor
+    ProductPrevision(new_factors)
+end
 
 function decompose(p::ExchangeablePrevision)
     p.prior_on_components isa DirichletPrevision ||

--- a/src/program_space/agent_state.jl
+++ b/src/program_space/agent_state.jl
@@ -1,18 +1,9 @@
 """
     agent_state.jl — AgentState and parallel-array management
 
-Bundles the MixtureMeasure belief with its parallel arrays (metadata,
+Bundles the MixturePrevision belief with its parallel arrays (metadata,
 compiled_kernels, all_programs). sync_prune!/sync_truncate! keep them
-in lock-step and reindex TaggedBetaMeasure tags.
-
-Under Posture 3's Measure-as-view framing (Move 3 wrapping; Move 7
-constitutional), the `belief::MixtureMeasure` field is the consumer-
-facing surface; internally the Measure wraps a MixturePrevision
-(see `src/prevision.jl`). The getproperty shield forwards
-`.components` and `.log_weights` to the underlying prevision by
-reference, preserving the shared-reference contract that
-`sync_prune!` and `sync_truncate!` depend on when mutating the
-belief in place.
+in lock-step and reindex TaggedBetaPrevision tags.
 """
 
 using .Ontology
@@ -22,7 +13,7 @@ using .Ontology
 # ═══════════════════════════════════════
 
 mutable struct AgentState
-    belief::Ontology.MixtureMeasure
+    belief::Ontology.MixturePrevision
     metadata::Vector{Tuple{Int, Int}}       # (grammar_id, program_id)
     compiled_kernels::Vector{CompiledKernel}
     all_programs::Vector{Program}
@@ -34,18 +25,16 @@ end
     sync_prune!(state; threshold) → state
 
 Prune negligible components AND the parallel arrays together.
-Reindex TaggedBetaMeasure tags so that tag == array position.
+Reindex TaggedBetaPrevision tags so that tag == array position.
 """
 function sync_prune!(state::AgentState; threshold::Float64=-30.0)
     max_lw = maximum(state.belief.log_weights)
     keep = [i for i in eachindex(state.belief.log_weights)
             if state.belief.log_weights[i] - max_lw > threshold]
     length(keep) == length(state.belief.components) && return state
-    new_comps = Ontology.Measure[Ontology.TaggedBetaMeasure(state.belief.components[k].space, j,
-                                          state.belief.components[k].beta)
-                        for (j, k) in enumerate(keep)]
-    state.belief = Ontology.MixtureMeasure(state.belief.space, new_comps,
-                                   state.belief.log_weights[keep])
+    new_comps = [Ontology.TaggedBetaPrevision(j, state.belief.components[k].beta)
+                 for (j, k) in enumerate(keep)]
+    state.belief = Ontology.MixturePrevision(new_comps, state.belief.log_weights[keep])
     state.metadata = state.metadata[keep]
     state.compiled_kernels = state.compiled_kernels[keep]
     state.all_programs = state.all_programs[keep]
@@ -61,11 +50,9 @@ function sync_truncate!(state::AgentState; max_components::Int=2000)
     length(state.belief.components) <= max_components && return state
     perm = sortperm(state.belief.log_weights, rev=true)
     keep = perm[1:min(max_components, length(perm))]
-    new_comps = Ontology.Measure[Ontology.TaggedBetaMeasure(state.belief.components[k].space, j,
-                                          state.belief.components[k].beta)
-                        for (j, k) in enumerate(keep)]
-    state.belief = Ontology.MixtureMeasure(state.belief.space, new_comps,
-                                   state.belief.log_weights[keep])
+    new_comps = [Ontology.TaggedBetaPrevision(j, state.belief.components[k].beta)
+                 for (j, k) in enumerate(keep)]
+    state.belief = Ontology.MixturePrevision(new_comps, state.belief.log_weights[keep])
     state.metadata = state.metadata[keep]
     state.compiled_kernels = state.compiled_kernels[keep]
     state.all_programs = state.all_programs[keep]
@@ -128,7 +115,7 @@ function add_programs_to_state!(
 
     n_added = 0
     base_idx = length(state.compiled_kernels)
-    new_components = Ontology.Measure[]
+    new_components = Any[]
     new_lw = Float64[]
     new_meta = Tuple{Int, Int}[]
     new_ck = CompiledKernel[]
@@ -139,9 +126,8 @@ function add_programs_to_state!(
         any(e -> expr_equal(e, p.expr), existing_exprs) && continue
 
         base_idx += 1
-        push!(new_components, Ontology.TaggedBetaMeasure(
-            Ontology.Interval(0.0, 1.0), base_idx,
-            Ontology.BetaMeasure(1.0, 1.0)))
+        push!(new_components, Ontology.TaggedBetaPrevision(
+            base_idx, Ontology.BetaPrevision(1.0, 1.0)))
         lw = -grammar.complexity * log(2) - p.complexity * log(2)
         push!(new_lw, lw)
         push!(new_meta, (grammar.id, pi))
@@ -151,10 +137,9 @@ function add_programs_to_state!(
     end
 
     if !isempty(new_components)
-        all_comps = Ontology.Measure[state.belief.components..., new_components...]
+        all_comps = Any[state.belief.components..., new_components...]
         all_lw = Float64[state.belief.log_weights..., new_lw...]
-        state.belief = Ontology.MixtureMeasure(
-            Ontology.Interval(0.0, 1.0), all_comps, all_lw)
+        state.belief = Ontology.MixturePrevision(all_comps, all_lw)
         append!(state.metadata, new_meta)
         append!(state.compiled_kernels, new_ck)
         append!(state.all_programs, new_progs)

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -67,7 +67,7 @@ weights(p::BetaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 weights(p::TaggedBetaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 weights(p::GaussianPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 weights(p::GammaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
-weights(p::DirichletPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
+weights(p::DirichletPrevision) = p.alpha ./ sum(p.alpha)
 weights(p::NormalGammaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 
 function marginal(p::MixturePrevision, indices::Vector{Int})

--- a/test/test_email_agent.jl
+++ b/test/test_email_agent.jl
@@ -13,6 +13,7 @@ using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPre
 using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 using Credence: weights, mean, condition
 using Credence: TaggedBetaMeasure, MixtureMeasure, BetaMeasure
+using Credence: TaggedBetaPrevision, MixturePrevision
 using Credence: Interval, Finite, Kernel, Measure
 using Credence: Grammar, Program, CompiledKernel, ProductionRule
 using Credence: enumerate_programs, compile_kernel
@@ -469,20 +470,20 @@ let
     programs = enumerate_programs(g, 2; action_space=DOMAIN_ACTIONS, min_log_prior=-15.0)
 
     # Build a state with uniform priors (high entropy)
-    components = Measure[]
+    components = Any[]
     log_prior = Float64[]
     meta = Tuple{Int, Int}[]
     ck = CompiledKernel[]
     progs = Program[]
     for (pi, p) in enumerate(programs[1:min(20, length(programs))])
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, wrap_in_measure(BetaPrevision(1.0, 1.0))))
+        push!(components, TaggedBetaPrevision(pi, BetaPrevision(1.0, 1.0)))
         push!(log_prior, 0.0)
         push!(meta, (g.id, pi))
         push!(ck, compile_kernel(p, g, pi))
         push!(progs, p)
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior)
+    belief = MixturePrevision(components, log_prior)
     grammar_dict = Dict{Int, Grammar}(g.id => g)
     state = AgentState(belief, meta, ck, progs, grammar_dict, 2)
 
@@ -505,18 +506,18 @@ let
     # Now create a concentrated state (one component dominates)
     conc_lw = [-100.0 for _ in 1:length(components)]
     conc_lw[1] = 0.0  # only component 1 has weight
-    conc_belief = MixtureMeasure(Interval(0.0, 1.0), components, conc_lw)
+    conc_belief = MixturePrevision(components, conc_lw)
     conc_state = AgentState(conc_belief, meta, ck, progs, grammar_dict, 2)
 
     # Simulate many observations
     for comp in conc_state.belief.components
-        tbm = comp::TaggedBetaMeasure
+        tbm = comp::TaggedBetaPrevision
         # Simulate high observation count by using Beta(50, 50)
     end
     # Use a state where mean_observation_count is high
-    conc_comps = Measure[TaggedBetaMeasure(Interval(0.0, 1.0), i, wrap_in_measure(BetaPrevision(50.0, 50.0)))
-                         for i in 1:length(components)]
-    conc_belief2 = MixtureMeasure(Interval(0.0, 1.0), conc_comps, conc_lw)
+    conc_comps = Any[TaggedBetaPrevision(i, BetaPrevision(50.0, 50.0))
+                     for i in 1:length(components)]
+    conc_belief2 = MixturePrevision(conc_comps, conc_lw)
     conc_state2 = AgentState(conc_belief2, meta, ck, progs, grammar_dict, 2)
 
     w2 = weights(conc_state2.belief)
@@ -542,7 +543,7 @@ let
     grammars = generate_email_seed_grammars()
 
     # Build a minimal state
-    components = Measure[]
+    components = Any[]
     log_prior = Float64[]
     meta = Tuple{Int, Int}[]
     ck = CompiledKernel[]
@@ -555,7 +556,7 @@ let
         programs = enumerate_programs(g, 2; action_space=DOMAIN_ACTIONS, min_log_prior=-15.0)
         for (pi, p) in enumerate(programs)
             idx += 1
-            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, wrap_in_measure(BetaPrevision(1.0, 1.0))))
+            push!(components, TaggedBetaPrevision(idx, BetaPrevision(1.0, 1.0)))
             push!(log_prior, -g.complexity * log(2) - p.complexity * log(2))
             push!(meta, (g.id, pi))
             push!(ck, compile_kernel(p, g, pi))
@@ -563,7 +564,7 @@ let
         end
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior)
+    belief = MixturePrevision(components, log_prior)
     state = AgentState(belief, meta, ck, progs, grammar_dict, 2)
 
     n_before = length(state.belief.components)
@@ -1030,7 +1031,7 @@ let
     action_space = vcat(PRIMITIVE_ACTIONS, [:done])
     programs = enumerate_programs(g, 2; action_space=action_space, min_log_prior=-15.0)
 
-    components = Measure[]
+    components = Any[]
     log_prior = Float64[]
     meta = Tuple{Int, Int}[]
     ck_list = CompiledKernel[]
@@ -1038,14 +1039,14 @@ let
 
     for (pi, p) in enumerate(programs[1:min(30, length(programs))])
         # Use Beta(5,2) so mean≈0.71 — asymmetric, so correct/incorrect give different likelihoods
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, wrap_in_measure(BetaPrevision(5.0, 2.0))))
+        push!(components, TaggedBetaPrevision(pi, BetaPrevision(5.0, 2.0)))
         push!(log_prior, 0.0)
         push!(meta, (g.id, pi))
         push!(ck_list, compile_kernel(p, g, pi))
         push!(progs, p)
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior)
+    belief = MixturePrevision(components, log_prior)
     grammar_dict = Dict{Int, Grammar}(g.id => g)
     state = AgentState(belief, meta, ck_list, progs, grammar_dict, 2)
 

--- a/test/test_grid_world.jl
+++ b/test/test_grid_world.jl
@@ -12,6 +12,7 @@ using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPre
 using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 using Credence: expect, condition, weights, mean
 using Credence: BetaMeasure, TaggedBetaMeasure, MixtureMeasure, Finite, Interval, Kernel, Measure
+using Credence: TaggedBetaPrevision, MixturePrevision
 using Credence: prune, truncate
 using Credence: AgentState, sync_prune!, sync_truncate!
 using Credence: Grammar, Program, CompiledKernel
@@ -110,7 +111,7 @@ let
     p1 = enumerate_programs(g1, 3; action_space=[:food, :enemy])
     p2 = enumerate_programs(g2, 3; action_space=[:food, :enemy])
 
-    components = Measure[]
+    components = Any[]
     log_prior = Float64[]
     meta = Tuple{Int, Int}[]
     ck = CompiledKernel[]
@@ -119,7 +120,7 @@ let
     idx = 0
     for (pi, p) in enumerate(p1)
         idx += 1
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, wrap_in_measure(BetaPrevision(1.0, 1.0))))
+        push!(components, TaggedBetaPrevision(idx, BetaPrevision(1.0, 1.0)))
         push!(log_prior, -g1.complexity * log(2) - p.complexity * log(2))
         push!(meta, (g1.id, pi))
         push!(ck, compile_kernel(p, g1, pi))
@@ -127,14 +128,14 @@ let
     end
     for (pi, p) in enumerate(p2)
         idx += 1
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, wrap_in_measure(BetaPrevision(1.0, 1.0))))
+        push!(components, TaggedBetaPrevision(idx, BetaPrevision(1.0, 1.0)))
         push!(log_prior, -g2.complexity * log(2) - p.complexity * log(2))
         push!(meta, (g2.id, pi))
         push!(ck, compile_kernel(p, g2, pi))
         push!(progs, p)
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior)
+    belief = MixturePrevision(components, log_prior)
     grammar_dict = Dict{Int, Grammar}(g1.id => g1, g2.id => g2)
     state = AgentState(belief, meta, ck, progs, grammar_dict, 3)
 
@@ -148,7 +149,7 @@ let
     @assert length(state.all_programs) == n_after "all_programs length mismatch"
 
     for (i, comp) in enumerate(state.belief.components)
-        @assert comp isa TaggedBetaMeasure
+        @assert comp isa TaggedBetaPrevision
         @assert comp.tag == i "Tag reindex failed: expected $i, got $(comp.tag)"
     end
 
@@ -171,21 +172,21 @@ let
     g = grammars[2]
     programs = enumerate_programs(g, 3; action_space=[:food, :enemy])
 
-    components = Measure[]
+    components = Any[]
     log_prior = Float64[]
     meta = Tuple{Int, Int}[]
     ck = CompiledKernel[]
     progs = Program[]
 
     for (pi, p) in enumerate(programs)
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, wrap_in_measure(BetaPrevision(1.0, 1.0))))
+        push!(components, TaggedBetaPrevision(pi, BetaPrevision(1.0, 1.0)))
         push!(log_prior, -g.complexity * log(2) - p.complexity * log(2))
         push!(meta, (g.id, pi))
         push!(ck, compile_kernel(p, g, pi))
         push!(progs, p)
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior)
+    belief = MixturePrevision(components, log_prior)
     grammar_dict = Dict{Int, Grammar}(g.id => g)
     state = AgentState(belief, meta, ck, progs, grammar_dict, 3)
 
@@ -281,9 +282,9 @@ let
     @assert correct_prog !== nothing "Should find a program that predicts :enemy for red"
     @assert incorrect_prog !== nothing "Should find a program that predicts :food for red"
 
-    comp1 = TaggedBetaMeasure(Interval(0.0, 1.0), 1, wrap_in_measure(BetaPrevision(1.0, 1.0)))
-    comp2 = TaggedBetaMeasure(Interval(0.0, 1.0), 2, wrap_in_measure(BetaPrevision(1.0, 1.0)))
-    belief = MixtureMeasure(Interval(0.0, 1.0), Measure[comp1, comp2], [0.0, 0.0])
+    comp1 = TaggedBetaPrevision(1, BetaPrevision(1.0, 1.0))
+    comp2 = TaggedBetaPrevision(2, BetaPrevision(1.0, 1.0))
+    belief = MixturePrevision(Any[comp1, comp2], [0.0, 0.0])
 
     ck_vec = [correct_prog[3], incorrect_prog[3]]
 
@@ -295,8 +296,8 @@ let
 
     c1 = posterior.components[1]
     c2 = posterior.components[2]
-    @assert c1 isa TaggedBetaMeasure
-    @assert c2 isa TaggedBetaMeasure
+    @assert c1 isa TaggedBetaPrevision
+    @assert c2 isa TaggedBetaPrevision
 
     @assert c1.beta.alpha ≈ 6.0 "Both programs should have α=6 after 5 obs, got $(c1.beta.alpha)"
     @assert c2.beta.alpha ≈ 6.0 "Both programs should have α=6 after 5 obs, got $(c2.beta.alpha)"

--- a/test/test_program_space.jl
+++ b/test/test_program_space.jl
@@ -11,7 +11,7 @@ using Credence
 using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision  # Posture 4 Move 4
 using Credence.Ontology: wrap_in_measure  # Posture 4 Move 4
 using Credence: expect, condition, weights, mean
-using Credence: BetaMeasure, TaggedBetaMeasure, MixtureMeasure, Finite, Interval, Kernel, Measure
+using Credence: BetaMeasure, TaggedBetaMeasure, TaggedBetaPrevision, MixtureMeasure, MixturePrevision, BetaPrevision, Finite, Interval, Kernel, Measure
 using Credence: prune, truncate
 using Credence: ActionExpr, IfExpr
 
@@ -665,21 +665,21 @@ let
 
     # Build initial state with some programs
     programs = enumerate_programs(g, 2; action_space=[:food, :enemy])
-    components = Measure[]
+    components = Any[]
     log_prior = Float64[]
     meta = Tuple{Int, Int}[]
     ck = CompiledKernel[]
     progs = Program[]
 
     for (pi, p) in enumerate(programs)
-        push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), pi, wrap_in_measure(BetaPrevision(1.0, 1.0))))
+        push!(components, TaggedBetaPrevision(pi, BetaPrevision(1.0, 1.0)))
         push!(log_prior, -g.complexity * log(2) - p.complexity * log(2))
         push!(meta, (g.id, pi))
         push!(ck, compile_kernel(p, g, pi))
         push!(progs, p)
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior)
+    belief = MixturePrevision(components, log_prior)
     grammar_dict = Dict{Int, Grammar}(g.id => g)
     state = AgentState(belief, meta, ck, progs, grammar_dict, 2)
 
@@ -724,7 +724,7 @@ let
     grammars = generate_seed_grammars()
     g1, g2, g3 = grammars[1], grammars[2], grammars[3]
 
-    components = Measure[]
+    components = Any[]
     log_prior = Float64[]
     meta = Tuple{Int, Int}[]
     ck = CompiledKernel[]
@@ -737,7 +737,7 @@ let
         programs = enumerate_programs(g, 2; action_space=[:food, :enemy])
         for (pi, p) in enumerate(programs[1:min(3, length(programs))])
             idx += 1
-            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, wrap_in_measure(BetaPrevision(1.0, 1.0))))
+            push!(components, TaggedBetaPrevision(idx, BetaPrevision(1.0, 1.0)))
             push!(log_prior, grammar_weights_target[g.id])
             push!(meta, (g.id, pi))
             push!(ck, compile_kernel(p, g, pi))
@@ -745,7 +745,7 @@ let
         end
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior)
+    belief = MixturePrevision(components, log_prior)
     grammar_dict = Dict{Int, Grammar}(g.id => g for g in [g1, g2, g3])
     state = AgentState(belief, meta, ck, progs, grammar_dict, 2)
 


### PR DESCRIPTION
## Summary

- Prevision-primary types throughout: `AgentState.belief` is `MixturePrevision`, host kernel closures check `TaggedBetaPrevision`, skin's `build_prevision` is the primary entry point
- Scalar Prevision-level `condition` methods (Beta, TaggedBeta, Gaussian, Gamma, Dirichlet, NormalGamma, Product) as Move 5 substrate completion — conjugate path returns Prevision directly
- Skin migration: `handle_create_state`, `handle_dispatch_path`, `handle_factor`/`replace_factor`/`n_factors` all Prevision-aware; `CategoricalMeasure` and `ProductMeasure` stay as Measure (design doc §5.1)
- `expect(::DirichletPrevision|NormalGammaPrevision, ::Identity)`, `log_predictive(::DirichletPrevision, ...)`, `weights(::DirichletPrevision)` close substrate gaps surfaced by the migration

## Test plan

- [x] `julia test/test_core.jl` — ALL TESTS PASSED
- [x] `julia test/test_email_agent.jl` — ALL EMAIL AGENT TESTS PASSED
- [x] `julia test/test_grid_world.jl` — ALL GRID WORLD TESTS PASSED
- [x] `julia test/test_program_space.jl` — ALL PROGRAM SPACE TESTS PASSED
- [x] `python apps/skin/test_skin.py` — All tests passed (skin smoke)
- [x] `credence_lint.py check apps/` — 144 files, 0 violations
- [x] `credence_lint.py test` — 14 good / 10 bad (pass one) / 5 bad (pass two)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)