### PR TITLE
posture-5/move-2 sub-PR 5: fail-open behaviour

### DIFF
--- a/apps/openclaw-plugin/src/index.ts
+++ b/apps/openclaw-plugin/src/index.ts
@@ -11,6 +11,8 @@ type ToolHistoryEntry = {
   timestamp: number;
 };
 
+type SidecarAvailability = "unknown" | "available" | "unavailable";
+
 const HISTORY_WINDOW = 50;
 
 function renderDecision(response: EvaluateResponse): Record<string, unknown> | undefined {
@@ -64,11 +66,21 @@ export default {
     const config = api.config ?? {};
     const sidecarUrl =
       (config.sidecarUrl as string) ?? "http://localhost:3100";
-    const timeoutMs = (config.timeoutMs as number) ?? 200;
+    const timeoutMs = (config.timeoutMs as number) ?? 50;
+    const silentMode = (config.silentMode as boolean) ?? false;
 
     const client = new SidecarClient(sidecarUrl, timeoutMs);
     const recentHistory: ToolHistoryEntry[] = [];
     let pendingEscalation: { toolName: string; params: Record<string, unknown> } | null = null;
+
+    let availability: SidecarAvailability = "unknown";
+    let warnedUnavailable = false;
+    let announcedResume = false;
+
+    const log = (level: string, message: string) => {
+      if (silentMode) return;
+      api.log?.(level, message);
+    };
 
     api.on(
       "before_tool_call",
@@ -83,6 +95,25 @@ export default {
         };
 
         const response = await client.evaluate(req);
+
+        if (response.reachable) {
+          if (availability === "unavailable" && !announcedResume) {
+            log("info", "Credence governance resumed — sidecar is available again.");
+            announcedResume = true;
+          }
+          availability = "available";
+        } else {
+          if (!warnedUnavailable) {
+            log("warn",
+              `Credence governance unavailable — could not reach sidecar at ${sidecarUrl}. ` +
+              `Proceeding without governance protection. ` +
+              `Verify the sidecar is running with: julia apps/credence-governance-sidecar/server.jl`);
+            warnedUnavailable = true;
+          }
+          availability = "unavailable";
+          return undefined;
+        }
+
         const decision = response.decision ?? (response.action === "block" ? "halt" : "proceed");
 
         if (decision === "escalate") {

--- a/apps/openclaw-plugin/src/sidecar-client.ts
+++ b/apps/openclaw-plugin/src/sidecar-client.ts
@@ -33,6 +33,7 @@ export type EvaluateResponse = {
   reason?: string;
   signals?: EvaluateSignals;
   requireApproval?: RequireApprovalPayload | null;
+  reachable: boolean;
 };
 
 export type ObserveRequest = {
@@ -63,11 +64,12 @@ export class SidecarClient {
         signal: AbortSignal.timeout(this.timeoutMs),
       });
       if (!response.ok) {
-        return { action: "proceed" };
+        return { action: "proceed", reachable: false };
       }
-      return (await response.json()) as EvaluateResponse;
+      const body = (await response.json()) as EvaluateResponse;
+      return { ...body, reachable: true };
     } catch {
-      return { action: "proceed" };
+      return { action: "proceed", reachable: false };
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds sidecar availability state machine (`unknown`/`available`/`unavailable`) to the plugin, with warning-once on first unavailability and resume-once when the sidecar comes back mid-session
- Changes default `timeoutMs` from 200ms to 50ms (within the 100ms hook latency budget; sidecar p99 is 0.1ms)
- Adds `silentMode` config option to suppress log messages (for CI environments where governance is optional)
- `SidecarClient.evaluate()` now returns a `reachable` flag so the plugin can distinguish sidecar decisions from fail-open defaults

## Test plan

- [ ] `tsc --noEmit` passes
- [ ] `credence-lint check apps/` passes
- [ ] CI green
- [ ] Manual verification: plugin with no sidecar running — all tool calls proceed, one warning logged
- [ ] Manual verification: plugin with sidecar started mid-session — resume message fires once

🤖 Generated with [Claude Code](https://claude.com/claude-code)