### PR TITLE
posture-5/move-2 sub-PR 3: persistence machinery

### DIFF
--- a/apps/credence-governance-sidecar/persistence.jl
+++ b/apps/credence-governance-sidecar/persistence.jl
@@ -1,0 +1,164 @@
+# Role: body
+#
+# State persistence for the governance sidecar.
+# Loaded by server.jl after brain.jl.
+
+using Dates
+using Random
+
+const SIDECAR_SCHEMA_VERSION = 1
+const DEFAULT_STATE_DIR = joinpath(homedir(), ".credence", "state")
+const STATE_FILENAME = "posterior.json"
+
+function get_state_dir()::String
+    get(ENV, "CREDENCE_STATE_DIR", DEFAULT_STATE_DIR)
+end
+
+function get_state_path()::String
+    joinpath(get_state_dir(), STATE_FILENAME)
+end
+
+function generate_uuid4()::String
+    bytes = rand(UInt8, 16)
+    bytes[7] = (bytes[7] & 0x0f) | 0x40  # version 4
+    bytes[9] = (bytes[9] & 0x3f) | 0x80  # variant 1
+    hex = bytes2hex(bytes)
+    "$(hex[1:8])-$(hex[9:12])-$(hex[13:16])-$(hex[17:20])-$(hex[21:32])"
+end
+
+function now_iso8601()::String
+    Dates.format(now(Dates.UTC), dateformat"yyyy-mm-ddTHH:MM:SSZ")
+end
+
+function serialize_tool_posteriors(outcomes::Dict{PosteriorKey, BetaMeasure})::Dict{String, Any}
+    result = Dict{String, Any}()
+    for (key, m) in outcomes
+        k = "$(key.tool_name):$(key.category)"
+        # credence-lint: allow — precedent:expect-through-accessor — serialising alpha/beta for state persistence
+        result[k] = Dict{String, Any}("alpha" => m.alpha, "beta" => m.beta)
+    end
+    result
+end
+
+function deserialize_tool_posteriors(data)::Dict{PosteriorKey, BetaMeasure}
+    result = Dict{PosteriorKey, BetaMeasure}()
+    for (k, v) in data
+        parts = split(string(k), ":", limit=2)
+        length(parts) == 2 || error("Malformed posterior key: $k (expected 'tool_name:category')")
+        tool_name, category = String(parts[1]), String(parts[2])
+        alpha = Float64(v isa Dict ? v["alpha"] : v[:alpha])
+        beta = Float64(v isa Dict ? v["beta"] : v[:beta])
+        (alpha <= 0 || beta <= 0) && error("Beta parameters must be positive reals for key '$k': alpha=$alpha, beta=$beta")
+        result[PosteriorKey(tool_name, category)] = BetaMeasure(alpha, beta)
+    end
+    result
+end
+
+function serialize_model_posteriors(quality::Dict{String, Dict{String, BetaMeasure}})::Dict{String, Any}
+    result = Dict{String, Any}()
+    for (model_id, categories) in quality
+        for (category, m) in categories
+            k = "$model_id:$category"
+            # credence-lint: allow — precedent:expect-through-accessor — serialising alpha/beta for state persistence
+            result[k] = Dict{String, Any}("alpha" => m.alpha, "beta" => m.beta)
+        end
+    end
+    result
+end
+
+function deserialize_model_posteriors(data)::Dict{String, Dict{String, BetaMeasure}}
+    result = Dict{String, Dict{String, BetaMeasure}}()
+    for (k, v) in data
+        parts = split(string(k), ":", limit=2)
+        length(parts) == 2 || error("Malformed model posterior key: $k (expected 'model_id:category')")
+        model_id, category = String(parts[1]), String(parts[2])
+        alpha = Float64(v isa Dict ? v["alpha"] : v[:alpha])
+        beta = Float64(v isa Dict ? v["beta"] : v[:beta])
+        (alpha <= 0 || beta <= 0) && error("Beta parameters must be positive reals for model key '$k': alpha=$alpha, beta=$beta")
+        if !haskey(result, model_id)
+            result[model_id] = Dict{String, BetaMeasure}()
+        end
+        result[model_id][category] = BetaMeasure(alpha, beta)
+    end
+    result
+end
+
+function reconstruct_observation_count(outcomes::Dict{PosteriorKey, BetaMeasure})::Int
+    # credence-lint: allow — precedent:expect-through-accessor — alpha/beta needed to reconstruct observation count from persisted posteriors
+    sum(Int(round(m.alpha + m.beta - 2.0)) for m in values(outcomes); init=0)
+end
+
+function save_sidecar_state(brain::BrainState, user_id::String, created_at::String)
+    dir = get_state_dir()
+    mkpath(dir)
+    chmod(dir, 0o700)
+
+    data = Dict{String, Any}(
+        "schema_version" => SIDECAR_SCHEMA_VERSION,
+        "user_id" => user_id,
+        "created_at" => created_at,
+        "updated_at" => now_iso8601(),
+        "tool_posteriors" => serialize_tool_posteriors(brain.tool_outcomes),
+        "model_posteriors" => serialize_model_posteriors(brain.model_quality),
+        "registered_instructions" => Any[],
+    )
+
+    filepath = get_state_path()
+    tmp_path = filepath * ".tmp"
+    open(tmp_path, "w") do io
+        JSON3.pretty(io, data)
+    end
+    chmod(tmp_path, 0o600)
+    Base.Filesystem.rename(tmp_path, filepath)
+    chmod(filepath, 0o600)
+end
+
+function validate_state_file(data, filepath::String)
+    sv = get(data, "schema_version", nothing)
+    sv === nothing && error("State file at $filepath missing required field 'schema_version'")
+    sv = Int(sv)
+    sv > SIDECAR_SCHEMA_VERSION && error(
+        "State file schema version $sv is newer than this sidecar supports " *
+        "(v$SIDECAR_SCHEMA_VERSION); please upgrade the sidecar"
+    )
+
+    for field in ("user_id", "tool_posteriors", "model_posteriors")
+        get(data, field, nothing) === nothing && error(
+            "State file at $filepath missing required field '$field'"
+        )
+    end
+end
+
+function load_sidecar_state!(brain::BrainState)::@NamedTuple{user_id::String, created_at::String}
+    filepath = get_state_path()
+
+    if !isfile(filepath)
+        user_id = generate_uuid4()
+        created_at = now_iso8601()
+        save_sidecar_state(brain, user_id, created_at)
+        return (; user_id, created_at)
+    end
+
+    raw = try
+        read(filepath, String)
+    catch e
+        error("Cannot read state file at $filepath: $(sprint(showerror, e))")
+    end
+
+    data = try
+        JSON3.read(raw, Dict{String, Any})
+    catch e
+        error("Malformed JSON in state file at $filepath: $(sprint(showerror, e))")
+    end
+
+    validate_state_file(data, filepath)
+
+    user_id = String(data["user_id"])
+    created_at = String(get(data, "created_at", now_iso8601()))
+
+    brain.tool_outcomes = deserialize_tool_posteriors(data["tool_posteriors"])
+    brain.model_quality = deserialize_model_posteriors(data["model_posteriors"])
+    brain.observation_count = reconstruct_observation_count(brain.tool_outcomes)
+
+    (; user_id, created_at)
+end

--- a/apps/credence-governance-sidecar/server.jl
+++ b/apps/credence-governance-sidecar/server.jl
@@ -9,6 +9,7 @@ push!(LOAD_PATH, REPO_ROOT)
 using Credence
 
 include("brain.jl")
+include("persistence.jl")
 
 const DEFAULT_PORT = 3100
 
@@ -18,8 +19,12 @@ function make_state(; max_repetitions::Int=3, prototype_fallback::Bool=true)
     brain = make_brain_state(budget_table;
                              prototype_fallback_enabled=prototype_fallback,
                              max_repetitions=max_repetitions)
+
+    (; user_id, created_at) = load_sidecar_state!(brain)
+
     history = Dict{String,Any}[]
-    return (; brain, history, start_time=now())
+    state_lock = ReentrantLock()
+    return (; brain, history, start_time=now(), user_id, created_at, state_lock)
 end
 
 function handle_evaluate(state, body::Dict{String,Any})
@@ -117,14 +122,22 @@ function run_server(; port::Int=DEFAULT_PORT, max_repetitions::Int=3, prototype_
 
     HTTP.register!(router, "POST", "/observe", function(req)
         body = JSON3.read(String(req.body), Dict{String,Any})
-        result = handle_observe(state, body)
+        result = lock(state.state_lock) do
+            r = handle_observe(state, body)
+            save_sidecar_state(state.brain, state.user_id, state.created_at)
+            r
+        end
         return HTTP.Response(200, ["Content-Type" => "application/json"],
                             JSON3.write(result))
     end)
 
     HTTP.register!(router, "POST", "/compaction-preview", function(req)
         body = JSON3.read(String(req.body), Dict{String,Any})
-        result = handle_compaction_preview(state, body)
+        result = lock(state.state_lock) do
+            r = handle_compaction_preview(state, body)
+            save_sidecar_state(state.brain, state.user_id, state.created_at)
+            r
+        end
         return HTTP.Response(200, ["Content-Type" => "application/json"],
                             JSON3.write(result))
     end)
@@ -136,6 +149,8 @@ function run_server(; port::Int=DEFAULT_PORT, max_repetitions::Int=3, prototype_
     end)
 
     println("Credence governance sidecar starting on port $port")
+    println("  user_id = $(state.user_id)")
+    println("  state_dir = $(get_state_dir())")
     println("  prototype_fallback = $prototype_fallback")
     println("  max_repetitions = $max_repetitions")
     println("  observation_count = $(state.brain.observation_count)")

--- a/test/test_governance_persistence.jl
+++ b/test/test_governance_persistence.jl
@@ -1,0 +1,453 @@
+#!/usr/bin/env julia
+"""
+    test_governance_persistence.jl — Tests for sidecar state persistence.
+
+Verifies: bootstrap, round-trip, schema validation, atomic save,
+concurrent writes, file permissions, UUID format, observation count
+reconstruction.
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, ".."))
+using Credence
+using JSON3
+
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "brain.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "persistence.jl"))
+
+function with_temp_state_dir(f)
+    dir = mktempdir()
+    old = get(ENV, "CREDENCE_STATE_DIR", nothing)
+    ENV["CREDENCE_STATE_DIR"] = dir
+    try
+        f(dir)
+    finally
+        if old === nothing
+            delete!(ENV, "CREDENCE_STATE_DIR")
+        else
+            ENV["CREDENCE_STATE_DIR"] = old
+        end
+        rm(dir; recursive=true, force=true)
+    end
+end
+
+config_path = joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "config", "budgets.json")
+bt = load_budget_table(config_path)
+
+# ── Test 1: Bootstrap — no state file ──
+
+println("=" ^ 60)
+println("TEST 1: Bootstrap with no existing state file")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    brain = make_brain_state(bt)
+    (; user_id, created_at) = load_sidecar_state!(brain)
+
+    @assert !isempty(user_id) "user_id should not be empty"
+    @assert occursin(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", user_id) "user_id should be UUID v4, got: $user_id"
+    @assert !isempty(created_at) "created_at should not be empty"
+
+    state_path = joinpath(dir, "posterior.json")
+    @assert isfile(state_path) "State file should exist after bootstrap"
+
+    dir_mode = filemode(dir) & 0o777
+    @assert dir_mode == 0o700 "State directory mode should be 0700, got $(string(dir_mode, base=8))"
+
+    file_mode = filemode(state_path) & 0o777
+    @assert file_mode == 0o600 "State file mode should be 0600, got $(string(file_mode, base=8))"
+
+    data = JSON3.read(read(state_path, String), Dict{String,Any})
+    @assert data["schema_version"] == 1 "schema_version should be 1"
+    @assert data["user_id"] == user_id
+    @assert data["created_at"] == created_at
+    @assert haskey(data, "updated_at")
+    @assert data["tool_posteriors"] isa Dict
+    @assert data["model_posteriors"] isa Dict
+    @assert data["registered_instructions"] isa AbstractVector
+    @assert isempty(data["registered_instructions"])
+end
+println("PASSED: Bootstrap creates valid state file")
+println()
+
+# ── Test 2: Round-trip — save, reload, verify exact match ──
+
+println("=" ^ 60)
+println("TEST 2: Round-trip save and reload")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    brain = make_brain_state(bt)
+    (; user_id, created_at) = load_sidecar_state!(brain)
+
+    update_posterior!(brain, "Bash", "generic", true)
+    update_posterior!(brain, "Bash", "generic", true)
+    update_posterior!(brain, "Bash", "generic", false)
+    update_posterior!(brain, "Read", "code", true)
+    save_sidecar_state(brain, user_id, created_at)
+
+    brain2 = make_brain_state(bt)
+    result2 = load_sidecar_state!(brain2)
+
+    @assert result2.user_id == user_id "user_id should survive round-trip"
+    @assert result2.created_at == created_at "created_at should survive round-trip"
+
+    m_bash = get_posterior(brain2, "Bash", "generic")
+    @assert m_bash.alpha == 3.0 "Expected Bash:generic alpha=3.0, got $(m_bash.alpha)"
+    @assert m_bash.beta == 2.0 "Expected Bash:generic beta=2.0, got $(m_bash.beta)"
+
+    m_read = get_posterior(brain2, "Read", "code")
+    @assert m_read.alpha == 2.0 "Expected Read:code alpha=2.0, got $(m_read.alpha)"
+    @assert m_read.beta == 1.0 "Expected Read:code beta=1.0, got $(m_read.beta)"
+
+    @assert brain2.observation_count == 4 "Expected observation_count=4, got $(brain2.observation_count)"
+end
+println("PASSED: Round-trip preserves exact alpha/beta and observation count")
+println()
+
+# ── Test 3: Schema version validation — reject newer ──
+
+println("=" ^ 60)
+println("TEST 3: Reject schema_version > 1")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    state_path = joinpath(dir, "posterior.json")
+    data = Dict{String,Any}(
+        "schema_version" => 2,
+        "user_id" => "00000000-0000-4000-8000-000000000000",
+        "created_at" => "2026-01-01T00:00:00Z",
+        "updated_at" => "2026-01-01T00:00:00Z",
+        "tool_posteriors" => Dict{String,Any}(),
+        "model_posteriors" => Dict{String,Any}(),
+        "registered_instructions" => Any[],
+    )
+    open(state_path, "w") do io
+        JSON3.pretty(io, data)
+    end
+
+    brain = make_brain_state(bt)
+    rejected = false
+    msg = ""
+    try
+        load_sidecar_state!(brain)
+    catch e
+        rejected = true
+        msg = sprint(showerror, e)
+    end
+    @assert rejected "Should reject schema_version 2"
+    @assert occursin("newer than this sidecar supports", msg) "Error message should mention upgrade, got: $msg"
+end
+println("PASSED: Schema version 2 rejected with clear message")
+println()
+
+# ── Test 4: Missing required fields ──
+
+println("=" ^ 60)
+println("TEST 4: Reject state files with missing required fields")
+println("=" ^ 60)
+
+required_fields = ["user_id", "tool_posteriors", "model_posteriors"]
+
+with_temp_state_dir() do dir
+    for field in required_fields
+        state_path = joinpath(dir, "posterior.json")
+        data = Dict{String,Any}(
+            "schema_version" => 1,
+            "user_id" => "00000000-0000-4000-8000-000000000000",
+            "created_at" => "2026-01-01T00:00:00Z",
+            "updated_at" => "2026-01-01T00:00:00Z",
+            "tool_posteriors" => Dict{String,Any}(),
+            "model_posteriors" => Dict{String,Any}(),
+            "registered_instructions" => Any[],
+        )
+        delete!(data, field)
+        open(state_path, "w") do io
+            JSON3.pretty(io, data)
+        end
+
+        brain = make_brain_state(bt)
+        rejected = false
+        msg = ""
+        try
+            load_sidecar_state!(brain)
+        catch e
+            rejected = true
+            msg = sprint(showerror, e)
+        end
+        @assert rejected "Should reject state file missing '$field'"
+        @assert occursin(field, msg) "Error should name missing field '$field', got: $msg"
+    end
+end
+println("PASSED: Missing required fields detected")
+println()
+
+# ── Test 5: Malformed JSON ──
+
+println("=" ^ 60)
+println("TEST 5: Reject malformed JSON")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    state_path = joinpath(dir, "posterior.json")
+    write(state_path, "{ not valid json !!!")
+
+    brain = make_brain_state(bt)
+    rejected = false
+    try
+        load_sidecar_state!(brain)
+    catch e
+        rejected = true
+    end
+    @assert rejected "Should reject malformed JSON"
+end
+println("PASSED: Malformed JSON rejected")
+println()
+
+# ── Test 6: Non-positive Beta parameters ──
+
+println("=" ^ 60)
+println("TEST 6: Reject non-positive alpha/beta")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    state_path = joinpath(dir, "posterior.json")
+    data = Dict{String,Any}(
+        "schema_version" => 1,
+        "user_id" => "00000000-0000-4000-8000-000000000000",
+        "created_at" => "2026-01-01T00:00:00Z",
+        "updated_at" => "2026-01-01T00:00:00Z",
+        "tool_posteriors" => Dict{String,Any}(
+            "Bash:generic" => Dict{String,Any}("alpha" => 0.0, "beta" => 1.0)
+        ),
+        "model_posteriors" => Dict{String,Any}(),
+        "registered_instructions" => Any[],
+    )
+    open(state_path, "w") do io
+        JSON3.pretty(io, data)
+    end
+
+    brain = make_brain_state(bt)
+    rejected = false
+    msg = ""
+    try
+        load_sidecar_state!(brain)
+    catch e
+        rejected = true
+        msg = sprint(showerror, e)
+    end
+    @assert rejected "Should reject alpha=0.0"
+    @assert occursin("positive reals", msg) "Error should mention positive reals, got: $msg"
+
+    data["tool_posteriors"] = Dict{String,Any}(
+        "Bash:generic" => Dict{String,Any}("alpha" => 1.0, "beta" => -0.5)
+    )
+    open(state_path, "w") do io
+        JSON3.pretty(io, data)
+    end
+
+    brain2 = make_brain_state(bt)
+    rejected2 = false
+    try
+        load_sidecar_state!(brain2)
+    catch
+        rejected2 = true
+    end
+    @assert rejected2 "Should reject beta=-0.5"
+end
+println("PASSED: Non-positive parameters rejected")
+println()
+
+# ── Test 7: File permissions enforced on every save ──
+
+println("=" ^ 60)
+println("TEST 7: File permissions re-enforced on save")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    brain = make_brain_state(bt)
+    (; user_id, created_at) = load_sidecar_state!(brain)
+    state_path = joinpath(dir, "posterior.json")
+
+    chmod(state_path, 0o644)
+    @assert (filemode(state_path) & 0o777) == 0o644 "Sanity: mode should be 644 after chmod"
+
+    save_sidecar_state(brain, user_id, created_at)
+    restored_mode = filemode(state_path) & 0o777
+    @assert restored_mode == 0o600 "Mode should be restored to 0600 after save, got $(string(restored_mode, base=8))"
+end
+println("PASSED: Permissions restored on save")
+println()
+
+# ── Test 8: Concurrent saves produce well-formed state ──
+
+println("=" ^ 60)
+println("TEST 8: Concurrent saves don't corrupt state")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    brain = make_brain_state(bt)
+    (; user_id, created_at) = load_sidecar_state!(brain)
+
+    state_lock = ReentrantLock()
+    tasks = map(1:100) do i
+        Threads.@spawn begin
+            lock(state_lock) do
+                update_posterior!(brain, "Bash", "generic", rand(Bool))
+                save_sidecar_state(brain, user_id, created_at)
+            end
+        end
+    end
+    foreach(wait, tasks)
+
+    state_path = joinpath(dir, "posterior.json")
+    raw = read(state_path, String)
+    data = JSON3.read(raw, Dict{String,Any})
+    @assert data["schema_version"] == 1 "State file should be well-formed after concurrent writes"
+    @assert haskey(data["tool_posteriors"], "Bash:generic")
+
+    brain2 = make_brain_state(bt)
+    result2 = load_sidecar_state!(brain2)
+    @assert result2.user_id == user_id "user_id should survive concurrent writes"
+
+    m = get_posterior(brain2, "Bash", "generic")
+    # credence-lint: allow — precedent:expect-through-accessor — verifying persisted alpha/beta after concurrent writes
+    total_obs = m.alpha + m.beta - 2.0
+    @assert total_obs == 100.0 "Expected 100 observations, got $total_obs"
+end
+println("PASSED: 100 concurrent saves produce well-formed state")
+println()
+
+# ── Test 9: UUID v4 format ──
+
+println("=" ^ 60)
+println("TEST 9: UUID v4 generation format")
+println("=" ^ 60)
+
+for _ in 1:20
+    uuid = generate_uuid4()
+    @assert occursin(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", uuid) "UUID should match v4 format, got: $uuid"
+end
+println("PASSED: 20 UUIDs all match v4 format")
+println()
+
+# ── Test 10: Observation count reconstruction ──
+
+println("=" ^ 60)
+println("TEST 10: Observation count reconstructed from posteriors")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    brain = make_brain_state(bt)
+    load_sidecar_state!(brain)
+
+    for i in 1:15
+        update_posterior!(brain, "Edit", "code", true)
+    end
+    for i in 1:7
+        update_posterior!(brain, "Bash", "deploy", false)
+    end
+    for i in 1:3
+        update_posterior!(brain, "Read", "documentation", true)
+    end
+    @assert brain.observation_count == 25 "Expected 25 observations in-memory"
+
+    save_sidecar_state(brain, "test-uid", "2026-01-01T00:00:00Z")
+
+    brain2 = make_brain_state(bt)
+    load_sidecar_state!(brain2)
+    @assert brain2.observation_count == 25 "Expected 25 observations after reload, got $(brain2.observation_count)"
+end
+println("PASSED: Observation count matches after reload")
+println()
+
+# ── Test 11: Missing schema_version field ──
+
+println("=" ^ 60)
+println("TEST 11: Reject state file with no schema_version")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    state_path = joinpath(dir, "posterior.json")
+    data = Dict{String,Any}(
+        "user_id" => "00000000-0000-4000-8000-000000000000",
+        "tool_posteriors" => Dict{String,Any}(),
+        "model_posteriors" => Dict{String,Any}(),
+        "registered_instructions" => Any[],
+    )
+    open(state_path, "w") do io
+        JSON3.pretty(io, data)
+    end
+
+    brain = make_brain_state(bt)
+    rejected = false
+    msg = ""
+    try
+        load_sidecar_state!(brain)
+    catch e
+        rejected = true
+        msg = sprint(showerror, e)
+    end
+    @assert rejected "Should reject state file without schema_version"
+    @assert occursin("schema_version", msg) "Error should mention schema_version, got: $msg"
+end
+println("PASSED: Missing schema_version rejected")
+println()
+
+# ── Test 12: CREDENCE_STATE_DIR override ──
+
+println("=" ^ 60)
+println("TEST 12: CREDENCE_STATE_DIR override")
+println("=" ^ 60)
+
+custom_dir = mktempdir()
+old_env = get(ENV, "CREDENCE_STATE_DIR", nothing)
+ENV["CREDENCE_STATE_DIR"] = custom_dir
+try
+    @assert get_state_dir() == custom_dir "get_state_dir should return custom dir"
+    @assert get_state_path() == joinpath(custom_dir, "posterior.json")
+
+    brain = make_brain_state(bt)
+    load_sidecar_state!(brain)
+    @assert isfile(joinpath(custom_dir, "posterior.json")) "State file should exist in custom dir"
+finally
+    if old_env === nothing
+        delete!(ENV, "CREDENCE_STATE_DIR")
+    else
+        ENV["CREDENCE_STATE_DIR"] = old_env
+    end
+    rm(custom_dir; recursive=true, force=true)
+end
+println("PASSED: CREDENCE_STATE_DIR override works")
+println()
+
+# ── Test 13: Model posteriors round-trip ──
+
+println("=" ^ 60)
+println("TEST 13: Model posteriors serialisation round-trip")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    brain = make_brain_state(bt)
+    (; user_id, created_at) = load_sidecar_state!(brain)
+
+    brain.model_quality["gpt-4"] = Dict{String,BetaMeasure}(
+        "code" => BetaMeasure(10.0, 3.0),
+        "documentation" => BetaMeasure(5.0, 2.0),
+    )
+    save_sidecar_state(brain, user_id, created_at)
+
+    brain2 = make_brain_state(bt)
+    load_sidecar_state!(brain2)
+
+    @assert haskey(brain2.model_quality, "gpt-4") "Model quality should survive round-trip"
+    @assert brain2.model_quality["gpt-4"]["code"].alpha == 10.0
+    @assert brain2.model_quality["gpt-4"]["code"].beta == 3.0
+    @assert brain2.model_quality["gpt-4"]["documentation"].alpha == 5.0
+    @assert brain2.model_quality["gpt-4"]["documentation"].beta == 2.0
+end
+println("PASSED: Model posteriors survive round-trip")
+println()
+
+println("=" ^ 60)
+println("ALL GOVERNANCE PERSISTENCE TESTS PASSED")
+println("=" ^ 60)


### PR DESCRIPTION
## Summary

- Sidecar gains load/save for per-user posterior state at `~/.credence/state/posterior.json` (or `CREDENCE_STATE_DIR` override)
- Schema v1: `user_id` (UUID v4), `tool_posteriors`, `model_posteriors`, `registered_instructions` (empty, reserved for sub-PR 4), timestamps
- Atomic save via temp-file-and-rename (`Base.Filesystem.rename` = POSIX `rename(2)`). `ReentrantLock` wraps `/observe` and `/compaction-preview`. `/evaluate` reads lock-free

## Details

- **Bootstrap**: On first start, generates fresh UUID v4, initialises Beta(1,1) priors, writes state file with mode 0600 in directory with mode 0700
- **Load**: Validates schema version (rejects >1 with clear upgrade message), required fields, positive alpha/beta. Reconstructs `observation_count` from posteriors
- **Save**: After every `/observe` and `/compaction-preview`, under the same lock that protects in-memory state. Permissions re-enforced on every save
- **Error paths**: Malformed JSON, missing required fields, non-positive parameters, newer schema version — all rejected with clear error messages; sidecar refuses to start rather than silently overwriting

## Halting conditions

No halting conditions triggered. The Posture 3 persistence machinery uses Julia's binary `Serialization` (schema v3 for agent state). The sidecar needs JSON with a different schema (v1 for governance posteriors). The *pattern* (version field, validation, reject-newer) is reused; the code is purpose-built for JSON. These are independent version lineages.

## Test plan

- [x] 13 tests pass locally (`julia test/test_governance_persistence.jl`)
- [x] Existing brain tests pass (`julia test/test_governance_brain.jl`)
- [x] Credence-lint clean (149 files, 0 violations)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)