### PR TITLE
posture-5/move-2: server-side streaming metrics fix

### DIFF
--- a/apps/python/credence_router/src/credence_router/server.py
+++ b/apps/python/credence_router/src/credence_router/server.py
@@ -20,6 +20,7 @@ import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from starlette.background import BackgroundTask
 
 log = logging.getLogger(__name__)
 
@@ -279,46 +280,45 @@ async def proxy_chat_completions(request: Request):
         model = decision.provider_name
         log.info("LLM routing: '%s...' → %s", user_message[:50], model)
 
+    obs_holder: dict = {}
+
     async def generate():
-        observation = None
-        async for chunk, obs in forward_streaming(body, model):
-            if obs is not None:
-                observation = obs
-            else:
+        async for chunk, obs in forward_streaming(body, model, obs_out=obs_holder):
+            if obs is None:
                 yield chunk
-        if observation is not None:
-            # Schedule async quality judge (runs after response is delivered)
-            if not forced and observation.response_text and os.environ.get("ANTHROPIC_API_KEY"):
-                asyncio.create_task(
-                    _judge_and_update(user_message, observation.response_text, model, observation)
-                )
-            elif not forced:
-                # No judge available — fall back to binary signal
-                _llm_domain.queue_outcome(observation)
-            _request_log.append({
-                "user_message": user_message[:100],
-                "model_selected": model,
-                "input_tokens": observation.input_tokens,
-                "output_tokens": observation.output_tokens,
-                "cost_usd": observation.cost_usd,
-                "ttft_seconds": observation.ttft_seconds,
-                "total_seconds": observation.total_seconds,
-                "useful": observation.useful,
-                "forced": bool(forced),
-            })
-            # Persist LLM state after each request
-            if _llm_state_path and not forced:
-                try:
-                    _llm_domain.save_state(_llm_state_path)
-                except Exception as e:
-                    log.warning("Could not save LLM state: %s", e)
+
+    async def after_stream():
+        observation = obs_holder.get("observation")
+        if observation is None:
+            return
+        if not forced and observation.response_text and os.environ.get("ANTHROPIC_API_KEY"):
+            asyncio.create_task(
+                _judge_and_update(user_message, observation.response_text, model, observation)
+            )
+        elif not forced:
+            _llm_domain.queue_outcome(observation)
+        _request_log.append({
+            "user_message": user_message[:100],
+            "model_selected": model,
+            "input_tokens": observation.input_tokens,
+            "output_tokens": observation.output_tokens,
+            "cost_usd": observation.cost_usd,
+            "ttft_seconds": observation.ttft_seconds,
+            "total_seconds": observation.total_seconds,
+            "useful": observation.useful,
+            "forced": bool(forced),
+        })
+        if _llm_state_path and not forced:
+            try:
+                _llm_domain.save_state(_llm_state_path)
+            except Exception as e:
+                log.warning("Could not save LLM state: %s", e)
 
     return StreamingResponse(
         generate(),
         media_type="text/event-stream",
-        headers={
-            "X-Credence-Model": model,
-        },
+        headers={"X-Credence-Model": model},
+        background=BackgroundTask(after_stream),
     )
 
 

--- a/apps/python/credence_router/src/credence_router/tools/llm/provider.py
+++ b/apps/python/credence_router/src/credence_router/tools/llm/provider.py
@@ -131,28 +131,41 @@ def extract_user_message(request_body: bytes) -> str:
 async def forward_streaming(
     request_body: bytes,
     model_name: str,
+    obs_out: dict | None = None,
 ) -> AsyncIterator[tuple[bytes, Observation | None]]:
     """Forward an OpenAI-format request to the correct provider and yield SSE chunks.
 
     The request is forwarded unchanged except for the model field.
     Routes to the provider's OpenAI-compatible endpoint based on model name.
+
+    obs_out: if provided, observation is stored as obs_out["observation"]
+    in a finally block, guaranteeing delivery even on client disconnect.
     """
     spec = ALL_MODELS.get(model_name)
     if spec is None:
         log.error("Unknown model: %s", model_name)
-        yield b"", Observation(completed=False, error_type="unknown_model")
+        obs = Observation(completed=False, error_type="unknown_model")
+        if obs_out is not None:
+            obs_out["observation"] = obs
+        yield b"", obs
         return
 
     endpoint = PROVIDER_ENDPOINTS.get(spec.provider)
     if endpoint is None:
         log.error("Unknown provider: %s", spec.provider)
-        yield b"", Observation(completed=False, error_type="unknown_provider")
+        obs = Observation(completed=False, error_type="unknown_provider")
+        if obs_out is not None:
+            obs_out["observation"] = obs
+        yield b"", obs
         return
 
     api_key = os.environ.get(endpoint["env_var"], "").strip()
     if not api_key:
         log.error("Missing API key for %s: %s not set", spec.provider, endpoint["env_var"])
-        yield b"", Observation(completed=False, error_type="missing_api_key")
+        obs = Observation(completed=False, error_type="missing_api_key")
+        if obs_out is not None:
+            obs_out["observation"] = obs
+        yield b"", obs
         return
 
     base_url = endpoint["base_url"]
@@ -171,101 +184,102 @@ async def forward_streaming(
     completed = False
     error_type = None
     truncated = False
-    response_parts: list[str] = []  # buffer response text for quality judging
+    response_parts: list[str] = []
+    observation = None
 
-    async with httpx.AsyncClient() as client:
-        try:
-            async with client.stream(
-                "POST",
-                base_url,
-                headers={
-                    endpoint["auth_header"]: auth_value,
-                    "Content-Type": "application/json",
-                },
-                content=json.dumps(data),
-                timeout=120.0,
-            ) as response:
-                if response.status_code in (401, 403):
-                    error_type = "auth"
-                    log.error("%s auth failed (HTTP %d)", spec.provider, response.status_code)
-                    raise httpx.HTTPStatusError(
-                        f"Auth failed: {response.status_code}",
-                        request=response.request,
-                        response=response,
-                    )
-                if response.status_code == 429:
-                    error_type = "rate_limit"
-                    log.error("%s rate limited", spec.provider)
-                elif response.status_code >= 500:
-                    error_type = "server_error"
-                    log.error("%s server error: %d", spec.provider, response.status_code)
+    try:
+        async with httpx.AsyncClient() as client:
+            try:
+                async with client.stream(
+                    "POST",
+                    base_url,
+                    headers={
+                        endpoint["auth_header"]: auth_value,
+                        "Content-Type": "application/json",
+                    },
+                    content=json.dumps(data),
+                    timeout=120.0,
+                ) as response:
+                    if response.status_code in (401, 403):
+                        error_type = "auth"
+                        log.error("%s auth failed (HTTP %d)", spec.provider, response.status_code)
+                        raise httpx.HTTPStatusError(
+                            f"Auth failed: {response.status_code}",
+                            request=response.request,
+                            response=response,
+                        )
+                    if response.status_code == 429:
+                        error_type = "rate_limit"
+                        log.error("%s rate limited", spec.provider)
+                    elif response.status_code >= 500:
+                        error_type = "server_error"
+                        log.error("%s server error: %d", spec.provider, response.status_code)
 
-                first_chunk = True
-                async for chunk in response.aiter_bytes():
-                    if first_chunk:
-                        ttft = time.monotonic() - t_start
-                        first_chunk = False
-                    yield chunk, None
+                    first_chunk = True
+                    async for chunk in response.aiter_bytes():
+                        if first_chunk:
+                            ttft = time.monotonic() - t_start
+                            first_chunk = False
+                        yield chunk, None
 
-                    # Parse SSE for usage + finish reason
-                    for line in chunk.decode("utf-8", errors="replace").split("\n"):
-                        if not line.startswith("data: ") or line.strip() == "data: [DONE]":
-                            continue
-                        try:
-                            event = json.loads(line[6:])
-                            # OpenAI format: usage in final chunk
-                            usage = event.get("usage")
-                            if usage:
-                                input_tokens = usage.get("prompt_tokens", usage.get("input_tokens", input_tokens))
-                                output_tokens = usage.get("completion_tokens", usage.get("output_tokens", output_tokens))
-                            # Extract content text for quality judging
-                            choices = event.get("choices", [])
-                            if choices:
-                                delta = choices[0].get("delta", {})
-                                content = delta.get("content")
-                                if content:
-                                    response_parts.append(content)
-                                finish = choices[0].get("finish_reason")
-                                if finish in ("stop", "end_turn"):
-                                    completed = True
-                                elif finish in ("length", "max_tokens"):
-                                    completed = True
-                                    truncated = True
-                        except (json.JSONDecodeError, KeyError, IndexError):
-                            pass
+                        for line in chunk.decode("utf-8", errors="replace").split("\n"):
+                            if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                                continue
+                            try:
+                                event = json.loads(line[6:])
+                                usage = event.get("usage")
+                                if usage:
+                                    input_tokens = usage.get("prompt_tokens", usage.get("input_tokens", input_tokens))
+                                    output_tokens = usage.get("completion_tokens", usage.get("output_tokens", output_tokens))
+                                choices = event.get("choices", [])
+                                if choices:
+                                    delta = choices[0].get("delta", {})
+                                    content = delta.get("content")
+                                    if content:
+                                        response_parts.append(content)
+                                    finish = choices[0].get("finish_reason")
+                                    if finish in ("stop", "end_turn"):
+                                        completed = True
+                                    elif finish in ("length", "max_tokens"):
+                                        completed = True
+                                        truncated = True
+                            except (json.JSONDecodeError, KeyError, IndexError):
+                                pass
 
-                if error_type is None and not completed:
-                    completed = True
+                    if error_type is None and not completed:
+                        completed = True
 
-        except httpx.TimeoutException:
-            error_type = "timeout"
-            log.error("Request timed out for %s/%s", spec.provider, model_name)
-        except httpx.ConnectError as e:
-            error_type = "timeout"
-            log.error("Connection error for %s: %s", spec.provider, e)
+            except httpx.TimeoutException:
+                error_type = "timeout"
+                log.error("Request timed out for %s/%s", spec.provider, model_name)
+            except httpx.ConnectError as e:
+                error_type = "timeout"
+                log.error("Connection error for %s: %s", spec.provider, e)
+    finally:
+        total_seconds = time.monotonic() - t_start
+        cost = compute_cost(spec, input_tokens, output_tokens)
+        response_text = "".join(response_parts)
 
-    total_seconds = time.monotonic() - t_start
-    cost = compute_cost(spec, input_tokens, output_tokens)
+        observation = Observation(
+            completed=completed and error_type is None,
+            error_type=error_type,
+            ttft_seconds=ttft,
+            total_seconds=total_seconds,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            truncated=truncated,
+            cost_usd=cost,
+            response_text=response_text,
+        )
 
-    response_text = "".join(response_parts)
+        log.info(
+            "%s/%s: %s in %.1fs (ttft=%.2fs, %d+%d tok, $%.4f)",
+            spec.provider, model_name,
+            "ok" if observation.useful else error_type or "failed",
+            total_seconds, ttft, input_tokens, output_tokens, cost,
+        )
 
-    observation = Observation(
-        completed=completed and error_type is None,
-        error_type=error_type,
-        ttft_seconds=ttft,
-        total_seconds=total_seconds,
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        truncated=truncated,
-        cost_usd=cost,
-        response_text=response_text,
-    )
-
-    log.info(
-        "%s/%s: %s in %.1fs (ttft=%.2fs, %d+%d tok, $%.4f)",
-        spec.provider, model_name,
-        "ok" if observation.useful else error_type or "failed",
-        total_seconds, ttft, input_tokens, output_tokens, cost,
-    )
+        if obs_out is not None:
+            obs_out["observation"] = observation
 
     yield b"", observation

--- a/apps/python/credence_router/tests/test_streaming_metrics.py
+++ b/apps/python/credence_router/tests/test_streaming_metrics.py
@@ -1,0 +1,214 @@
+# Role: body
+"""Tests that streaming metrics are recorded even when the client disconnects.
+
+The proxy uses async generators to stream SSE responses. When clients close the
+connection after data: [DONE], the generator is abandoned (GeneratorExit). These
+tests verify that observation data and request metrics survive that scenario.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from credence_router.routing_domain import Observation
+
+
+# ---------------------------------------------------------------------------
+# forward_streaming: obs_out populated on aclose (simulated client disconnect)
+# ---------------------------------------------------------------------------
+
+
+def test_forward_streaming_obs_out_on_aclose():
+    """forward_streaming stores observation in obs_out even when generator is
+    abandoned via aclose() (simulates client disconnect)."""
+
+    async def _run():
+        from credence_router.tools.llm.provider import forward_streaming
+
+        obs_holder: dict = {}
+
+        fake_chunks = [
+            b'data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}\n\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+
+        class FakeResponse:
+            status_code = 200
+
+            async def aiter_bytes(self):
+                for chunk in fake_chunks:
+                    yield chunk
+
+            async def aread(self):
+                return b""
+
+            async def aclose(self):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeClient:
+            def stream(self, *args, **kwargs):
+                return FakeResponse()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        with patch("credence_router.tools.llm.provider.httpx.AsyncClient", return_value=FakeClient()):
+            gen = forward_streaming(
+                b'{"model":"auto","messages":[{"role":"user","content":"hi"}]}',
+                "claude-haiku-4-5",
+                obs_out=obs_holder,
+            )
+
+            chunk, obs = await gen.__anext__()
+            assert obs is None
+            await gen.aclose()
+
+        assert "observation" in obs_holder
+        obs = obs_holder["observation"]
+        assert isinstance(obs, Observation)
+
+    asyncio.run(_run())
+
+
+def test_forward_streaming_obs_out_on_normal_completion():
+    """forward_streaming stores observation in obs_out on normal completion too."""
+
+    async def _run():
+        from credence_router.tools.llm.provider import forward_streaming
+
+        obs_holder: dict = {}
+
+        fake_chunks = [
+            b'data: {"choices":[{"delta":{"content":"world"},"finish_reason":null}]}\n\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":3}}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+
+        class FakeResponse:
+            status_code = 200
+
+            async def aiter_bytes(self):
+                for chunk in fake_chunks:
+                    yield chunk
+
+            async def aread(self):
+                return b""
+
+            async def aclose(self):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeClient:
+            def stream(self, *args, **kwargs):
+                return FakeResponse()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        with patch("credence_router.tools.llm.provider.httpx.AsyncClient", return_value=FakeClient()):
+            gen = forward_streaming(
+                b'{"model":"auto","messages":[{"role":"user","content":"hi"}]}',
+                "claude-haiku-4-5",
+                obs_out=obs_holder,
+            )
+            async for _chunk, _obs in gen:
+                pass
+
+        assert "observation" in obs_holder
+        obs = obs_holder["observation"]
+        assert obs.input_tokens == 8
+        assert obs.output_tokens == 3
+        assert obs.completed
+        assert obs.response_text == "world"
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# server generate() + BackgroundTask: _request_log populated after response
+# ---------------------------------------------------------------------------
+
+
+def test_request_log_populated_via_background_task():
+    """BackgroundTask appends to _request_log after response completes."""
+    import credence_router.server as srv
+
+    old_log = srv._request_log.copy()
+    old_domain = srv._llm_domain
+    old_state_path = srv._llm_state_path
+    old_brain = srv._brain
+    srv._request_log.clear()
+    srv._llm_state_path = None
+
+    fake_obs = Observation(
+        completed=True,
+        input_tokens=42,
+        output_tokens=17,
+        cost_usd=0.001,
+        ttft_seconds=0.5,
+        total_seconds=2.0,
+    )
+
+    try:
+        from starlette.testclient import TestClient
+        from credence_router.server import app
+
+        mock_domain = type("MockDomain", (), {
+            "route": lambda self, msg: type("D", (), {"provider_name": "claude-haiku-4-5"})(),
+            "queue_outcome": lambda self, obs: None,
+            "provider_names": ["claude-haiku-4-5"],
+            "load_state": lambda self, path: None,
+        })()
+
+        async def fake_forward(body, model, obs_out=None):
+            if obs_out is not None:
+                obs_out["observation"] = fake_obs
+            yield b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n", None
+            yield b"data: [DONE]\n\n", None
+            yield b"", fake_obs
+
+        with (
+            patch("credence_router.server._init_llm_domain"),
+            patch("credence_router.tools.llm.provider.forward_streaming", fake_forward),
+            patch.dict("os.environ", {"CREDENCE_FORCE_MODEL": "claude-haiku-4-5"}, clear=False),
+        ):
+            srv._llm_domain = mock_domain
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/v1/chat/completions",
+                    json={"model": "auto", "messages": [{"role": "user", "content": "test"}]},
+                )
+                assert resp.status_code == 200
+
+        assert len(srv._request_log) == 1
+        record = srv._request_log[0]
+        assert record["input_tokens"] == 42
+        assert record["output_tokens"] == 17
+        assert record["cost_usd"] == 0.001
+        assert record["model_selected"] == "claude-haiku-4-5"
+
+    finally:
+        srv._request_log.clear()
+        srv._request_log.extend(old_log)
+        srv._llm_domain = old_domain
+        srv._llm_state_path = old_state_path
+        srv._brain = old_brain


### PR DESCRIPTION
## Summary

Fixes the server-side metrics collection bug discovered during Move 2 session 2 (feasibility check). When SSE clients disconnect after `data: [DONE]`, the proxy's async generators were abandoned via `GeneratorExit` before post-yield bookkeeping could execute, causing `_request_log` entries to be silently lost.

## Inventory

Two async generators with post-yield bookkeeping, chained in a producer-consumer relationship:

**Site 1: `provider.py` — `forward_streaming()`** (lines 131-272)
- Post-yield code: Observation construction, cost computation, provider completion log
- Fix: `try/finally` around the streaming body; observation constructed in `finally` and stored via `obs_out` dict side-channel

**Site 2: `server.py` — `generate()`** (lines 282-314)
- Post-yield code: `_request_log.append()`, quality judge scheduling, state persistence
- Fix: all bookkeeping moved to `after_stream()` coroutine, passed as a Starlette `BackgroundTask` which runs after the response completes regardless of client disconnect

## Fix pattern

`forward_streaming` accumulates token counts, timing, and response text in local variables during streaming. The `finally` block constructs the `Observation` from whatever state was accumulated (complete on normal exit, partial on early disconnect) and stores it via `obs_out["observation"]`. The `BackgroundTask` in `server.py` reads from this dict after the response is done.

## Test plan

- [x] `test_forward_streaming_obs_out_on_aclose` — simulates client disconnect via `aclose()`, verifies `obs_out` is populated
- [x] `test_forward_streaming_obs_out_on_normal_completion` — verifies `obs_out` works on normal completion with correct token counts
- [x] `test_request_log_populated_via_background_task` — full integration test with mock `forward_streaming`, verifies `_request_log` gets a record with correct fields
- [x] 116 existing tests pass, 0 regressions, credence-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)