### PR TITLE
posture-5/move-2 sub-PR 4: compaction-survival pattern matching

### DIFF
--- a/apps/credence-governance-sidecar/brain.jl
+++ b/apps/credence-governance-sidecar/brain.jl
@@ -4,6 +4,7 @@
 # Loaded by server.jl; uses Credence substrate types.
 
 using ..Credence
+using Dates
 
 # ── Category inference ──
 
@@ -93,6 +94,7 @@ mutable struct BrainState
     budget_table::BudgetTable
     prototype_fallback_enabled::Bool
     max_repetitions::Int
+    registered_instructions::Vector{Dict{String,Any}}
 end
 
 function make_brain_state(budget_table::BudgetTable;
@@ -105,6 +107,7 @@ function make_brain_state(budget_table::BudgetTable;
         budget_table,
         prototype_fallback_enabled,
         max_repetitions,
+        Dict{String,Any}[],
     )
 end
 
@@ -170,6 +173,21 @@ function compute_eu(state::BrainState, tool_name::AbstractString, category::Abst
     escalate_threshold = 1.0 / sqrt(concentration)  # credence-lint: allow — precedent:display-arithmetic — Amendment 1 threshold derivation
 
     escalate_fires = cv > escalate_threshold && uncertainty > 0.3
+
+    # credence-lint: allow — precedent:display-arithmetic — instruction-based escalation elevation
+    instruction_boost = 0.0
+    for inst in state.registered_instructions
+        if instruction_matches_category(string(inst["action_class"]), category)
+            ps = Float64(inst["prior_strength"])
+            approvals = Int(get(inst, "approvals", 0))
+            denials = Int(get(inst, "denials", 0))
+            denial_rate = (1.0 + denials) / (2.0 + approvals + denials)
+            instruction_boost = max(instruction_boost, ps * denial_rate)
+            escalate_fires = true
+        end
+    end
+    eu_escalate += instruction_boost
+
     # credence-lint: allow — precedent:display-arithmetic — host-level argmax decision logic
     downgrade_fires = comparison_p > downgrade_threshold && eu_downgrade > eu_proceed && eu_proceed > eu_halt
 
@@ -230,6 +248,31 @@ function _make_reason(decision::AbstractString, tool_name::AbstractString,
     else
         ""
     end
+end
+
+# ── Instruction registration ──
+
+const DEFAULT_PRIOR_STRENGTH = 5.0
+
+function register_instruction!(state::BrainState, pattern_id::String, action_class::String;
+                                prior_strength::Float64=DEFAULT_PRIOR_STRENGTH)
+    for inst in state.registered_instructions
+        if inst["pattern"] == pattern_id && inst["action_class"] == action_class
+            inst["last_seen"] = Dates.format(now(Dates.UTC), dateformat"yyyy-mm-ddTHH:MM:SSZ")
+            return false
+        end
+    end
+
+    push!(state.registered_instructions, Dict{String,Any}(
+        "pattern" => pattern_id,
+        "action_class" => action_class,
+        "registered_at" => Dates.format(now(Dates.UTC), dateformat"yyyy-mm-ddTHH:MM:SSZ"),
+        "last_seen" => Dates.format(now(Dates.UTC), dateformat"yyyy-mm-ddTHH:MM:SSZ"),
+        "prior_strength" => prior_strength,
+        "approvals" => 0,
+        "denials" => 0,
+    ))
+    true
 end
 
 # ── Prototype fallback: repetition counting ──

--- a/apps/credence-governance-sidecar/brain.jl
+++ b/apps/credence-governance-sidecar/brain.jl
@@ -275,6 +275,27 @@ function register_instruction!(state::BrainState, pattern_id::String, action_cla
     true
 end
 
+function update_instruction_decay!(state::BrainState, category::String, approved::Bool)
+    retired = Int[]
+    for (i, inst) in enumerate(state.registered_instructions)
+        instruction_matches_category(string(inst["action_class"]), category) || continue
+        if approved
+            inst["approvals"] = get(inst, "approvals", 0) + 1
+        else
+            inst["denials"] = get(inst, "denials", 0) + 1
+        end
+        # credence-lint: allow — precedent:display-arithmetic — retirement threshold check
+        approvals = Int(inst["approvals"])
+        denials = Int(inst["denials"])
+        precision = 2.0 + approvals + denials
+        prior_strength = Float64(inst["prior_strength"])
+        if precision > 10.0 * prior_strength && approvals > denials
+            push!(retired, i)
+        end
+    end
+    deleteat!(state.registered_instructions, retired)
+end
+
 # ── Prototype fallback: repetition counting ──
 
 function canonical_key(tool_name::AbstractString, params::Dict)

--- a/apps/credence-governance-sidecar/instruction_patterns.jl
+++ b/apps/credence-governance-sidecar/instruction_patterns.jl
@@ -1,0 +1,95 @@
+# Role: body
+#
+# Compaction-survival instruction patterns.
+# Seven regex patterns from the Move 2 design doc §5.4 table.
+# Loaded by server.jl before brain.jl.
+
+const DESTRUCTIVE_CLASSES = Set(["delete", "deploy", "privileged-exec", "dependency"])
+
+struct InstructionPattern
+    regex::Regex
+    action_class::String
+    id::String
+end
+
+const INSTRUCTION_PATTERNS = [
+    InstructionPattern(
+        r"confirm\s+before\s+(?:deleting|removing|dropping)"i,
+        "delete",
+        "confirm-before-delete",
+    ),
+    InstructionPattern(
+        r"(?:don'?t|do\s+not|never)\s+(?:delete|remove|drop)\b"i,
+        "delete",
+        "negation-delete",
+    ),
+    InstructionPattern(
+        r"(?:always|must)\s+ask\s+before\b"i,
+        "any-destructive",
+        "ask-before-any",
+    ),
+    InstructionPattern(
+        r"confirm\s+before\s+(?:pushing|deploying|merging)"i,
+        "deploy",
+        "confirm-before-deploy",
+    ),
+    InstructionPattern(
+        r"(?:don'?t|do\s+not|never)\s+(?:push|deploy|merge)\s+(?:to|into)\s+(?:main|master|prod)"i,
+        "deploy",
+        "negation-deploy-to-protected",
+    ),
+    InstructionPattern(
+        r"(?:don'?t|do\s+not|never)\s+run\b.*(?:sudo|as\s+root)"i,
+        "privileged-exec",
+        "negation-run-privileged",
+    ),
+    InstructionPattern(
+        r"(?:don'?t|do\s+not|never)\s+(?:install|add|upgrade)\b.*package"i,
+        "dependency",
+        "negation-install-package",
+    ),
+]
+
+function instruction_matches_category(instruction_class::String, candidate_category::String)::Bool
+    instruction_class == candidate_category && return true
+    instruction_class == "any-destructive" && candidate_category in DESTRUCTIVE_CLASSES && return true
+    false
+end
+
+function extract_message_text(msg)::String
+    content = if msg isa AbstractDict
+        c = get(msg, "content", get(msg, :content, nothing))
+        if c isa AbstractVector
+            join((get(block, "text", get(block, :text, "")) for block in c
+                  if (get(block, "type", get(block, :type, "")) == "text")), " ")
+        else
+            c
+        end
+    elseif msg isa AbstractString
+        msg
+    else
+        nothing
+    end
+    content !== nothing ? string(content) : ""
+end
+
+function match_instructions(messages::Vector)::Vector{Tuple{String, String}}
+    results = Tuple{String, String}[]
+    seen = Set{String}()
+
+    for msg in messages
+        text = extract_message_text(msg)
+        isempty(text) && continue
+
+        for pattern in INSTRUCTION_PATTERNS
+            pattern.id in seen && continue
+            m = match(pattern.regex, text)
+            if m !== nothing
+                push!(seen, pattern.id)
+                push!(results, (m.match, pattern.action_class))
+            end
+        end
+    end
+
+    results
+end

--- a/apps/credence-governance-sidecar/persistence.jl
+++ b/apps/credence-governance-sidecar/persistence.jl
@@ -100,7 +100,7 @@ function save_sidecar_state(brain::BrainState, user_id::String, created_at::Stri
         "updated_at" => now_iso8601(),
         "tool_posteriors" => serialize_tool_posteriors(brain.tool_outcomes),
         "model_posteriors" => serialize_model_posteriors(brain.model_quality),
-        "registered_instructions" => Any[],
+        "registered_instructions" => brain.registered_instructions,
     )
 
     filepath = get_state_path()
@@ -159,6 +159,12 @@ function load_sidecar_state!(brain::BrainState)::@NamedTuple{user_id::String, cr
     brain.tool_outcomes = deserialize_tool_posteriors(data["tool_posteriors"])
     brain.model_quality = deserialize_model_posteriors(data["model_posteriors"])
     brain.observation_count = reconstruct_observation_count(brain.tool_outcomes)
+
+    raw_instructions = get(data, "registered_instructions", Any[])
+    brain.registered_instructions = [
+        Dict{String,Any}(String(k) => v for (k, v) in inst)
+        for inst in raw_instructions
+    ]
 
     (; user_id, created_at)
 end

--- a/apps/credence-governance-sidecar/server.jl
+++ b/apps/credence-governance-sidecar/server.jl
@@ -8,6 +8,7 @@ const REPO_ROOT = dirname(dirname(@__DIR__))
 push!(LOAD_PATH, REPO_ROOT)
 using Credence
 
+include("instruction_patterns.jl")
 include("brain.jl")
 include("persistence.jl")
 
@@ -88,7 +89,21 @@ function handle_observe(state, body::Dict{String,Any})
 end
 
 function handle_compaction_preview(state, body::Dict{String,Any})
-    return Dict{String,Any}("status" => "ok")
+    messages = get(body, "messages", Any[])
+    messages_vec = messages isa Vector ? messages : collect(messages)
+    matches = match_instructions(messages_vec)
+    registered = String[]
+    for (matched_text, action_class) in matches
+        for pattern in INSTRUCTION_PATTERNS
+            if pattern.action_class == action_class && match(pattern.regex, matched_text) !== nothing
+                if register_instruction!(state.brain, pattern.id, action_class)
+                    push!(registered, "$(pattern.id):$(action_class)")
+                end
+                break
+            end
+        end
+    end
+    return Dict{String,Any}("status" => "ok", "registered" => registered)
 end
 
 function handle_health(state)

--- a/apps/credence-governance-sidecar/server.jl
+++ b/apps/credence-governance-sidecar/server.jl
@@ -85,6 +85,11 @@ function handle_observe(state, body::Dict{String,Any})
                                duration_ms isa Real ? duration_ms : nothing)
     update_posterior!(state.brain, tool_name, category, success)
 
+    user_approval = get(body, "userApproval", nothing)
+    if user_approval !== nothing
+        update_instruction_decay!(state.brain, category, user_approval == true)
+    end
+
     return Dict{String,Any}("status" => "ok")
 end
 

--- a/apps/openclaw-plugin/src/index.ts
+++ b/apps/openclaw-plugin/src/index.ts
@@ -130,6 +130,10 @@ export default {
       });
     });
 
+    api.on("before_compaction", (event: { messages: unknown[] }) => {
+      client.compactionPreview(event.messages);
+    });
+
     api.on("agent_end", async () => {
       recentHistory.length = 0;
       pendingEscalation = null;

--- a/apps/openclaw-plugin/src/sidecar-client.ts
+++ b/apps/openclaw-plugin/src/sidecar-client.ts
@@ -84,6 +84,19 @@ export class SidecarClient {
     }
   }
 
+  async compactionPreview(messages: unknown[]): Promise<void> {
+    try {
+      await fetch(`${this.baseUrl}/compaction-preview`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages }),
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch {
+      // fire-and-forget: sidecar unavailability doesn't block compaction
+    }
+  }
+
   async health(): Promise<boolean> {
     try {
       const response = await fetch(`${this.baseUrl}/health`, {

--- a/test/test_compaction_survival.jl
+++ b/test/test_compaction_survival.jl
@@ -1,0 +1,241 @@
+#!/usr/bin/env julia
+"""
+    test_compaction_survival.jl — Integration tests for compaction-survival.
+
+Verifies: instruction registration, persistence across restarts,
+escalation elevation, deduplication, and the full Yue/Meta lifecycle.
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, ".."))
+using Credence
+using JSON3
+using Dates
+
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "instruction_patterns.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "brain.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "persistence.jl"))
+
+function with_temp_state_dir(f)
+    dir = mktempdir()
+    old = get(ENV, "CREDENCE_STATE_DIR", nothing)
+    ENV["CREDENCE_STATE_DIR"] = dir
+    try
+        f(dir)
+    finally
+        if old === nothing
+            delete!(ENV, "CREDENCE_STATE_DIR")
+        else
+            ENV["CREDENCE_STATE_DIR"] = old
+        end
+        rm(dir; recursive=true, force=true)
+    end
+end
+
+config_path = joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "config", "budgets.json")
+bt = load_budget_table(config_path)
+
+# ── Test 1: Instruction registration ──
+
+println("=" ^ 60)
+println("TEST 1: register_instruction! creates entry")
+println("=" ^ 60)
+
+brain1 = make_brain_state(bt)
+@assert isempty(brain1.registered_instructions)
+
+added = register_instruction!(brain1, "negation-delete", "delete")
+@assert added == true "First registration should return true"
+@assert length(brain1.registered_instructions) == 1
+inst = brain1.registered_instructions[1]
+@assert inst["pattern"] == "negation-delete"
+@assert inst["action_class"] == "delete"
+@assert inst["prior_strength"] == 5.0
+@assert inst["approvals"] == 0
+@assert inst["denials"] == 0
+@assert haskey(inst, "registered_at")
+@assert haskey(inst, "last_seen")
+println("PASSED: Instruction registered correctly")
+println()
+
+# ── Test 2: Deduplication ──
+
+println("=" ^ 60)
+println("TEST 2: Deduplication — same pattern not re-registered")
+println("=" ^ 60)
+
+added2 = register_instruction!(brain1, "negation-delete", "delete")
+@assert added2 == false "Duplicate registration should return false"
+@assert length(brain1.registered_instructions) == 1 "Should still be 1 instruction"
+
+added3 = register_instruction!(brain1, "confirm-before-delete", "delete")
+@assert added3 == true "Different pattern should register"
+@assert length(brain1.registered_instructions) == 2
+println("PASSED: Deduplication works")
+println()
+
+# ── Test 3: Persistence across restart ──
+
+println("=" ^ 60)
+println("TEST 3: Instructions persist across sidecar restart")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    brain_a = make_brain_state(bt)
+    (; user_id, created_at) = load_sidecar_state!(brain_a)
+
+    register_instruction!(brain_a, "negation-delete", "delete")
+    register_instruction!(brain_a, "negation-deploy-to-protected", "deploy")
+    save_sidecar_state(brain_a, user_id, created_at)
+
+    brain_b = make_brain_state(bt)
+    load_sidecar_state!(brain_b)
+
+    @assert length(brain_b.registered_instructions) == 2 "Expected 2 instructions after reload, got $(length(brain_b.registered_instructions))"
+    patterns = Set(inst["pattern"] for inst in brain_b.registered_instructions)
+    @assert "negation-delete" in patterns
+    @assert "negation-deploy-to-protected" in patterns
+end
+println("PASSED: Instructions survive restart")
+println()
+
+# ── Test 4: Escalation elevation — post-registration ──
+
+println("=" ^ 60)
+println("TEST 4: Post-registration escalation fires for guarded class")
+println("=" ^ 60)
+
+brain4 = make_brain_state(bt)
+brain4.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+
+result_before = compute_eu(brain4, "Bash", "delete")
+@assert result_before.decision == "proceed" "Before registration, concentrated Beta(50,2) should proceed, got $(result_before.decision)"
+
+register_instruction!(brain4, "negation-delete", "delete")
+
+result_after = compute_eu(brain4, "Bash", "delete")
+@assert result_after.decision == "escalate" "After registration, delete-class tool should escalate, got $(result_after.decision)"
+
+println("PASSED: Escalation fires after instruction registration")
+println()
+
+# ── Test 5: any-destructive matches multiple categories ──
+
+println("=" ^ 60)
+println("TEST 5: any-destructive instruction escalates multiple classes")
+println("=" ^ 60)
+
+brain5 = make_brain_state(bt)
+brain5.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+brain5.tool_outcomes[PosteriorKey("Bash", "deploy")] = BetaMeasure(50.0, 2.0)
+brain5.tool_outcomes[PosteriorKey("Bash", "privileged-exec")] = BetaMeasure(50.0, 2.0)
+brain5.tool_outcomes[PosteriorKey("Edit", "code")] = BetaMeasure(50.0, 2.0)
+
+register_instruction!(brain5, "ask-before-any", "any-destructive")
+
+@assert compute_eu(brain5, "Bash", "delete").decision == "escalate" "delete should escalate"
+@assert compute_eu(brain5, "Bash", "deploy").decision == "escalate" "deploy should escalate"
+@assert compute_eu(brain5, "Bash", "privileged-exec").decision == "escalate" "privileged-exec should escalate"
+@assert compute_eu(brain5, "Edit", "code").decision != "escalate" "code should NOT escalate via any-destructive"
+
+println("PASSED: any-destructive covers delete, deploy, privileged-exec but not code")
+println()
+
+# ── Test 6: Instruction boost decays with approvals ──
+
+println("=" ^ 60)
+println("TEST 6: Instruction boost weakens with approvals")
+println("=" ^ 60)
+
+brain6 = make_brain_state(bt)
+brain6.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+register_instruction!(brain6, "negation-delete", "delete")
+
+result_fresh = compute_eu(brain6, "Bash", "delete")
+@assert result_fresh.decision == "escalate" "Fresh instruction should escalate"
+
+brain6.registered_instructions[1]["approvals"] = 40
+result_decayed = compute_eu(brain6, "Bash", "delete")
+@assert result_decayed.decision != "escalate" "After 40 approvals, instruction boost should be too weak to escalate against Beta(50,2), got $(result_decayed.decision)"
+
+println("PASSED: Instruction boost decays with approvals")
+println()
+
+# ── Test 7: Denials keep boost strong ──
+
+println("=" ^ 60)
+println("TEST 7: Denials maintain instruction strength")
+println("=" ^ 60)
+
+brain7 = make_brain_state(bt)
+brain7.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+register_instruction!(brain7, "negation-delete", "delete")
+brain7.registered_instructions[1]["denials"] = 40
+
+result_denied = compute_eu(brain7, "Bash", "delete")
+@assert result_denied.decision == "escalate" "After 40 denials, instruction should still escalate, got $(result_denied.decision)"
+
+println("PASSED: Denials maintain escalation")
+println()
+
+# ── Test 8: Unrelated categories not affected ──
+
+println("=" ^ 60)
+println("TEST 8: Registration doesn't affect unrelated categories")
+println("=" ^ 60)
+
+brain8 = make_brain_state(bt)
+brain8.tool_outcomes[PosteriorKey("Bash", "version-control")] = BetaMeasure(50.0, 2.0)
+register_instruction!(brain8, "negation-delete", "delete")
+
+result_vc = compute_eu(brain8, "Bash", "version-control")
+@assert result_vc.decision == "proceed" "version-control should not be affected by delete instruction, got $(result_vc.decision)"
+
+println("PASSED: Unrelated categories unaffected")
+println()
+
+# ── Test 9: Full Yue/Meta inbox-deletion lifecycle ──
+
+println("=" ^ 60)
+println("TEST 9: Yue/Meta lifecycle — register via compaction → escalate")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    brain9 = make_brain_state(bt)
+    (; user_id, created_at) = load_sidecar_state!(brain9)
+
+    for _ in 1:30
+        update_posterior!(brain9, "Bash", "delete", true)
+    end
+    r_before = compute_eu(brain9, "Bash", "delete")
+    @assert r_before.decision == "proceed" "Before instruction, concentrated posterior should proceed"
+
+    messages = [
+        Dict{String,Any}("role" => "user", "content" => "please confirm before deleting any files"),
+        Dict{String,Any}("role" => "assistant", "content" => "Understood, I'll ask before deleting."),
+    ]
+    matches = match_instructions(messages)
+    @assert length(matches) >= 1 "Should find at least one instruction"
+    for (_, action_class) in matches
+        for p in INSTRUCTION_PATTERNS
+            if p.action_class == action_class
+                register_instruction!(brain9, p.id, action_class)
+                break
+            end
+        end
+    end
+    save_sidecar_state(brain9, user_id, created_at)
+
+    r_after = compute_eu(brain9, "Bash", "delete")
+    @assert r_after.decision == "escalate" "After instruction, delete-class should escalate"
+
+    brain9b = make_brain_state(bt)
+    load_sidecar_state!(brain9b)
+    r_reloaded = compute_eu(brain9b, "Bash", "delete")
+    @assert r_reloaded.decision == "escalate" "After restart, instruction should still escalate"
+end
+println("PASSED: Yue/Meta lifecycle — compaction → registration → escalation → persistence")
+println()
+
+println("=" ^ 60)
+println("ALL COMPACTION-SURVIVAL TESTS PASSED")
+println("=" ^ 60)

--- a/test/test_instruction_decay.jl
+++ b/test/test_instruction_decay.jl
@@ -1,0 +1,279 @@
+#!/usr/bin/env julia
+"""
+    test_instruction_decay.jl — Tests for instruction decay and retirement.
+
+Verifies: approval-driven retirement, denial-driven persistence,
+retirement threshold (10× prior_strength), and full lifecycle
+trajectories.
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, ".."))
+using Credence
+using JSON3
+using Dates
+
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "instruction_patterns.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "brain.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "persistence.jl"))
+
+function with_temp_state_dir(f)
+    dir = mktempdir()
+    old = get(ENV, "CREDENCE_STATE_DIR", nothing)
+    ENV["CREDENCE_STATE_DIR"] = dir
+    try
+        f(dir)
+    finally
+        if old === nothing
+            delete!(ENV, "CREDENCE_STATE_DIR")
+        else
+            ENV["CREDENCE_STATE_DIR"] = old
+        end
+        rm(dir; recursive=true, force=true)
+    end
+end
+
+config_path = joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "config", "budgets.json")
+bt = load_budget_table(config_path)
+
+# ── Test 1: Approval increments ──
+
+println("=" ^ 60)
+println("TEST 1: Approval increments approval count")
+println("=" ^ 60)
+
+brain1 = make_brain_state(bt)
+register_instruction!(brain1, "negation-delete", "delete")
+@assert brain1.registered_instructions[1]["approvals"] == 0
+
+update_instruction_decay!(brain1, "delete", true)
+@assert brain1.registered_instructions[1]["approvals"] == 1 "Expected 1 approval, got $(brain1.registered_instructions[1]["approvals"])"
+@assert brain1.registered_instructions[1]["denials"] == 0
+
+update_instruction_decay!(brain1, "delete", true)
+@assert brain1.registered_instructions[1]["approvals"] == 2
+
+println("PASSED: Approvals increment correctly")
+println()
+
+# ── Test 2: Denial increments ──
+
+println("=" ^ 60)
+println("TEST 2: Denial increments denial count")
+println("=" ^ 60)
+
+brain2 = make_brain_state(bt)
+register_instruction!(brain2, "negation-delete", "delete")
+
+update_instruction_decay!(brain2, "delete", false)
+@assert brain2.registered_instructions[1]["denials"] == 1
+@assert brain2.registered_instructions[1]["approvals"] == 0
+
+update_instruction_decay!(brain2, "delete", false)
+@assert brain2.registered_instructions[1]["denials"] == 2
+
+println("PASSED: Denials increment correctly")
+println()
+
+# ── Test 3: Retirement after sufficient approvals ──
+
+println("=" ^ 60)
+println("TEST 3: Instruction retires after α+β > 10 × prior_strength")
+println("=" ^ 60)
+
+brain3 = make_brain_state(bt)
+register_instruction!(brain3, "negation-delete", "delete")
+@assert length(brain3.registered_instructions) == 1
+
+for _ in 1:47
+    update_instruction_decay!(brain3, "delete", true)
+    @assert length(brain3.registered_instructions) == 1 "Should not retire yet"
+end
+
+@assert brain3.registered_instructions[1]["approvals"] == 47
+# precision = 2 + 47 + 0 = 49, threshold = 50 → not retired
+@assert length(brain3.registered_instructions) == 1 "49 < 50, should not retire"
+
+update_instruction_decay!(brain3, "delete", true)
+# precision = 2 + 48 + 0 = 50, threshold = 50, approvals(48) > denials(0) → NOT retired (need > not >=)
+@assert brain3.registered_instructions[1]["approvals"] == 48
+
+# One more to get precision = 51 > 50
+update_instruction_decay!(brain3, "delete", true)
+@assert isempty(brain3.registered_instructions) "precision=51 > 50, approvals(49) > denials(0) → should retire"
+
+println("PASSED: Retirement fires at correct threshold")
+println()
+
+# ── Test 4: Denials prevent retirement ──
+
+println("=" ^ 60)
+println("TEST 4: Denials prevent retirement even with high precision")
+println("=" ^ 60)
+
+brain4 = make_brain_state(bt)
+register_instruction!(brain4, "negation-delete", "delete")
+
+for _ in 1:30
+    update_instruction_decay!(brain4, "delete", false)
+end
+for _ in 1:25
+    update_instruction_decay!(brain4, "delete", true)
+end
+
+# precision = 2 + 25 + 30 = 57 > 50, but approvals(25) < denials(30) → no retirement
+@assert length(brain4.registered_instructions) == 1 "Denials should prevent retirement"
+@assert brain4.registered_instructions[1]["approvals"] == 25
+@assert brain4.registered_instructions[1]["denials"] == 30
+
+println("PASSED: Denials prevent retirement")
+println()
+
+# ── Test 5: Mixed trajectory — eventual retirement when approvals dominate ──
+
+println("=" ^ 60)
+println("TEST 5: Mixed trajectory — approvals eventually dominate → retirement")
+println("=" ^ 60)
+
+brain5 = make_brain_state(bt)
+register_instruction!(brain5, "negation-delete", "delete")
+
+for _ in 1:5
+    update_instruction_decay!(brain5, "delete", false)
+end
+for _ in 1:50
+    update_instruction_decay!(brain5, "delete", true)
+end
+
+# precision = 2 + 50 + 5 = 57 > 50, approvals(50) > denials(5) → retired
+@assert isempty(brain5.registered_instructions) "Should retire when approvals dominate"
+
+println("PASSED: Mixed trajectory retires correctly")
+println()
+
+# ── Test 6: Only matching category affected ──
+
+println("=" ^ 60)
+println("TEST 6: Decay only affects matching action class")
+println("=" ^ 60)
+
+brain6 = make_brain_state(bt)
+register_instruction!(brain6, "negation-delete", "delete")
+register_instruction!(brain6, "negation-deploy-to-protected", "deploy")
+
+update_instruction_decay!(brain6, "delete", true)
+delete_inst = first(i for i in brain6.registered_instructions if i["pattern"] == "negation-delete")
+deploy_inst = first(i for i in brain6.registered_instructions if i["pattern"] == "negation-deploy-to-protected")
+
+@assert delete_inst["approvals"] == 1 "delete instruction should have 1 approval"
+@assert deploy_inst["approvals"] == 0 "deploy instruction should be unaffected"
+
+println("PASSED: Only matching class affected")
+println()
+
+# ── Test 7: any-destructive decays on multiple categories ──
+
+println("=" ^ 60)
+println("TEST 7: any-destructive instruction decays on any destructive class")
+println("=" ^ 60)
+
+brain7 = make_brain_state(bt)
+register_instruction!(brain7, "ask-before-any", "any-destructive")
+
+update_instruction_decay!(brain7, "delete", true)
+update_instruction_decay!(brain7, "deploy", true)
+update_instruction_decay!(brain7, "privileged-exec", false)
+
+@assert brain7.registered_instructions[1]["approvals"] == 2
+@assert brain7.registered_instructions[1]["denials"] == 1
+
+update_instruction_decay!(brain7, "code", true)
+@assert brain7.registered_instructions[1]["approvals"] == 2 "code should not match any-destructive"
+
+println("PASSED: any-destructive decays on destructive categories")
+println()
+
+# ── Test 8: Retirement removes from persistence ──
+
+println("=" ^ 60)
+println("TEST 8: Retired instructions removed from persisted state")
+println("=" ^ 60)
+
+with_temp_state_dir() do dir
+    brain8 = make_brain_state(bt)
+    (; user_id, created_at) = load_sidecar_state!(brain8)
+
+    register_instruction!(brain8, "negation-delete", "delete")
+    register_instruction!(brain8, "negation-deploy-to-protected", "deploy")
+    save_sidecar_state(brain8, user_id, created_at)
+
+    for _ in 1:49
+        update_instruction_decay!(brain8, "delete", true)
+    end
+    @assert length(brain8.registered_instructions) == 1 "delete instruction should be retired"
+    @assert brain8.registered_instructions[1]["pattern"] == "negation-deploy-to-protected" "deploy instruction should remain"
+
+    save_sidecar_state(brain8, user_id, created_at)
+
+    brain8b = make_brain_state(bt)
+    load_sidecar_state!(brain8b)
+    @assert length(brain8b.registered_instructions) == 1 "Only deploy instruction should survive reload"
+    @assert brain8b.registered_instructions[1]["pattern"] == "negation-deploy-to-protected"
+end
+println("PASSED: Retirement persists correctly")
+println()
+
+# ── Test 9: Full self-tuning lifecycle ──
+
+println("=" ^ 60)
+println("TEST 9: Full self-tuning lifecycle — register → escalate → approve × N → retire")
+println("=" ^ 60)
+
+brain9 = make_brain_state(bt)
+for _ in 1:30
+    update_posterior!(brain9, "Bash", "delete", true)
+end
+
+register_instruction!(brain9, "confirm-before-delete", "delete")
+
+r_before = compute_eu(brain9, "Bash", "delete")
+@assert r_before.decision == "escalate" "Should escalate after registration"
+
+for i in 1:49
+    update_instruction_decay!(brain9, "delete", true)
+end
+
+@assert isempty(brain9.registered_instructions) "Instruction should retire after 49 approvals"
+
+r_after = compute_eu(brain9, "Bash", "delete")
+@assert r_after.decision == "proceed" "After retirement, concentrated posterior should proceed, got $(r_after.decision)"
+
+println("PASSED: Full lifecycle: register → escalate → approve × 49 → retire → proceed")
+println()
+
+# ── Test 10: Denial-heavy lifecycle — instruction persists ──
+
+println("=" ^ 60)
+println("TEST 10: Denial-heavy lifecycle — instruction never retires")
+println("=" ^ 60)
+
+brain10 = make_brain_state(bt)
+for _ in 1:30
+    update_posterior!(brain10, "Bash", "delete", true)
+end
+register_instruction!(brain10, "confirm-before-delete", "delete")
+
+for _ in 1:60
+    update_instruction_decay!(brain10, "delete", false)
+end
+
+@assert length(brain10.registered_instructions) == 1 "Instruction should persist after 60 denials"
+
+r_denied = compute_eu(brain10, "Bash", "delete")
+@assert r_denied.decision == "escalate" "Should still escalate after 60 denials, got $(r_denied.decision)"
+
+println("PASSED: Denial-heavy lifecycle — instruction persists and keeps escalating")
+println()
+
+println("=" ^ 60)
+println("ALL INSTRUCTION DECAY TESTS PASSED")
+println("=" ^ 60)

--- a/test/test_instruction_patterns.jl
+++ b/test/test_instruction_patterns.jl
@@ -1,0 +1,264 @@
+#!/usr/bin/env julia
+"""
+    test_instruction_patterns.jl — Tests for compaction-survival instruction patterns.
+
+Verifies: each of the seven patterns matches its canonical example and
+rejects plausible non-matches. Action-class extraction is correct.
+"""
+
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "instruction_patterns.jl"))
+
+function msg(text::String)
+    Dict{String,Any}("role" => "user", "content" => text)
+end
+
+# ── Test 1: Pattern 1 — confirm before deleting ──
+
+println("=" ^ 60)
+println("TEST 1: confirm before deleting/removing/dropping")
+println("=" ^ 60)
+
+r1 = match_instructions([msg("please confirm before deleting any files")])
+@assert length(r1) == 1 "Should match, got $(length(r1))"
+@assert r1[1][2] == "delete" "Action class should be 'delete', got '$(r1[1][2])'"
+
+r1b = match_instructions([msg("confirm before removing the database")])
+@assert length(r1b) == 1 && r1b[1][2] == "delete"
+
+r1c = match_instructions([msg("confirm before dropping the table")])
+@assert length(r1c) == 1 && r1c[1][2] == "delete"
+
+r1_neg = match_instructions([msg("I confirmed the deletion already")])
+@assert isempty(r1_neg) "'I confirmed the deletion' should NOT match"
+
+r1_neg2 = match_instructions([msg("the file was deleted before I could check")])
+@assert isempty(r1_neg2) "'was deleted before' should NOT match"
+
+println("PASSED: confirm-before-delete pattern")
+println()
+
+# ── Test 2: Pattern 2 — don't/do not/never delete ──
+
+println("=" ^ 60)
+println("TEST 2: don't/do not/never delete/remove/drop")
+println("=" ^ 60)
+
+r2 = match_instructions([msg("don't delete anything without asking")])
+@assert length(r2) == 1 && r2[1][2] == "delete"
+
+r2b = match_instructions([msg("do not remove files from production")])
+@assert length(r2b) == 1 && r2b[1][2] == "delete"
+
+r2c = match_instructions([msg("never drop tables without backup")])
+@assert length(r2c) == 1 && r2c[1][2] == "delete"
+
+r2_neg = match_instructions([msg("the user denied my request to delete")])
+@assert isempty(r2_neg) "'denied my request to delete' should NOT match"
+
+r2_neg2 = match_instructions([msg("I deleted the file yesterday")])
+@assert isempty(r2_neg2) "'I deleted' should NOT match"
+
+println("PASSED: negation-delete pattern")
+println()
+
+# ── Test 3: Pattern 3 — always/must ask before ──
+
+println("=" ^ 60)
+println("TEST 3: always/must ask before")
+println("=" ^ 60)
+
+r3 = match_instructions([msg("always ask before running destructive commands")])
+@assert length(r3) == 1 && r3[1][2] == "any-destructive"
+
+r3b = match_instructions([msg("you must ask before making changes")])
+@assert length(r3b) == 1 && r3b[1][2] == "any-destructive"
+
+r3_neg = match_instructions([msg("I asked about the deployment")])
+@assert isempty(r3_neg) "'I asked about' should NOT match"
+
+r3_neg2 = match_instructions([msg("they should ask the team first")])
+@assert isempty(r3_neg2) "'should ask' (no always/must) should NOT match"
+
+println("PASSED: ask-before-any pattern")
+println()
+
+# ── Test 4: Pattern 4 — confirm before pushing/deploying/merging ──
+
+println("=" ^ 60)
+println("TEST 4: confirm before pushing/deploying/merging")
+println("=" ^ 60)
+
+r4 = match_instructions([msg("confirm before pushing to production")])
+@assert length(r4) == 1 && r4[1][2] == "deploy"
+
+r4b = match_instructions([msg("please confirm before deploying the service")])
+@assert length(r4b) == 1 && r4b[1][2] == "deploy"
+
+r4c = match_instructions([msg("confirm before merging this PR")])
+@assert length(r4c) == 1 && r4c[1][2] == "deploy"
+
+r4_neg = match_instructions([msg("I confirmed the push already")])
+@assert isempty(r4_neg) "'confirmed the push' should NOT match"
+
+println("PASSED: confirm-before-deploy pattern")
+println()
+
+# ── Test 5: Pattern 5 — don't push/deploy/merge to main/master/prod ──
+
+println("=" ^ 60)
+println("TEST 5: don't push/deploy/merge to main/master/prod")
+println("=" ^ 60)
+
+r5 = match_instructions([msg("never push to main without review")])
+@assert length(r5) == 1 && r5[1][2] == "deploy"
+
+r5b = match_instructions([msg("don't deploy to prod directly")])
+@assert length(r5b) == 1 && r5b[1][2] == "deploy"
+
+r5c = match_instructions([msg("do not merge into master without approval")])
+@assert length(r5c) == 1 && r5c[1][2] == "deploy"
+
+r5_neg = match_instructions([msg("I pushed to main yesterday")])
+@assert isempty(r5_neg) "'I pushed to main' should NOT match"
+
+r5_neg2 = match_instructions([msg("don't push to the feature branch")])
+@assert isempty(r5_neg2) "'push to feature branch' (not main/master/prod) should NOT match"
+
+println("PASSED: negation-deploy-to-protected pattern")
+println()
+
+# ── Test 6: Pattern 6 — don't run as sudo/root ──
+
+println("=" ^ 60)
+println("TEST 6: don't run as sudo/root")
+println("=" ^ 60)
+
+r6 = match_instructions([msg("don't run anything as root")])
+@assert length(r6) == 1 && r6[1][2] == "privileged-exec"
+
+r6b = match_instructions([msg("never run commands with sudo")])
+@assert length(r6b) == 1 && r6b[1][2] == "privileged-exec"
+
+r6_neg = match_instructions([msg("I ran the command as root to test")])
+@assert isempty(r6_neg) "'I ran as root' should NOT match"
+
+r6_neg2 = match_instructions([msg("the sudo command completed successfully")])
+@assert isempty(r6_neg2) "'sudo command completed' should NOT match"
+
+println("PASSED: negation-run-privileged pattern")
+println()
+
+# ── Test 7: Pattern 7 — don't install/add/upgrade packages ──
+
+println("=" ^ 60)
+println("TEST 7: don't install/add/upgrade packages")
+println("=" ^ 60)
+
+r7 = match_instructions([msg("don't install new packages without asking")])
+@assert length(r7) == 1 && r7[1][2] == "dependency"
+
+r7b = match_instructions([msg("never add packages to the project")])
+@assert length(r7b) == 1 && r7b[1][2] == "dependency"
+
+r7c = match_instructions([msg("do not upgrade any package versions")])
+@assert length(r7c) == 1 && r7c[1][2] == "dependency"
+
+r7_neg = match_instructions([msg("I installed the package yesterday")])
+@assert isempty(r7_neg) "'I installed the package' should NOT match"
+
+println("PASSED: negation-install-package pattern")
+println()
+
+# ── Test 8: Deduplication across messages ──
+
+println("=" ^ 60)
+println("TEST 8: Deduplication — same pattern in multiple messages")
+println("=" ^ 60)
+
+r8 = match_instructions([
+    msg("don't delete anything"),
+    msg("never delete files either"),
+])
+@assert length(r8) == 1 "Same pattern in two messages should deduplicate to 1, got $(length(r8))"
+
+println("PASSED: Deduplication")
+println()
+
+# ── Test 9: Multiple distinct patterns ──
+
+println("=" ^ 60)
+println("TEST 9: Multiple distinct patterns in one batch")
+println("=" ^ 60)
+
+r9 = match_instructions([
+    msg("don't delete anything without asking"),
+    msg("never push to main without review"),
+    msg("don't run anything as root"),
+])
+@assert length(r9) == 3 "Should find 3 distinct patterns, got $(length(r9))"
+classes = Set(x[2] for x in r9)
+@assert "delete" in classes
+@assert "deploy" in classes
+@assert "privileged-exec" in classes
+
+println("PASSED: Multiple distinct patterns")
+println()
+
+# ── Test 10: instruction_matches_category ──
+
+println("=" ^ 60)
+println("TEST 10: instruction_matches_category helper")
+println("=" ^ 60)
+
+@assert instruction_matches_category("delete", "delete") == true
+@assert instruction_matches_category("delete", "deploy") == false
+@assert instruction_matches_category("any-destructive", "delete") == true
+@assert instruction_matches_category("any-destructive", "deploy") == true
+@assert instruction_matches_category("any-destructive", "privileged-exec") == true
+@assert instruction_matches_category("any-destructive", "dependency") == true
+@assert instruction_matches_category("any-destructive", "code") == false
+@assert instruction_matches_category("any-destructive", "generic") == false
+@assert instruction_matches_category("deploy", "delete") == false
+
+println("PASSED: instruction_matches_category")
+println()
+
+# ── Test 11: Content extraction from different message formats ──
+
+println("=" ^ 60)
+println("TEST 11: Content extraction (string, array, missing)")
+println("=" ^ 60)
+
+r11a = match_instructions([Dict{String,Any}("content" => "don't delete files")])
+@assert length(r11a) == 1 "String content should match"
+
+r11b = match_instructions([Dict{String,Any}("content" => [
+    Dict{String,Any}("type" => "text", "text" => "don't delete files"),
+])])
+@assert length(r11b) == 1 "Array content with text block should match"
+
+r11c = match_instructions([Dict{String,Any}("role" => "user")])
+@assert isempty(r11c) "Missing content should not crash"
+
+r11d = match_instructions([Dict{String,Any}("content" => 42)])
+@assert isempty(r11d) "Non-string content should not crash"
+
+println("PASSED: Content extraction")
+println()
+
+# ── Test 12: Empty and edge cases ──
+
+println("=" ^ 60)
+println("TEST 12: Empty and edge cases")
+println("=" ^ 60)
+
+@assert isempty(match_instructions(Dict{String,Any}[]))
+@assert isempty(match_instructions([msg("")]))
+@assert isempty(match_instructions([msg("hello world, nothing interesting here")]))
+
+println("PASSED: Edge cases")
+println()
+
+println("=" ^ 60)
+println("ALL INSTRUCTION PATTERN TESTS PASSED")
+println("=" ^ 60)


### PR DESCRIPTION
## Summary

- Issue #1084 mitigation: user instructions survive context compaction via Bayesian registration and self-tuning decay
- Seven regex patterns from the design doc §5.4, instruction registration with persistence, escalation elevation, and approval-driven retirement
- Three commits, each independently testable

## Commits

**1/3 — Pattern matching:** Seven regex patterns (`confirm-before-delete`, `negation-delete`, `ask-before-any`, `confirm-before-deploy`, `negation-deploy-to-protected`, `negation-run-privileged`, `negation-install-package`). Pure `match_instructions(messages)` function. 12 tests.

**2/3 — Instruction registration + persistence:** `/compaction-preview` does real work — matches instructions, registers them deduplicated, persists via schema v1. `compute_eu` elevates `EU(escalate)` for guarded action classes with a boost of `prior_strength × denial_rate` that decays smoothly with approvals. Plugin registers `before_compaction` hook (fire-and-forget). 9 tests including full Yue/Meta lifecycle.

**3/3 — Decay logic:** `/observe` processes `userApproval` to update instruction approval/denial counts. Retirement when precision > 10× prior_strength AND approvals > denials. Self-tuning: consistent approvals → instruction retires; consistent denials → instruction persists indefinitely. 10 tests.

## Halting conditions

No halting conditions triggered:
- No cross-matching between patterns (each has distinct keyword sets)
- Action-class derivation uses fixed classes from the design doc table (no NLP needed)
- Escalation elevation is quantitatively correct: fresh instructions boost enough to escalate even confident posteriors (Beta(50,2)); boost decays naturally with approvals
- Retirement at 49 approvals for prior_strength=5.0 is reasonable (10× precision ratio)
- Plugin `before_compaction` hook is fire-and-forget as designed

## Test plan

- [x] 12 pattern tests pass (`julia test/test_instruction_patterns.jl`)
- [x] 9 compaction-survival tests pass (`julia test/test_compaction_survival.jl`)
- [x] 10 decay tests pass (`julia test/test_instruction_decay.jl`)
- [x] 10 brain tests pass — no regressions (`julia test/test_governance_brain.jl`)
- [x] 13 persistence tests pass — no regressions (`julia test/test_governance_persistence.jl`)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Credence-lint clean (150 files, 0 violations)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)