### PR TITLE
posture-5/move-2: design doc amendments — threshold derivation, race-window clarity, decay self-tuning

### DIFF
--- a/docs/posture-5/move-2-design.md
+++ b/docs/posture-5/move-2-design.md
@@ -740,17 +740,19 @@ processing. If compaction completes before the sidecar processes the
 compaction preview, the instruction registration may race with the
 post-compaction tool calls.
 
-**Mitigation.** The sidecar processes the compaction preview synchronously
-within the `/compaction-preview` handler. The HTTP request completes when
-processing finishes. The plugin sends the request and awaits the response
-before returning from the hook handler. Since the hook is void, OpenClaw
-doesn't wait for the plugin's return — but the sidecar's state is updated
-as soon as the HTTP response returns. The race window is the time between
-the sidecar's response and the next `before_tool_call` evaluation, which
-is typically milliseconds. If a tool call arrives during the race window,
-it evaluates against a stale (pre-compaction) posterior, which is
-conservative (the elevated threshold isn't yet active, so the tool call
-proceeds without escalation). The next tool call sees the updated posterior.
+**Mitigation.** The plugin `await`s the sidecar's HTTP response inside the
+hook handler, so the sidecar's state is updated before the handler returns.
+But `before_compaction` is a void hook — OpenClaw does not wait for the
+plugin's handler to return before proceeding. The race window is therefore
+bounded by agent-side latency: the time between OpenClaw firing the hook
+and the agent's next tool call. In practice this is tens of milliseconds
+(the sidecar's `/compaction-preview` handler runs in <10ms; the plugin's
+`await` adds only HTTP round-trip). If a tool call arrives during this
+window, it evaluates against a pre-compaction posterior — the elevated
+threshold is not yet active, so the tool call proceeds without escalation.
+This is the same outcome as not having Credence installed at all: the
+failure mode of the race window is identical to the no-Credence baseline,
+not worse than it.
 
 ## 7. Test plan
 

--- a/docs/posture-5/move-2-design.md
+++ b/docs/posture-5/move-2-design.md
@@ -120,10 +120,17 @@ posterior's uncertainty about the comparison. The margin condition prevents
 triggering on noise — the sidecar only vetoes when the alternative is
 confidently better, not when the comparison is ambiguous.
 
-The margin is derived from the posterior itself: the sidecar computes the
-probability P(EU(alt) > EU(proceed)) under the current posterior, and triggers
-downgrade when this probability exceeds a threshold (e.g., 0.9). This is a
-Bayesian comparison, not a point-estimate comparison.
+The margin is derived from the posterior itself: the sidecar computes
+P(EU(alt) > EU(proceed)) under the current posterior. Downgrade fires when
+this probability exceeds 1 − 1/(α + β), where α and β are the Beta
+parameters of the tool-success belief for the candidate action class. A
+fresh prior (α = β = 1) yields a threshold of 0.5 — downgrade fires on
+any evidence of alternative superiority, which is correct: the sidecar has
+no reason to prefer the candidate. As observations accumulate, the
+threshold rises toward 1, requiring stronger evidence to override a
+well-established tool. This is not a tuning parameter; it is a consequence
+of demanding that the downgrade decision's confidence scale with the
+posterior's own precision.
 
 In v0.1, the alternative space is limited: the sidecar considers only the
 "read instead of exec" substitution (the dominant pattern from Issue #34574)
@@ -180,12 +187,17 @@ function for the proposed action's class. When the variance-to-mean ratio of
 EU(proceed) exceeds a threshold, the sidecar cannot confidently determine whether
 the user would want this action — the correct response is to ask.
 
-The threshold is derived from the posterior's own uncertainty structure. The
-sidecar computes P(EU(proceed) > 0) and P(EU(proceed) < 0) under the current
-posterior. When both probabilities are substantial (neither exceeds 0.8), the
-action's desirability is genuinely uncertain, and escalation fires. This is the
-"two-sided uncertainty" condition — not "I think this is bad" (that would be
-veto) but "I don't know if this is good or bad" (that is escalation).
+The threshold is derived from the posterior's own concentration. The sidecar
+computes the coefficient of variation (CV) of EU(proceed) under the current
+posterior. When CV exceeds 1/√(α + β) — where α and β are the Beta
+parameters of the action-class preference belief — escalation fires. A fresh
+prior (α = β = 1) yields CV threshold 1/√2 ≈ 0.71, making escalation easy
+to trigger, which is correct: the sidecar has little evidence about user
+preference and should ask. As observations accumulate, √(α + β) grows and
+the threshold tightens, requiring proportionally less uncertainty to stay
+silent. This mirrors the downgrade threshold's derivation: both are
+consequences of scaling decision confidence with posterior precision, not
+independent tuning parameters.
 
 The escalation threshold is also elevated by the compaction-survival mechanism
 (§5.4): when the sidecar detects a lost user instruction, it raises the

--- a/docs/posture-5/move-2-design.md
+++ b/docs/posture-5/move-2-design.md
@@ -528,6 +528,16 @@ dogma. If the user's behaviour after compaction consistently approves actions
 in the guarded class, the agent learns that the instruction is no longer
 load-bearing and stops escalating.
 
+The decay mechanism has a second, less obvious property: it discovers user
+preferences that the user never explicitly stated. A user who consistently
+denies escalation prompts for a particular action class is providing
+evidence that those actions are undesirable — the posterior shifts even
+though the user never typed "don't do X". The same mechanism that retires
+stale instructions also learns new constraints from the user's approval
+and denial patterns. This is preference discovery via Bayesian updating
+on revealed choices, not a separate feature — it falls out of the same
+posterior that governs escalation thresholds.
+
 #### Known limitations
 
 v0.1's pattern matching misses instructions phrased in unusual ways. Examples:


### PR DESCRIPTION
## Summary

- **Threshold derivation**: Replace hardcoded 0.8/0.9 thresholds in §5.1 with posterior-derived conditions — downgrade fires at P > 1−1/(α+β), escalate fires at CV > 1/√(α+β). Both scale with Beta precision, no tuning parameters.
- **Race-window clarity**: Rewrite Risk 7 mitigation to distinguish plugin-internal `await` (blocks the handler) from OpenClaw's void hook semantics (fire-and-forget). Name the failure mode: identical to the no-Credence baseline.
- **Decay self-tuning**: Name the preference-discovery property in §5.4 — the same posterior that retires stale instructions also learns new constraints from approval/denial patterns.

## Test plan

- [ ] Verify threshold formulas are internally consistent across §5.1 escalate and downgrade
- [ ] Verify Risk 7 rewrite doesn't contradict §5.4's `before_compaction` description
- [ ] Verify self-tuning paragraph doesn't claim a mechanism beyond what's already described

🤖 Generated with [Claude Code](https://claude.com/claude-code)