### PR TITLE
posture-5/move-2: cost table corrections + OpenAI model upgrade

### DIFF
--- a/apps/python/credence_router/README.md
+++ b/apps/python/credence_router/README.md
@@ -57,8 +57,8 @@ The proxy routes across all models whose API key is provided:
 | claude-haiku-4-5 | Anthropic | `ANTHROPIC_API_KEY` |
 | claude-sonnet-4-6 | Anthropic | `ANTHROPIC_API_KEY` |
 | claude-opus-4-6 | Anthropic | `ANTHROPIC_API_KEY` |
-| gpt-4o-mini | OpenAI | `OPENAI_API_KEY` |
-| gpt-4o | OpenAI | `OPENAI_API_KEY` |
+| gpt-5.4-mini | OpenAI | `OPENAI_API_KEY` |
+| gpt-5.4 | OpenAI | `OPENAI_API_KEY` |
 
 Set at least one provider key. The proxy only routes to models with available keys.
 

--- a/apps/python/credence_router/src/credence_router/tools/llm/provider.py
+++ b/apps/python/credence_router/src/credence_router/tools/llm/provider.py
@@ -61,7 +61,7 @@ PROVIDER_ENDPOINTS = {
 ALL_MODELS: dict[str, ModelSpec] = {
     "claude-haiku-4-5": ModelSpec(
         name="claude-haiku-4-5", provider="anthropic",
-        input_price_per_1k=0.0008, output_price_per_1k=0.004,
+        input_price_per_1k=0.001, output_price_per_1k=0.005,
         expected_latency=1.0,
         coverage=np.array([0.5, 0.3, 0.4, 0.8, 0.9]),
     ),
@@ -73,19 +73,19 @@ ALL_MODELS: dict[str, ModelSpec] = {
     ),
     "claude-opus-4-6": ModelSpec(
         name="claude-opus-4-6", provider="anthropic",
-        input_price_per_1k=0.015, output_price_per_1k=0.075,
+        input_price_per_1k=0.005, output_price_per_1k=0.025,
         expected_latency=8.0,
         coverage=np.array([0.9, 0.9, 0.9, 0.6, 0.5]),
     ),
-    "gpt-4o-mini": ModelSpec(
-        name="gpt-4o-mini", provider="openai",
-        input_price_per_1k=0.00015, output_price_per_1k=0.0006,
+    "gpt-5.4-mini": ModelSpec(
+        name="gpt-5.4-mini", provider="openai",
+        input_price_per_1k=0.00075, output_price_per_1k=0.0045,
         expected_latency=1.0,
         coverage=np.array([0.5, 0.3, 0.4, 0.7, 0.9]),
     ),
-    "gpt-4o": ModelSpec(
-        name="gpt-4o", provider="openai",
-        input_price_per_1k=0.0025, output_price_per_1k=0.01,
+    "gpt-5.4": ModelSpec(
+        name="gpt-5.4", provider="openai",
+        input_price_per_1k=0.0025, output_price_per_1k=0.015,
         expected_latency=3.0,
         coverage=np.array([0.8, 0.8, 0.7, 0.7, 0.7]),
     ),

--- a/apps/python/credence_router/tests/test_routing_domain.py
+++ b/apps/python/credence_router/tests/test_routing_domain.py
@@ -119,14 +119,14 @@ class TestLLMProvider:
 
     def test_extract_user_message_string(self):
         body = json.dumps({
-            "model": "gpt-4o",
+            "model": "gpt-5.4",
             "messages": [{"role": "user", "content": "hello world"}],
         }).encode()
         assert extract_user_message(body) == "hello world"
 
     def test_extract_user_message_content_blocks(self):
         body = json.dumps({
-            "model": "gpt-4o",
+            "model": "gpt-5.4",
             "messages": [{"role": "user", "content": [
                 {"type": "text", "text": "describe this image"},
             ]}],
@@ -135,7 +135,7 @@ class TestLLMProvider:
 
     def test_extract_user_message_multi_turn(self):
         body = json.dumps({
-            "model": "gpt-4o",
+            "model": "gpt-5.4",
             "messages": [
                 {"role": "user", "content": "first message"},
                 {"role": "assistant", "content": "response"},

--- a/docs/posture-5/master-plan.md
+++ b/docs/posture-5/master-plan.md
@@ -32,6 +32,10 @@ Package credence-proxy for distribution: Docker image tagging, versioned release
 
 Publish v0.1. Write the release announcement.
 
+## Post-Move-2 follow-ups
+
+- **Decouple pricing from source code.** The proxy's `ModelSpec` prices are hardcoded in `provider.py`. Load from a config file or fetch at startup so the cost table cannot silently drift from official pricing again. (Named in Move 1 §5.4.)
+
 ## Deferred to Posture 6
 
 The personal-agent direction — `Connection` abstraction, Maildir reader, Telegram trainer, server loop, schema v4 — is deferred to a later posture (provisionally Posture 6). The design questions from the original Move 9 draft (event-form vs parametric-form convention for email observations, Telegram preference encoding, production persistence schema) require empirical evidence from the proxy's deployment to inform the brain/body interface design. See `docs/posture-6-prep/personal-agent-priors.md` for the preserved design priors.


### PR DESCRIPTION
## Summary

Verify all `ModelSpec` prices in `provider.py` against official pricing pages and correct entries exceeding the ±5% threshold specified in Move 1 §5.4. Also replace deprecated OpenAI models (gpt-4o, gpt-4o-mini) with current-generation equivalents.

## Verification table

Pricing snapshot date: **2026-04-28**.

### Anthropic models

Source: [platform.claude.com/docs/en/docs/about-claude/pricing](https://platform.claude.com/docs/en/docs/about-claude/pricing)

| Model | Before (per MTok in/out) | After (per MTok in/out) | Discrepancy | Action |
|-------|-------------------------|------------------------|-------------|--------|
| claude-haiku-4-5 | $0.80 / $4.00 | $1.00 / $5.00 | −20% / −20% (used Haiku 3.5 rates) | **Corrected** |
| claude-sonnet-4-6 | $3.00 / $15.00 | $3.00 / $15.00 | 0% / 0% | No change needed |
| claude-opus-4-6 | $15.00 / $75.00 | $5.00 / $25.00 | +200% / +200% (used Opus 4.0 rates) | **Corrected** |

### OpenAI models

Source: [developers.openai.com/api/docs/pricing](https://developers.openai.com/api/docs/pricing)

GPT-4o and GPT-4o-mini no longer appear on OpenAI's current pricing page — superseded by the GPT-5.x family.

| Model (before → after) | Before (per MTok in/out) | After (per MTok in/out) | Action |
|------------------------|-------------------------|------------------------|--------|
| gpt-4o-mini → **gpt-5.4-mini** | $0.15 / $0.60 | $0.75 / $4.50 | **Replaced + repriced** |
| gpt-4o → **gpt-5.4** | $2.50 / $10.00 | $2.50 / $15.00 | **Replaced + repriced** |

### Routing impact of corrections

- **Opus 4.6** was priced at 3× actual, making it almost never selected. At the corrected $5/$25, Opus is now cost-competitive with Sonnet ($3/$15) — the EU calculation can select Opus when its quality edge justifies the modest price premium.
- **Haiku 4.5** was 20% underpriced, mildly biasing routing toward it. Correction is small but directionally honest.
- **OpenAI model upgrade** brings the proxy to current-generation models. gpt-5.4-mini is more expensive than gpt-4o-mini was, which may shift some cheap-tier routing toward Haiku.

## Files changed

- `apps/python/credence_router/src/credence_router/tools/llm/provider.py` — ModelSpec price and name corrections
- `apps/python/credence_router/tests/test_routing_domain.py` — Update model name in test request bodies
- `apps/python/credence_router/README.md` — Update model table
- `docs/posture-5/master-plan.md` — Add "decouple pricing from source code" post-Move-2 follow-up

## Test plan

- [x] All 23 `test_routing_domain.py` tests pass
- [x] No changes to routing logic, only data corrections
- [x] Post-Move-2 TODO for pricing decoupling recorded in master-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)