### PR TITLE
Move 8b Phase A′: ParticlePrevision{T} + EnumerationPrevision retirement

### DIFF
--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -36,7 +36,7 @@ using .Persistence
 
 export run_dsl, load_dsl, parse_sexpr, parse_all
 export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals, support
-export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, ProductMeasure, MixtureMeasure
+export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, EnumerationMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target
 export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
 export NormalNormal, Categorical, NormalGammaLikelihood, Exponential
@@ -48,7 +48,7 @@ export CenteredPower, CenteredSquare
 export BetaPrevision, TaggedBetaPrevision, GaussianPrevision, GammaPrevision
 export CategoricalPrevision, DirichletPrevision, NormalGammaPrevision
 export ProductPrevision, MixturePrevision, ExchangeablePrevision, decompose
-export ParticlePrevision, QuadraturePrevision, EnumerationPrevision
+export ParticlePrevision, QuadraturePrevision
 export ConditionalPrevision
 export push_component!, replace_component!, FrozenVectorView
 export factor, replace_factor
@@ -70,7 +70,7 @@ export ProductionRule, Grammar, compute_grammar_complexity
 export Program, CompiledKernel, SubprogramFrequencyTable
 export THRESHOLDS
 export expr_complexity, expanded_complexity
-export enumerate_programs, enumerate_programs_as_prevision
+export enumerate_programs, enumerate_programs_as_measure
 export compile_kernel, compile_expr, evaluate_predicate
 export analyse_posterior_subtrees, extract_subtrees
 export propose_nonterminal, perturb_grammar

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -22,7 +22,7 @@ import ..Previsions: TestFunction, Identity, Projection, NestedProjection,
                      Tabular, LinearCombination, OpaqueClosure, expect
 import ..Previsions: BetaPrevision, TaggedBetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision
 import ..Previsions: ExchangeablePrevision, decompose
-import ..Previsions: ParticlePrevision, QuadraturePrevision, EnumerationPrevision
+import ..Previsions: ParticlePrevision, QuadraturePrevision
 import ..Previsions: ConditionalPrevision
 import ..Previsions: condition
 import ..Previsions: ConjugatePrevision, maybe_conjugate, update, _dispatch_path
@@ -30,7 +30,7 @@ import ..Previsions: CenteredPower, CenteredSquare
 import ..Previsions: Indicator, apply
 
 export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals, support
-export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, ProductMeasure, MixtureMeasure
+export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, EnumerationMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target, kernel_params
 export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
 export NormalNormal, Categorical, NormalGammaLikelihood, Exponential
@@ -312,6 +312,30 @@ end
 Base.propertynames(::NormalGammaMeasure) = (:κ, :μ, :α, :β, :space, :prevision)
 
 mean(m::NormalGammaMeasure) = m.μ
+
+# ── Enumeration: carrier-binding Measure over CategoricalPrevision ──
+
+struct EnumerationMeasure{T} <: Measure
+    prevision::CategoricalPrevision
+    carrier::Vector{T}
+    space::Finite{T}
+
+    function EnumerationMeasure{T}(prevision::CategoricalPrevision, carrier::Vector{T}, space::Finite{T}) where {T}
+        length(carrier) == length(prevision.log_weights) || error("carrier and weights must match")
+        length(carrier) == length(space.values) || error("carrier and space must match")
+        new{T}(prevision, carrier, space)
+    end
+end
+
+function expect(m::EnumerationMeasure, f::Function)
+    lw = m.prevision.log_weights
+    max_lw = maximum(lw)
+    w = exp.(lw .- max_lw)
+    w ./= sum(w)
+    sum(w[i] * f(m.carrier[i]) for i in eachindex(w))
+end
+
+expect(m::EnumerationMeasure, tf::TestFunction) = expect(m, x -> apply(tf, x))
 
 # ── Product: independent joint ──
 
@@ -670,14 +694,6 @@ function expect(p::QuadraturePrevision, f::Function)
     sum(w[i] * f(p.grid[i]) for i in eachindex(w))
 end
 
-function expect(p::EnumerationPrevision, f::Function)
-    lw = p.log_weights
-    max_lw = maximum(lw)
-    w = exp.(lw .- max_lw)
-    w ./= sum(w)
-    sum(w[i] * f(p.enumerated[i]) for i in eachindex(w))
-end
-
 # MixturePrevision: linearity of expectation.
 function expect(p::MixturePrevision, f::Function)
     lw = p.log_weights
@@ -703,7 +719,6 @@ expect(p::GaussianPrevision, tf::TestFunction; kwargs...) = expect(p, x -> apply
 expect(p::GammaPrevision, tf::TestFunction; kwargs...) = expect(p, x -> apply(tf, x); kwargs...)
 expect(p::ParticlePrevision, tf::TestFunction) = expect(p, x -> apply(tf, x))
 expect(p::QuadraturePrevision, tf::TestFunction) = expect(p, x -> apply(tf, x))
-expect(p::EnumerationPrevision, tf::TestFunction) = expect(p, x -> apply(tf, x))
 
 # Prevision-level OpaqueClosure unwrapping.
 expect(p::Prevision, o::OpaqueClosure; kwargs...) = expect(p, o.f; kwargs...)

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -32,7 +32,7 @@ export Prevision, TestFunction, Indicator, apply, expect
 export Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure
 export BetaPrevision, TaggedBetaPrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision
 export ExchangeablePrevision, decompose
-export ParticlePrevision, QuadraturePrevision, EnumerationPrevision
+export ParticlePrevision, QuadraturePrevision
 export ConditionalPrevision
 export ConjugatePrevision, maybe_conjugate, update, _dispatch_path
 export push_component!, replace_component!
@@ -281,12 +281,11 @@ with log-weights `log_weights` normalised at construction time. The
 with `CategoricalMeasure`; the external `m.logw` surface persists until
 then for Moves 2–4 consumer compatibility).
 
-Field-name unification (Posture 4 Move 1): the five log-mass carriers
+Field-name unification (Posture 4 Move 1): the four log-mass carriers
 (`CategoricalPrevision`, `ParticlePrevision`, `QuadraturePrevision`,
-`EnumerationPrevision`, `MixturePrevision`) all store their normalised
-log-weight vector under the name `log_weights`. Prior to Move 1,
-`CategoricalPrevision.logw` was the one outlier; this rename aligns
-the surface.
+`MixturePrevision`) all store their normalised log-weight vector under
+the name `log_weights`. Prior to Move 1, `CategoricalPrevision.logw`
+was the one outlier; this rename aligns the surface.
 
 The `log_weights` field is returned by reference through the shield — see
 the shared-reference contract in docs/posture-3/move-3-design.md §3. In
@@ -489,33 +488,6 @@ struct QuadraturePrevision <: Prevision
     end
 end
 
-"""
-    EnumerationPrevision(enumerated::Vector, log_weights::Vector{Float64}) <: Prevision
-
-Move 6: typed carrier for exhaustive-enumeration posteriors (primarily
-program-space enumeration per `src/program_space/enumeration.jl`).
-`enumerated` holds the enumerated items (programs, AST shapes, etc.);
-`log_weights` the per-item log weights, normalised at construction via
-logsumexp.
-
-Enumeration is deterministic under fixed iteration order; Stratum-2
-tolerance per `precedents.md` §4 is `==`.
-"""
-struct EnumerationPrevision <: Prevision
-    enumerated::Vector
-    log_weights::Vector{Float64}
-
-    function EnumerationPrevision(enumerated::Vector, log_weights::Vector{Float64})
-        length(enumerated) == length(log_weights) || error("items and weights must match")
-        length(enumerated) > 0 || error("enumeration set must be non-empty")
-        if all(lw -> lw == -Inf, log_weights)
-            error("enumeration posterior has zero total mass")
-        end
-        max_lw = maximum(log_weights)
-        log_total = max_lw + log(sum(exp.(log_weights .- max_lw)))
-        new(enumerated, log_weights .- log_total)
-    end
-end
 
 """
     ConditionalPrevision{E}(base::Prevision, event::E, mass::Float64) <: Prevision

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -424,16 +424,16 @@ where the concrete component Measure types are in scope.
 function decompose end
 
 """
-    ParticlePrevision(samples::Vector, log_weights::Vector{Float64}, seed::Int) <: Prevision
+    ParticlePrevision{T}(samples::Vector{T}, log_weights::Vector{Float64}, seed::Int) <: Prevision
 
 Move 6: typed carrier for importance-sampling posteriors. `samples`
-holds the drawn hypotheses (one per particle; type depends on the
-sampled Measure — Float64, tuples, Vectors, Symbols, etc.).
-`log_weights` is the per-particle log importance weight, normalised at
-construction via logsumexp. `seed` records the RNG seed that produced
-the samples, for reproducibility auditing — not used by any computation,
-but load-bearing for the seeded-MC `==` precedent (see
-`docs/posture-3/precedents.md` §4).
+holds the drawn hypotheses (one per particle; element type `T` depends
+on the sampled Measure — `Float64` for Beta/Gaussian, `Vector{Float64}`
+for Dirichlet, tuples for NormalGamma, etc.). `log_weights` is the
+per-particle log importance weight, normalised at construction via
+logsumexp. `seed` records the RNG seed that produced the samples, for
+reproducibility auditing — not used by any computation, but load-bearing
+for the seeded-MC `==` precedent (see `docs/posture-3/precedents.md` §4).
 
 **Shared-reference contract inherited from Move 3** (precedent #2):
 `samples` and `log_weights` are returned by reference through the
@@ -441,20 +441,13 @@ but load-bearing for the seeded-MC `==` precedent (see
 breaks the shared-reference semantics that downstream Measure-surface
 readers depend on. See `test/test_prevision_particle.jl` — contract
 tests confirm the shield.
-
-At Move 6 Phase 2 the struct is declared additively: it exists as a
-type but no code path constructs it yet. Phase 3 wires
-`_condition_particle` to construct a `ParticlePrevision` wrapped by
-`CategoricalMeasure(Finite(samples), log_weights)` for consumer-
-surface compatibility. Phase 0's canonical-bit-invariance test is the
-tripwire across the refactor.
 """
-struct ParticlePrevision <: Prevision
-    samples::Vector
+struct ParticlePrevision{T} <: Prevision
+    samples::Vector{T}
     log_weights::Vector{Float64}
     seed::Int
 
-    function ParticlePrevision(samples::Vector, log_weights::Vector{Float64}, seed::Int)
+    function ParticlePrevision(samples::Vector{T}, log_weights::Vector{Float64}, seed::Int) where {T}
         length(samples) == length(log_weights) || error("particles and weights must match")
         length(samples) > 0 || error("particle set must be non-empty")
         if all(lw -> lw == -Inf, log_weights)
@@ -462,7 +455,7 @@ struct ParticlePrevision <: Prevision
         end
         max_lw = maximum(log_weights)
         log_total = max_lw + log(sum(exp.(log_weights .- max_lw)))
-        new(samples, log_weights .- log_total, seed)
+        new{T}(samples, log_weights .- log_total, seed)
     end
 end
 

--- a/src/program_space/enumeration.jl
+++ b/src/program_space/enumeration.jl
@@ -144,38 +144,29 @@ function enumerate_programs(g::Grammar, max_depth::Int;
 end
 
 """
-    enumerate_programs_as_prevision(grammar, max_depth; ...) → EnumerationPrevision
+    enumerate_programs_as_measure(grammar, max_depth; ...) → EnumerationMeasure{Program}
 
-Move 6: typed-Prevision wrapper around `enumerate_programs`. Returns an
-`EnumerationPrevision` whose `enumerated` field is the program vector
-and whose `log_weights` follow the complexity prior
-`-grammar.complexity * log(2) - p.complexity * log(2)` (matching the
-convention in `add_programs_to_state!`, the primary in-tree consumer
-of enumeration results).
-
-Additive — the existing `enumerate_programs` function continues to
-return `Vector{Program}` for backward compatibility with
-`add_programs_to_state!` and other callers. This wrapper is the
-live construction site for `EnumerationPrevision`; future consumers
-that want a typed carrier of enumerated-programs-with-weights
-(e.g. the paper case study, or a Move 8 follow-up if it wires
-program-space posteriors through the Prevision surface directly)
-call this variant.
+Typed-carrier wrapper around `enumerate_programs`. Returns an
+`EnumerationMeasure{Program}` whose `carrier` field is the program
+vector, `prevision` is a `CategoricalPrevision` with log-weights from
+the complexity prior `-grammar.complexity * log(2) - p.complexity *
+log(2)` (matching the convention in `add_programs_to_state!`), and
+`space` is `Finite(programs)`.
 
 Stratum-2 tolerance per `precedents.md` §4: `==` under deterministic
 iteration order. Enumeration order is grammar-fixed (sorted feature
 set, fixed threshold list, deterministic depth-wise expansion),
-so the returned `EnumerationPrevision` is reproducible bit-for-bit
+so the returned `EnumerationMeasure` is reproducible bit-for-bit
 across invocations with the same grammar / max_depth / action_space.
 """
-function enumerate_programs_as_prevision(g::Grammar, max_depth::Int;
-                                          include_temporal::Bool=false,
-                                          min_log_prior::Float64=-20.0,
-                                          action_space::Vector{Symbol}=Symbol[:classify])
+function enumerate_programs_as_measure(g::Grammar, max_depth::Int;
+                                       include_temporal::Bool=false,
+                                       min_log_prior::Float64=-20.0,
+                                       action_space::Vector{Symbol}=Symbol[:classify])
     programs = enumerate_programs(g, max_depth;
                                    include_temporal=include_temporal,
                                    min_log_prior=min_log_prior,
                                    action_space=action_space)
     log_weights = Float64[-g.complexity * log(2) - p.complexity * log(2) for p in programs]
-    Previsions.EnumerationPrevision(convert(Vector{Any}, programs), log_weights)
+    Ontology.EnumerationMeasure{Program}(CategoricalPrevision(log_weights), programs, Finite(programs))
 end

--- a/src/program_space/types.jl
+++ b/src/program_space/types.jl
@@ -132,11 +132,11 @@ Fields:
 - `id::Int` — grammar identifier, used by `add_programs_to_state!` to
   track which grammar produced each mixture component.
 
-See `enumerate_programs_as_prevision` for the typed-carrier surface
-(Move 6 Phase 5 wrapper) that returns an `EnumerationPrevision` over
-the programs a Grammar generates. The existing `enumerate_programs`
-function returns `Vector{Program}` for backward compatibility; both
-surfaces draw from the same enumeration logic.
+See `enumerate_programs_as_measure` for the typed-carrier surface
+that returns an `EnumerationMeasure{Program}` over the programs a
+Grammar generates. The existing `enumerate_programs` function returns
+`Vector{Program}` for backward compatibility; both surfaces draw from
+the same enumeration logic.
 """
 struct Grammar
     feature_set::Set{Symbol}

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -59,13 +59,6 @@ weights(p::QuadraturePrevision) = begin
     w ./ sum(w)
 end
 
-weights(p::EnumerationPrevision) = begin
-    lw = p.log_weights
-    max_lw = maximum(lw)
-    w = exp.(lw .- max_lw)
-    w ./ sum(w)
-end
-
 weights(p::BetaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 weights(p::TaggedBetaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 weights(p::GaussianPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))

--- a/test/test_prevision_particle.jl
+++ b/test/test_prevision_particle.jl
@@ -116,14 +116,14 @@ end
 # ── Shared-reference contract tests per precedents.md §2 + §3 ──
 #
 # Per Move 6 design doc §5.1 Option A narrowed form and §4.5's typed-carrier
-# trace: CategoricalMeasure wrapping ParticlePrevision / QuadraturePrevision /
-# EnumerationPrevision must preserve reference identity between the wrapper's
-# shield-accessed fields and the underlying Prevision's stored Vectors.
-# Breaking this contract silently corrupts downstream consumers (skin server
-# push! patterns, Move 7 event-conditioning paths, paper §2.3 isa-drilldown).
+# trace: CategoricalMeasure wrapping ParticlePrevision / QuadraturePrevision
+# must preserve reference identity between the wrapper's shield-accessed
+# fields and the underlying Prevision's stored Vectors. EnumerationMeasure
+# stores its carrier and CategoricalPrevision directly (no CategoricalMeasure
+# wrapper). Breaking these contracts silently corrupts downstream consumers.
 #
 # Contract: cm.logw === pp.log_weights (identity, not equality).
-#          cm.space.values === pp.samples / qp.grid / ep.enumerated.
+#          cm.space.values === pp.samples / qp.grid.
 #
 # These tests are named in invariant comments on the shield at
 # src/ontology.jl:getproperty(::CategoricalMeasure, …). Breaking either
@@ -160,25 +160,25 @@ function test_quadrature_shared_reference()
           cm.space.values === qp.grid, "")
 end
 
-function test_enumeration_shared_reference()
-    enumerated = Any[:a, :b, :c]
+function test_enumeration_measure_structure()
+    carrier = [:a, :b, :c]
     log_weights = [log(0.5), log(0.3), log(0.2)]
-    ep = EnumerationPrevision(enumerated, log_weights)
-    # Enumeration wraps over a Finite{Symbol} space using ep.enumerated
-    # as the values backing.
-    cm = CategoricalMeasure(Finite(ep.enumerated), ep)
+    cp = CategoricalPrevision(log_weights)
+    em = EnumerationMeasure{Symbol}(cp, carrier, Finite(carrier))
 
-    check("CategoricalMeasure wrapping EnumerationPrevision stores ep by ref",
-          cm.prevision === ep, "")
-    check("cm.logw === ep.log_weights (reference identity)",
-          cm.logw === ep.log_weights, "")
-    check("cm.space.values === ep.enumerated (reference identity)",
-          cm.space.values === ep.enumerated, "")
+    check("EnumerationMeasure stores CategoricalPrevision by ref",
+          em.prevision === cp, "")
+    check("EnumerationMeasure carrier preserved (reference identity)",
+          em.carrier === carrier, "")
+    check("EnumerationMeasure space.values === carrier (reference identity)",
+          em.space.values === carrier, "")
+    check("EnumerationMeasure{Symbol} isa EnumerationMeasure",
+          em isa EnumerationMeasure, "")
 end
 
 test_particle_shared_reference()
 test_quadrature_shared_reference()
-test_enumeration_shared_reference()
+test_enumeration_measure_structure()
 
 # ── _dispatch_path vocabulary pins per §5.3 Option A (uniform `:particle`) ──
 #
@@ -196,23 +196,22 @@ let k = Kernel(Euclidean(1), Euclidean(1),
 
     pp = ParticlePrevision([1.0, 2.0], [log(0.5), log(0.5)], 42)
     qp = QuadraturePrevision([0.1, 0.5, 0.9], [0.0, 0.0, 0.0])
-    ep = EnumerationPrevision([:a, :b], [log(0.7), log(0.3)])
+    em = EnumerationMeasure{Symbol}(CategoricalPrevision([log(0.7), log(0.3)]),
+                                     [:a, :b], Finite([:a, :b]))
 
     check("ParticlePrevision → :particle (uniform fallback label)",
           _dispatch_path(pp, k) === :particle, "got $(_dispatch_path(pp, k))")
     check("QuadraturePrevision → :particle (uniform fallback label)",
           _dispatch_path(qp, k) === :particle, "got $(_dispatch_path(qp, k))")
-    check("EnumerationPrevision → :particle (uniform fallback label)",
-          _dispatch_path(ep, k) === :particle, "got $(_dispatch_path(ep, k))")
+    check("EnumerationMeasure inner CategoricalPrevision → :particle (PushOnly kernel)",
+          _dispatch_path(em.prevision, k) === :particle, "got $(_dispatch_path(em.prevision, k))")
 
-    # Drilldown via concrete type, per §5.3 Decoupling-from-§5.2:
-    # tests that need the strategy distinction use `isa`, not the Symbol.
     check("ParticlePrevision isa ParticlePrevision (type-level drilldown)",
           pp isa ParticlePrevision, "")
     check("QuadraturePrevision isa QuadraturePrevision (type-level drilldown)",
           qp isa QuadraturePrevision, "")
-    check("EnumerationPrevision isa EnumerationPrevision (type-level drilldown)",
-          ep isa EnumerationPrevision, "")
+    check("EnumerationMeasure isa EnumerationMeasure (type-level drilldown)",
+          em isa EnumerationMeasure, "")
 end
 
 println()


### PR DESCRIPTION
## Summary

- **Commit 1:** `ParticlePrevision{T}` — parametric `samples::Vector{T}` field. Type parameter inferred at construction from the samples vector. All dispatch signatures use unparameterised `ParticlePrevision`, which Julia matches against parametric instances — zero method changes. Construction site (`_condition_particle`) already produces typed vectors via inference.

- **Commit 2:** Retire `EnumerationPrevision`, introduce `EnumerationMeasure{T}`. `EnumerationPrevision` conflated carrier objects (programs) with algebraic content (simplex weights) in a single Prevision struct. `EnumerationMeasure{T}` follows the standard `(Prevision, carrier-space)` shape: `CategoricalPrevision` holds the simplex, `carrier::Vector{T}` holds domain objects, `space::Finite{T}` is the carrier space. Three methods migrated, construction site renamed `enumerate_programs_as_measure`.

No premise failures surfaced. `Finite{T}` accepts typed vectors cleanly. No fourth method on `EnumerationPrevision` — the design doc's audit was complete.

## Test plan

- [x] `julia test/test_prevision_particle.jl` �� shared-reference contracts, `isa` drilldowns, `_dispatch_path` vocabulary pins
- [x] `julia test/test_core.jl` — 59 tests
- [x] `julia test/test_program_space.jl` — enumeration, compilation, conditioning pipeline
- [x] `julia test/test_prevision_mixture.jl` — mixture routing, ExchangeablePrevision
- [x] `julia test/test_prevision_unit.jl` — closed-form expect, shield contracts
- [x] `julia test/test_host.jl` — ProductMeasure conditioning, marginalize_betas
- [x] `julia test/test_persistence.jl` — v3 round-trip, fixture load
- [x] `julia test/test_flat_mixture.jl` — per-component dispatch, FiringByTag
- [x] `julia test/test_grid_world.jl` — full agent pipeline
- [x] `julia test/test_email_agent.jl` — multi-step agent
- [x] `python tools/credence-lint/credence_lint.py check apps/` — 0 violations
- [x] `python tools/credence-lint/credence_lint.py test` — corpus 14/10/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)