### PR TITLE
Move 8b Phase B: consumer construction-site typing

### DIFF
--- a/apps/julia/email_agent/eval_retrospective.jl
+++ b/apps/julia/email_agent/eval_retrospective.jl
@@ -14,7 +14,7 @@ through training with conditioning, then evaluates on held-out test set.
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "src"))
 using Credence
 using Credence: weights, mean, condition
-using Credence: TaggedBetaMeasure, MixtureMeasure, BetaMeasure
+using Credence: TaggedBetaPrevision, BetaPrevision, MixturePrevision, TaggedBetaMeasure
 using Credence: Interval, Finite, Kernel, Measure
 using Credence: Grammar, Program, CompiledKernel
 using Credence: enumerate_programs, compile_kernel
@@ -134,7 +134,7 @@ function init_agent(; action_space::Vector{Symbol}, program_max_depth::Int=2,
                       min_log_prior::Float64=-15.0)
     grammar_pool = generate_email_seed_grammars()
 
-    components = Measure[]
+    components = TaggedBetaPrevision[]
     log_prior_weights = Float64[]
     metadata = Tuple{Int, Int}[]
     compiled_kernels = CompiledKernel[]
@@ -147,7 +147,7 @@ function init_agent(; action_space::Vector{Symbol}, program_max_depth::Int=2,
                                        min_log_prior=min_log_prior)
         for (pi, p) in enumerate(programs)
             idx += 1
-            push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, BetaMeasure(1.0, 1.0)))
+            push!(components, TaggedBetaPrevision(idx, BetaPrevision(1.0, 1.0)))
             lw = -g.complexity * log(2) - p.complexity * log(2)
             push!(log_prior_weights, lw)
             push!(metadata, (g.id, pi))
@@ -156,7 +156,7 @@ function init_agent(; action_space::Vector{Symbol}, program_max_depth::Int=2,
         end
     end
 
-    belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior_weights)
+    belief = MixturePrevision(components, log_prior_weights)
     grammar_dict = Dict{Int, Grammar}(g.id => g for g in grammar_pool)
     AgentState(belief, metadata, compiled_kernels, all_programs,
                grammar_dict, program_max_depth)

--- a/apps/julia/email_agent/live.jl
+++ b/apps/julia/email_agent/live.jl
@@ -167,7 +167,7 @@ function run_live(;
         temporal_state = Dict{Symbol, Any}(:recent => Dict{Symbol, Float64}[])
 
         grammar_pool = generate_email_seed_grammars()
-        components = Measure[]
+        components = TaggedBetaPrevision[]
         log_prior_weights = Float64[]
         metadata = Tuple{Int, Int}[]
         compiled_kernels = CompiledKernel[]
@@ -180,7 +180,7 @@ function run_live(;
                                            min_log_prior=min_log_prior)
             for (pi, p) in enumerate(programs)
                 idx += 1
-                push!(components, TaggedBetaMeasure(Interval(0.0, 1.0), idx, BetaMeasure(1.0, 1.0)))
+                push!(components, TaggedBetaPrevision(idx, BetaPrevision(1.0, 1.0)))
                 push!(log_prior_weights, -g.complexity * log(2) - p.complexity * log(2))
                 push!(metadata, (g.id, pi))
                 push!(compiled_kernels, compile_kernel(p, g, pi))
@@ -188,7 +188,7 @@ function run_live(;
             end
         end
 
-        belief = MixtureMeasure(Interval(0.0, 1.0), components, log_prior_weights)
+        belief = MixturePrevision(components, log_prior_weights)
         grammar_dict = Dict{Int, Grammar}(g.id => g for g in grammar_pool)
         state = AgentState(belief, metadata, compiled_kernels, all_programs,
                            grammar_dict, program_max_depth)

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -621,7 +621,7 @@ function handle_create_state(params)
         end
 
         # Build components from grammars
-        all_components = Any[]
+        all_components = TaggedBetaPrevision[]
         all_lw = Float64[]
         all_meta = Tuple{Int,Int}[]
         all_ck = CompiledKernel[]


### PR DESCRIPTION
## Summary

- **server.jl:624** — `Any[]` → `TaggedBetaPrevision[]`
- **live.jl:170** — `Measure[]` → `TaggedBetaPrevision[]`, `TaggedBetaMeasure(...)` → `TaggedBetaPrevision(...)`, `MixtureMeasure(...)` → `MixturePrevision(...)`
- **eval_retrospective.jl:137** — same pattern as live.jl; import line updated from Measure types to Prevision types

The live.jl and eval_retrospective.jl sites were silently broken post-Phase-A: they constructed `MixtureMeasure` and passed it to `AgentState.belief::MixturePrevision`, which has no auto-conversion. These files are entry points not exercised by the test suite, so the MethodError was latent.

**Retained as-is:**
- `server.jl:212/215` — `Measure[]` is the honest type for heterogeneous `build_measure` results
- `eval_retrospective.jl:295` — `::TaggedBetaMeasure` assertion on a Measure-level shield path (correct post-Phase-A)
- `eval_retrospective.jl:79` — `Any[]` for raw email dicts (not a Measure container)

Phase A swept through `email_agent/host.jl`, `grid_world/host.jl`, `rss/host.jl`, and `examples/host_credence_agent.jl` — those sites were already done. Phase B covers the three remaining actionable sites.

## Test plan

- [x] `julia test/test_email_agent.jl` — all 28 tests pass
- [x] `julia test/test_core.jl` — all 59 tests pass
- [x] `credence-lint check apps/` — 0 violations
- [x] `uv run pytest apps/python/credence_router/` — 26 passed (1 test_live skipped/failed as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)