### PR TITLE
posture-5/move-2 sub-PR 2: intervention vocabulary

### DIFF
--- a/apps/openclaw-plugin/README.md
+++ b/apps/openclaw-plugin/README.md
@@ -36,14 +36,19 @@ plugins:
 1. Plugin registers on `before_tool_call` and `after_tool_call` hooks.
 2. Before each tool call, the plugin sends the candidate call and recent
    history to the sidecar at `POST /evaluate`.
-3. If the sidecar returns `{ action: "block" }`, the plugin vetoes the
-   tool call with a descriptive reason.
-4. After each tool call, the plugin sends the outcome to the sidecar at
-   `POST /observe` (fire-and-forget, no latency impact).
-5. If the sidecar is unavailable, the plugin fails open (no intervention).
+3. The sidecar returns an enriched response with a `decision` field
+   (`proceed`, `halt`, `downgrade`, `route`, or `escalate`) and optional
+   `signals` (alpha, beta, EU values) plus `requireApproval` payload.
+4. The plugin renders the decision as an OpenClaw hook return value:
+   - **proceed / route** — no intervention (`undefined`).
+   - **halt** — block with reason (`{ block: true, blockReason: "..." }`).
+   - **downgrade** — block with reason suggesting an alternative tool.
+   - **escalate** — request user approval (`{ requireApproval: { ... } }`).
+5. After each tool call, the plugin sends the outcome to the sidecar at
+   `POST /observe` (fire-and-forget). If the call was an escalation, the
+   user's approval decision is forwarded as `userApproval: boolean`.
+6. If the sidecar is unavailable, the plugin fails open (no intervention).
 
-## Prototype scope
-
-This prototype demonstrates only **loop detection** (veto when the same tool
-with the same arguments is called more than N times). Move 2 wires up the
-full Credence brain with four intervention types.
+The sidecar response is backwards-compatible with the Move 1 `action`
+field: if `decision` is absent, the plugin falls back to mapping
+`action: "block"` to `halt` and `action: "proceed"` to `proceed`.

--- a/apps/openclaw-plugin/src/index.ts
+++ b/apps/openclaw-plugin/src/index.ts
@@ -1,5 +1,9 @@
 import { SidecarClient } from "./sidecar-client.js";
-import type { EvaluateRequest } from "./sidecar-client.js";
+import type {
+  EvaluateRequest,
+  EvaluateResponse,
+  RequireApprovalPayload,
+} from "./sidecar-client.js";
 
 type ToolHistoryEntry = {
   toolName: string;
@@ -8,6 +12,47 @@ type ToolHistoryEntry = {
 };
 
 const HISTORY_WINDOW = 50;
+
+function renderDecision(response: EvaluateResponse): Record<string, unknown> | undefined {
+  const decision = response.decision ?? (response.action === "block" ? "halt" : "proceed");
+
+  switch (decision) {
+    case "proceed":
+    case "route":
+      return undefined;
+
+    case "halt":
+      return {
+        block: true,
+        blockReason: `Credence governance: ${response.reason ?? "tool call vetoed by expected utility calculation"}`,
+      };
+
+    case "downgrade":
+      return {
+        block: true,
+        blockReason: `Credence governance: ${response.reason ?? "alternative tool has higher expected utility"}`,
+      };
+
+    case "escalate": {
+      const payload = response.requireApproval;
+      if (payload != null) {
+        return { requireApproval: payload };
+      }
+      return {
+        requireApproval: {
+          title: "Credence governance check",
+          description: response.reason ?? "The proposed action has uncertain expected utility. Confirm to proceed.",
+          severity: "warning",
+          timeoutMs: 120000,
+          timeoutBehavior: "deny",
+        } satisfies RequireApprovalPayload,
+      };
+    }
+
+    default:
+      return undefined;
+  }
+}
 
 export default {
   id: "credence-governance",
@@ -23,6 +68,7 @@ export default {
 
     const client = new SidecarClient(sidecarUrl, timeoutMs);
     const recentHistory: ToolHistoryEntry[] = [];
+    let pendingEscalation: { toolName: string; params: Record<string, unknown> } | null = null;
 
     api.on(
       "before_tool_call",
@@ -36,16 +82,14 @@ export default {
           recentHistory: recentHistory.slice(-HISTORY_WINDOW),
         };
 
-        const decision = await client.evaluate(req);
+        const response = await client.evaluate(req);
+        const decision = response.decision ?? (response.action === "block" ? "halt" : "proceed");
 
-        if (decision.action === "block") {
-          return {
-            block: true,
-            blockReason: `Credence governance: ${decision.reason ?? "tool call vetoed by expected utility calculation"}`,
-          };
+        if (decision === "escalate") {
+          pendingEscalation = { toolName: event.toolName, params: event.params };
         }
 
-        return undefined;
+        return renderDecision(response);
       },
       { priority: 100 },
     );
@@ -56,6 +100,7 @@ export default {
       result?: unknown;
       error?: string;
       durationMs?: number;
+      userApproval?: boolean;
     }) => {
       const entry: ToolHistoryEntry = {
         toolName: event.toolName,
@@ -67,6 +112,13 @@ export default {
         recentHistory.shift();
       }
 
+      let approval: boolean | null = null;
+      if (pendingEscalation != null &&
+          pendingEscalation.toolName === event.toolName) {
+        approval = event.userApproval ?? true;
+        pendingEscalation = null;
+      }
+
       client.observe({
         toolName: event.toolName,
         params: event.params,
@@ -74,11 +126,13 @@ export default {
         error: event.error,
         durationMs: event.durationMs,
         timestamp: entry.timestamp,
+        userApproval: approval,
       });
     });
 
     api.on("agent_end", async () => {
       recentHistory.length = 0;
+      pendingEscalation = null;
     });
   },
 };

--- a/apps/openclaw-plugin/src/sidecar-client.ts
+++ b/apps/openclaw-plugin/src/sidecar-client.ts
@@ -8,9 +8,31 @@ export type EvaluateRequest = {
   }>;
 };
 
+export type EvaluateSignals = {
+  alpha: number;
+  beta: number;
+  comparison_p: number;
+  cv: number;
+  eu_proceed: number;
+  eu_halt: number;
+  eu_downgrade: number;
+  eu_escalate: number;
+};
+
+export type RequireApprovalPayload = {
+  title: string;
+  description: string;
+  severity: "warning" | "error" | "info";
+  timeoutMs: number;
+  timeoutBehavior: "deny" | "allow";
+};
+
 export type EvaluateResponse = {
-  action: "proceed" | "block";
+  action: "proceed" | "block" | "escalate";
+  decision?: "proceed" | "halt" | "downgrade" | "route" | "escalate";
   reason?: string;
+  signals?: EvaluateSignals;
+  requireApproval?: RequireApprovalPayload | null;
 };
 
 export type ObserveRequest = {
@@ -20,6 +42,7 @@ export type ObserveRequest = {
   error?: string;
   durationMs?: number;
   timestamp: number;
+  userApproval?: boolean | null;
 };
 
 export class SidecarClient {


### PR DESCRIPTION
## Summary

- Plugin interprets the sidecar's enriched response (`decision`, `signals`, `requireApproval`) and renders all four intervention types as OpenClaw hook return values
- Backwards-compatible: falls back to Move 1's `action` field when `decision` is absent
- Escalation tracking: forwards `userApproval: boolean` to `/observe` after user responds to a `requireApproval` dialog

## Changes

- `sidecar-client.ts`: Added `EvaluateSignals`, `RequireApprovalPayload` types; enriched `EvaluateResponse` with `decision`/`signals`/`requireApproval`; added `userApproval` to `ObserveRequest`
- `index.ts`: Extracted `renderDecision()` dispatch (proceed/route → undefined, halt/downgrade → block, escalate → requireApproval); added `pendingEscalation` tracking for userApproval forwarding; cleanup on `agent_end`
- `README.md`: Updated to document the five decision types and backwards compatibility

## Test plan

- [ ] `tsc --noEmit` passes (verified locally)
- [ ] `credence-lint check apps/` clean (verified locally, 0 violations)
- [ ] Manual: sidecar returns `{ decision: "proceed" }` → plugin returns undefined (no intervention)
- [ ] Manual: sidecar returns `{ decision: "halt", reason: "..." }` → plugin returns `{ block: true, blockReason: "..." }`
- [ ] Manual: sidecar returns `{ decision: "escalate" }` → plugin returns `{ requireApproval: { ... } }`
- [ ] Manual: Move 1 response `{ action: "block" }` (no decision field) → plugin maps to halt correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)