### PR TITLE
posture-5/move-2 sub-PR 6: three failure-mode detectors

### DIFF
--- a/apps/credence-governance-sidecar/brain.jl
+++ b/apps/credence-governance-sidecar/brain.jl
@@ -92,22 +92,22 @@ mutable struct BrainState
     model_quality::Dict{String, Dict{String, BetaMeasure}}
     observation_count::Int
     budget_table::BudgetTable
-    prototype_fallback_enabled::Bool
-    max_repetitions::Int
     registered_instructions::Vector{Dict{String,Any}}
+    tool_args_outcomes::Dict{String, Vector{Bool}}
+    eu_history::Vector{Float64}
+    no_confidence_consecutive::Int
 end
 
-function make_brain_state(budget_table::BudgetTable;
-                          prototype_fallback_enabled::Bool=true,
-                          max_repetitions::Int=3)
+function make_brain_state(budget_table::BudgetTable)
     BrainState(
         Dict{PosteriorKey, BetaMeasure}(),
         Dict{String, Dict{String, BetaMeasure}}(),
         0,
         budget_table,
-        prototype_fallback_enabled,
-        max_repetitions,
         Dict{String,Any}[],
+        Dict{String, Vector{Bool}}(),
+        Float64[],
+        0,
     )
 end
 
@@ -296,41 +296,9 @@ function update_instruction_decay!(state::BrainState, category::String, approved
     deleteat!(state.registered_instructions, retired)
 end
 
-# ── Prototype fallback: repetition counting ──
+# ── Utility: canonical key for per-(tool, args) tracking ──
 
 function canonical_key(tool_name::AbstractString, params::Dict)
     sorted_params = sort(collect(params), by=first)
     return "$tool_name:$(JSON3.write(sorted_params))"
-end
-
-function count_repetitions(history::Vector{Dict{String,Any}}, tool_name::AbstractString, params::Dict)
-    key = canonical_key(tool_name, params)
-    count = 0
-    for entry in history
-        entry_key = canonical_key(
-            get(entry, "toolName", ""),
-            get(entry, "params", Dict{String,Any}())
-        )
-        if entry_key == key
-            count += 1
-        end
-    end
-    return count
-end
-
-function check_prototype_fallback(state::BrainState, history::Vector{Dict{String,Any}},
-                                  tool_name::AbstractString, params::Dict{String,Any})
-    !state.prototype_fallback_enabled && return nothing
-    tool_name in READ_LIKE_TOOLS && return nothing
-    count = count_repetitions(history, tool_name, params)
-    if count >= state.max_repetitions
-        return Dict{String,Any}(
-            "action" => "block",
-            "decision" => "halt",
-            "reason" => "Loop detected: '$tool_name' with identical arguments has been called $count times (threshold: $(state.max_repetitions)). Halting to prevent runaway loop.",
-            "signals" => Dict{String,Any}(),
-            "requireApproval" => nothing,
-        )
-    end
-    return nothing
 end

--- a/apps/credence-governance-sidecar/config/read_tools.json
+++ b/apps/credence-governance-sidecar/config/read_tools.json
@@ -1,0 +1,1 @@
+["Read", "Grep", "LS", "Glob"]

--- a/apps/credence-governance-sidecar/detectors.jl
+++ b/apps/credence-governance-sidecar/detectors.jl
@@ -84,9 +84,10 @@ end
 const DEFAULT_EU_WINDOW_SIZE = 10
 const NO_CONFIDENCE_SPAN = 5
 
-function check_no_confidence(state::BrainState, category::AbstractString,
+function check_no_confidence(state::BrainState, tool_name::AbstractString,
+                             category::AbstractString,
                              eu_proceed::Float64, window_size::Int)::Bool
-    m = get_posterior(state, "", category)
+    m = get_posterior(state, tool_name, category)
 
     push!(state.eu_history, eu_proceed)
     if length(state.eu_history) > window_size

--- a/apps/credence-governance-sidecar/detectors.jl
+++ b/apps/credence-governance-sidecar/detectors.jl
@@ -1,0 +1,118 @@
+# Role: body
+#
+# Failure-mode detectors: posterior-signature checks that elevate EU
+# for the appropriate intervention action. Loaded by server.jl.
+
+using ..Credence
+
+# ── Configuration ──
+
+function load_read_tools(path::AbstractString)::Set{String}
+    data = JSON3.read(read(path, String), Vector{String})
+    Set(data)
+end
+
+function load_detector_windows(path::AbstractString)::Dict{String,Int}
+    data = JSON3.read(read(path, String), Dict{String,Any})
+    Dict{String,Int}(string(k) => Int(v) for (k, v) in data)
+end
+
+# ── Detector 1: Exec-repetition stationarity (#34574) ──
+
+function stationarity_window(m::BetaMeasure)::Int
+    # credence-lint: allow — precedent:expect-through-accessor — K derivation from posterior concentration
+    concentration = m.alpha + m.beta
+    max(2, ceil(Int, sqrt(concentration)))
+end
+
+function outcome_variance(outcomes::Vector{Bool})::Float64
+    isempty(outcomes) && return 0.0
+    # credence-lint: allow — precedent:display-arithmetic — host-level variance of empirical outcomes
+    μ = sum(outcomes) / length(outcomes)
+    sum((Float64(x) - μ)^2 for x in outcomes) / length(outcomes)
+end
+
+function stationarity_threshold(m::BetaMeasure)::Float64
+    # credence-lint: allow — precedent:display-arithmetic — host-level threshold derivation from posterior predictive variance
+    p = mean(m)
+    p * (1.0 - p) * 0.1  # credence-lint: allow — precedent:display-arithmetic — host-level threshold from posterior mean
+end
+
+struct StationarityResult
+    fires::Bool
+    tool_name::String
+    count::Int
+    outcome_var::Float64
+    threshold::Float64
+    window_size::Int
+end
+
+function check_stationarity(state::BrainState, read_tools::Set{String},
+                            tool_name::AbstractString, params::Dict{String,Any},
+                            category::AbstractString)::Union{StationarityResult, Nothing}
+    tool_name in read_tools && return nothing
+
+    key = canonical_key(tool_name, params)
+    outcomes = get(state.tool_args_outcomes, key, Bool[])
+
+    m = get_posterior(state, tool_name, category)
+    K = stationarity_window(m)
+
+    length(outcomes) < K && return nothing
+
+    window = outcomes[max(1, end-K+1):end]
+    ov = outcome_variance(window)
+    thresh = stationarity_threshold(m)
+    fires = ov <= thresh
+
+    StationarityResult(fires, string(tool_name), length(outcomes), ov, thresh, K)
+end
+
+function record_outcome!(state::BrainState, tool_name::AbstractString,
+                         params::Dict{String,Any}, success::Bool)
+    key = canonical_key(tool_name, params)
+    outcomes = get!(state.tool_args_outcomes, key, Bool[])
+    push!(outcomes, success)
+    max_window = 200
+    if length(outcomes) > max_window
+        deleteat!(outcomes, 1:length(outcomes)-max_window)
+    end
+end
+
+# ── Detector 3: No-confidence dreaming loops (#65550) ──
+
+const DEFAULT_EU_WINDOW_SIZE = 10
+const NO_CONFIDENCE_SPAN = 5
+
+function check_no_confidence(state::BrainState, category::AbstractString,
+                             eu_proceed::Float64, window_size::Int)::Bool
+    m = get_posterior(state, "", category)
+
+    push!(state.eu_history, eu_proceed)
+    if length(state.eu_history) > window_size
+        deleteat!(state.eu_history, 1:length(state.eu_history)-window_size)
+    end
+
+    length(state.eu_history) < window_size && return false
+
+    μ = sum(state.eu_history) / length(state.eu_history)
+    abs(μ) < 1e-12 && return false
+
+    # credence-lint: allow — precedent:display-arithmetic — host-level CV diagnostic
+    σ² = sum((x - μ)^2 for x in state.eu_history) / length(state.eu_history)
+    σ² < 0.0 && return false
+    cv = sqrt(σ²) / abs(μ)
+
+    # credence-lint: allow — precedent:expect-through-accessor — threshold from posterior concentration
+    concentration = m.alpha + m.beta
+    # credence-lint: allow — precedent:display-arithmetic — host-level threshold derivation
+    threshold = 1.0 / sqrt(concentration)
+
+    if cv > threshold
+        state.no_confidence_consecutive += 1
+    else
+        state.no_confidence_consecutive = 0
+    end
+
+    state.no_confidence_consecutive >= NO_CONFIDENCE_SPAN
+end

--- a/apps/credence-governance-sidecar/server.jl
+++ b/apps/credence-governance-sidecar/server.jl
@@ -10,45 +10,68 @@ using Credence
 
 include("instruction_patterns.jl")
 include("brain.jl")
+include("detectors.jl")
 include("persistence.jl")
 
 const DEFAULT_PORT = 3100
 
-function make_state(; max_repetitions::Int=3, prototype_fallback::Bool=true)
+function make_state()
     config_path = joinpath(@__DIR__, "config", "budgets.json")
     budget_table = load_budget_table(config_path)
-    brain = make_brain_state(budget_table;
-                             prototype_fallback_enabled=prototype_fallback,
-                             max_repetitions=max_repetitions)
+    brain = make_brain_state(budget_table)
+
+    read_tools_path = joinpath(@__DIR__, "config", "read_tools.json")
+    read_tools = load_read_tools(read_tools_path)
+
+    detector_windows_path = joinpath(@__DIR__, "config", "detector_windows.json")
+    eu_window_size = if isfile(detector_windows_path)
+        windows = load_detector_windows(detector_windows_path)
+        get(windows, "eu_proceed", DEFAULT_EU_WINDOW_SIZE)
+    else
+        DEFAULT_EU_WINDOW_SIZE
+    end
 
     (; user_id, created_at) = load_sidecar_state!(brain)
 
     history = Dict{String,Any}[]
     state_lock = ReentrantLock()
-    return (; brain, history, start_time=now(), user_id, created_at, state_lock)
+    return (; brain, history, start_time=now(), user_id, created_at, state_lock,
+              read_tools, eu_window_size)
 end
 
 function handle_evaluate(state, body::Dict{String,Any})
     tool_name = get(body, "toolName", "")
     params = Dict{String,Any}(get(body, "params", Dict{String,Any}()))
-    recent = get(body, "recentHistory", Dict{String,Any}[])
-
-    combined_history = vcat(
-        [Dict{String,Any}("toolName" => get(r, "toolName", ""),
-                          "params" => Dict{String,Any}(get(r, "params", Dict{String,Any}())))
-         for r in recent],
-        [Dict{String,Any}("toolName" => get(h, "toolName", ""),
-                          "params" => Dict{String,Any}(get(h, "params", Dict{String,Any}())))
-         for h in state.history]
-    )
-
-    fallback = check_prototype_fallback(state.brain, combined_history, tool_name, params)
-    if fallback !== nothing
-        return fallback
-    end
 
     category = infer_category(tool_name, params)
+
+    sr = check_stationarity(state.brain, state.read_tools, tool_name, params, category)
+    if sr !== nothing && sr.fires
+        return Dict{String,Any}(
+            "action" => "block",
+            "decision" => "halt",
+            "reason" => "Posterior stationary on repeated tool call: '$(sr.tool_name)' " *
+                        "called $(sr.count) times with identical arguments " *
+                        "(outcome_var=$(round(sr.outcome_var, digits=4)) ≤ threshold=$(round(sr.threshold, digits=4)), " *
+                        "window=$(sr.window_size)). Halting.",
+            "signals" => Dict{String,Any}(),
+            "requireApproval" => nothing,
+        )
+    end
+
     result = compute_eu(state.brain, tool_name, category)
+
+    nc = check_no_confidence(state.brain, category, result.eu_proceed, state.eu_window_size)
+    if nc
+        return Dict{String,Any}(
+            "action" => "block",
+            "decision" => "halt",
+            "reason" => "Posterior over next-action value is flat: EU(proceed) has high " *
+                        "coefficient of variation across recent evaluations. Halting.",
+            "signals" => result.signals,
+            "requireApproval" => nothing,
+        )
+    end
 
     response = Dict{String,Any}(
         "action" => result.action,
@@ -84,6 +107,7 @@ function handle_observe(state, body::Dict{String,Any})
                                error_str isa AbstractString ? error_str : nothing,
                                duration_ms isa Real ? duration_ms : nothing)
     update_posterior!(state.brain, tool_name, category, success)
+    record_outcome!(state.brain, tool_name, params, success)
 
     user_approval = get(body, "userApproval", nothing)
     if user_approval !== nothing
@@ -129,8 +153,8 @@ function handle_health(state)
     )
 end
 
-function run_server(; port::Int=DEFAULT_PORT, max_repetitions::Int=3, prototype_fallback::Bool=true)
-    state = make_state(; max_repetitions, prototype_fallback)
+function run_server(; port::Int=DEFAULT_PORT)
+    state = make_state()
     router = HTTP.Router()
 
     HTTP.register!(router, "POST", "/evaluate", function(req)
@@ -171,15 +195,13 @@ function run_server(; port::Int=DEFAULT_PORT, max_repetitions::Int=3, prototype_
     println("Credence governance sidecar starting on port $port")
     println("  user_id = $(state.user_id)")
     println("  state_dir = $(get_state_dir())")
-    println("  prototype_fallback = $prototype_fallback")
-    println("  max_repetitions = $max_repetitions")
     println("  observation_count = $(state.brain.observation_count)")
+    println("  eu_window_size = $(state.eu_window_size)")
+    println("  read_tools = $(state.read_tools)")
     println("  endpoints: POST /evaluate, POST /observe, POST /compaction-preview, GET /health")
 
     HTTP.serve(router, "127.0.0.1", port)
 end
 
 port = parse(Int, get(ENV, "CREDENCE_SIDECAR_PORT", string(DEFAULT_PORT)))
-max_reps = parse(Int, get(ENV, "CREDENCE_MAX_REPETITIONS", "3"))
-fallback = lowercase(get(ENV, "CREDENCE_PROTOTYPE_FALLBACK", "true")) in ("true", "1", "yes")
-run_server(; port, max_repetitions=max_reps, prototype_fallback=fallback)
+run_server(; port)

--- a/apps/credence-governance-sidecar/server.jl
+++ b/apps/credence-governance-sidecar/server.jl
@@ -61,7 +61,7 @@ function handle_evaluate(state, body::Dict{String,Any})
 
     result = compute_eu(state.brain, tool_name, category)
 
-    nc = check_no_confidence(state.brain, category, result.eu_proceed, state.eu_window_size)
+    nc = check_no_confidence(state.brain, tool_name, category, result.eu_proceed, state.eu_window_size)
     if nc
         return Dict{String,Any}(
             "action" => "block",

--- a/test/test_detector_1084.jl
+++ b/test/test_detector_1084.jl
@@ -1,0 +1,179 @@
+#!/usr/bin/env julia
+"""
+    test_detector_1084.jl — Tests for compaction-wipes-confirm-instruction detector.
+
+Verifies: instruction-based escalation elevation fires when a registered
+instruction matches the candidate's action class, magnitude tracks decay
+state, and the detector integrates with the full lifecycle.
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, ".."))
+using Credence
+using JSON3
+using Dates
+
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "instruction_patterns.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "brain.jl"))
+
+config_path = joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "config", "budgets.json")
+bt = load_budget_table(config_path)
+
+# ── Test 1: Registered instruction → escalate fires ──
+
+println("=" ^ 60)
+println("TEST 1: Registered instruction for matching class → escalate")
+println("=" ^ 60)
+
+state1 = make_brain_state(bt)
+state1.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+
+result_before = compute_eu(state1, "Bash", "delete")
+@assert result_before.decision == "proceed" "Concentrated posterior without instruction should proceed, got $(result_before.decision)"
+
+register_instruction!(state1, "negation-delete", "delete")
+result_after = compute_eu(state1, "Bash", "delete")
+@assert result_after.decision == "escalate" "With registered instruction, should escalate, got $(result_after.decision)"
+
+println("PASSED: Instruction registration triggers escalation")
+println()
+
+# ── Test 2: Instruction for non-matching class → no escalation ──
+
+println("=" ^ 60)
+println("TEST 2: Instruction for different class → no effect")
+println("=" ^ 60)
+
+state2 = make_brain_state(bt)
+state2.tool_outcomes[PosteriorKey("Bash", "version-control")] = BetaMeasure(50.0, 2.0)
+
+register_instruction!(state2, "negation-delete", "delete")
+result_vc = compute_eu(state2, "Bash", "version-control")
+@assert result_vc.decision == "proceed" "Instruction for 'delete' should not affect 'version-control', got $(result_vc.decision)"
+
+println("PASSED: Non-matching instruction class has no effect")
+println()
+
+# ── Test 3: No registered instruction → no escalation from detector ──
+
+println("=" ^ 60)
+println("TEST 3: No instruction → no escalation from this detector")
+println("=" ^ 60)
+
+state3 = make_brain_state(bt)
+state3.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+@assert isempty(state3.registered_instructions)
+
+result_no_inst = compute_eu(state3, "Bash", "delete")
+@assert result_no_inst.decision == "proceed" "No instruction, concentrated posterior → proceed, got $(result_no_inst.decision)"
+
+println("PASSED: No instruction means no escalation from #1084 detector")
+println()
+
+# ── Test 4: Fresh instruction → strong elevation ──
+
+println("=" ^ 60)
+println("TEST 4: Fresh instruction has strong elevation magnitude")
+println("=" ^ 60)
+
+state4 = make_brain_state(bt)
+state4.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+register_instruction!(state4, "negation-delete", "delete")
+
+result_fresh = compute_eu(state4, "Bash", "delete")
+@assert result_fresh.decision == "escalate" "Fresh instruction should escalate"
+fresh_eu_escalate = result_fresh.eu_escalate
+println("  Fresh instruction: eu_escalate = $(round(fresh_eu_escalate, digits=4))")
+
+println("PASSED: Fresh instruction produces strong escalation")
+println()
+
+# ── Test 5: Decayed instruction → weak elevation ──
+
+println("=" ^ 60)
+println("TEST 5: Decayed instruction has weak elevation magnitude")
+println("=" ^ 60)
+
+state5 = make_brain_state(bt)
+state5.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+register_instruction!(state5, "negation-delete", "delete")
+
+state5.registered_instructions[1]["approvals"] = 40
+
+result_decayed = compute_eu(state5, "Bash", "delete")
+decayed_eu_escalate = result_decayed.eu_escalate
+println("  Decayed instruction (40 approvals): eu_escalate = $(round(decayed_eu_escalate, digits=4))")
+
+@assert decayed_eu_escalate < fresh_eu_escalate "Decayed instruction should have weaker elevation than fresh"
+@assert result_decayed.decision != "escalate" "After 40 approvals, boost too weak against Beta(50,2), got $(result_decayed.decision)"
+
+println("PASSED: Instruction boost decays with approvals")
+println()
+
+# ── Test 6: Denial-heavy instruction → strong elevation persists ──
+
+println("=" ^ 60)
+println("TEST 6: Denial-heavy instruction maintains strong elevation")
+println("=" ^ 60)
+
+state6 = make_brain_state(bt)
+state6.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+register_instruction!(state6, "negation-delete", "delete")
+state6.registered_instructions[1]["denials"] = 40
+
+result_denied = compute_eu(state6, "Bash", "delete")
+@assert result_denied.decision == "escalate" "40 denials should keep escalation strong, got $(result_denied.decision)"
+
+println("PASSED: Denials maintain escalation strength")
+println()
+
+# ── Test 7: Full lifecycle — register → escalate → approve × N → retire → proceed ──
+
+println("=" ^ 60)
+println("TEST 7: Full #1084 detector lifecycle")
+println("=" ^ 60)
+
+state7 = make_brain_state(bt)
+for _ in 1:30
+    update_posterior!(state7, "Bash", "delete", true)
+end
+
+register_instruction!(state7, "confirm-before-delete", "delete")
+r_escalate = compute_eu(state7, "Bash", "delete")
+@assert r_escalate.decision == "escalate" "After registration, should escalate"
+
+for _ in 1:49
+    update_instruction_decay!(state7, "delete", true)
+end
+@assert isempty(state7.registered_instructions) "Instruction should retire after 49 approvals"
+
+r_proceed = compute_eu(state7, "Bash", "delete")
+@assert r_proceed.decision == "proceed" "After retirement, should proceed, got $(r_proceed.decision)"
+
+println("PASSED: Full lifecycle: register → escalate → retire → proceed")
+println()
+
+# ── Test 8: any-destructive covers multiple categories ──
+
+println("=" ^ 60)
+println("TEST 8: any-destructive instruction covers delete, deploy, privileged-exec")
+println("=" ^ 60)
+
+state8 = make_brain_state(bt)
+state8.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+state8.tool_outcomes[PosteriorKey("Bash", "deploy")] = BetaMeasure(50.0, 2.0)
+state8.tool_outcomes[PosteriorKey("Bash", "privileged-exec")] = BetaMeasure(50.0, 2.0)
+state8.tool_outcomes[PosteriorKey("Edit", "code")] = BetaMeasure(50.0, 2.0)
+
+register_instruction!(state8, "ask-before-any", "any-destructive")
+
+@assert compute_eu(state8, "Bash", "delete").decision == "escalate"
+@assert compute_eu(state8, "Bash", "deploy").decision == "escalate"
+@assert compute_eu(state8, "Bash", "privileged-exec").decision == "escalate"
+@assert compute_eu(state8, "Edit", "code").decision != "escalate" "code should NOT match any-destructive"
+
+println("PASSED: any-destructive covers destructive categories, not code")
+println()
+
+println("=" ^ 60)
+println("ALL #1084 DETECTOR TESTS PASSED")
+println("=" ^ 60)

--- a/test/test_detector_34574.jl
+++ b/test/test_detector_34574.jl
@@ -1,0 +1,198 @@
+#!/usr/bin/env julia
+"""
+    test_detector_34574.jl — Tests for exec-repetition stationarity detector.
+
+Verifies: stationarity fires after K identical observations, does not fire
+with fewer or mixed outcomes, read-tool exemption, and window-size scaling
+with posterior concentration.
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, ".."))
+using Credence
+using JSON3
+
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "instruction_patterns.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "brain.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "detectors.jl"))
+
+config_path = joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "config", "budgets.json")
+bt = load_budget_table(config_path)
+
+read_tools_path = joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "config", "read_tools.json")
+read_tools = load_read_tools(read_tools_path)
+
+# ── Test 1: Window size scales with posterior concentration ──
+
+println("=" ^ 60)
+println("TEST 1: Stationarity window size")
+println("=" ^ 60)
+
+@assert stationarity_window(BetaMeasure(1.0, 1.0)) == 2 "Beta(1,1): K should be 2, got $(stationarity_window(BetaMeasure(1.0, 1.0)))"
+@assert stationarity_window(BetaMeasure(50.0, 50.0)) == 10 "Beta(50,50): K should be 10, got $(stationarity_window(BetaMeasure(50.0, 50.0)))"
+@assert stationarity_window(BetaMeasure(5.0, 5.0)) >= 4 "Beta(5,5): K should be >= 4"
+@assert stationarity_window(BetaMeasure(100.0, 100.0)) >= 14 "Beta(100,100): K should be >= 14"
+
+println("PASSED: Window size scales with sqrt(concentration)")
+println()
+
+# ── Test 2: 10 identical observations → stationarity fires ──
+
+println("=" ^ 60)
+println("TEST 2: 10 identical observations → stationarity fires")
+println("=" ^ 60)
+
+state2 = make_brain_state(bt)
+state2.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(5.0, 5.0)
+params2 = Dict{String,Any}("command" => "ls -la")
+
+for _ in 1:10
+    record_outcome!(state2, "Bash", params2, true)
+end
+
+sr2 = check_stationarity(state2, read_tools, "Bash", params2, "generic")
+@assert sr2 !== nothing "Stationarity check should return a result"
+@assert sr2.fires "Stationarity should fire after 10 identical observations"
+
+println("PASSED: Stationarity fires after 10 identical observations")
+println()
+
+# ── Test 3: 9 identical + 1 differing → does NOT fire ──
+
+println("=" ^ 60)
+println("TEST 3: 9 identical + 1 differing → does NOT fire")
+println("=" ^ 60)
+
+state3 = make_brain_state(bt)
+state3.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(5.0, 5.0)
+params3 = Dict{String,Any}("command" => "echo test")
+
+for _ in 1:9
+    record_outcome!(state3, "Bash", params3, true)
+end
+record_outcome!(state3, "Bash", params3, false)
+
+sr3 = check_stationarity(state3, read_tools, "Bash", params3, "generic")
+@assert sr3 !== nothing "Stationarity check should return a result"
+@assert !sr3.fires "Stationarity should NOT fire with mixed outcomes"
+
+println("PASSED: Mixed outcomes prevent stationarity")
+println()
+
+# ── Test 4: Read tool exemption ──
+
+println("=" ^ 60)
+println("TEST 4: Read tool with 100 repetitions → exempt")
+println("=" ^ 60)
+
+state4 = make_brain_state(bt)
+params4 = Dict{String,Any}("file_path" => "/etc/hosts")
+
+for _ in 1:100
+    record_outcome!(state4, "Read", params4, true)
+end
+
+sr4 = check_stationarity(state4, read_tools, "Read", params4, "code")
+@assert sr4 === nothing "Read tool should be exempt from stationarity detection"
+
+sr4_grep = check_stationarity(state4, read_tools, "Grep", Dict{String,Any}(), "code")
+@assert sr4_grep === nothing "Grep tool should be exempt"
+
+sr4_ls = check_stationarity(state4, read_tools, "LS", Dict{String,Any}(), "code")
+@assert sr4_ls === nothing "LS tool should be exempt"
+
+sr4_glob = check_stationarity(state4, read_tools, "Glob", Dict{String,Any}(), "code")
+@assert sr4_glob === nothing "Glob tool should be exempt"
+
+println("PASSED: Read-like tools exempt from stationarity detection")
+println()
+
+# ── Test 5: Beta(1,1) with K=2 identical → fires ──
+
+println("=" ^ 60)
+println("TEST 5: Beta(1,1) prior with K=2 same outcome → fires")
+println("=" ^ 60)
+
+state5 = make_brain_state(bt)
+params5 = Dict{String,Any}("command" => "date")
+
+record_outcome!(state5, "Bash", params5, true)
+record_outcome!(state5, "Bash", params5, true)
+
+sr5 = check_stationarity(state5, read_tools, "Bash", params5, "generic")
+@assert sr5 !== nothing "Should get stationarity result"
+@assert sr5.fires "Beta(1,1) with K=2 identical outcomes should fire"
+@assert sr5.window_size == 2 "Window should be 2 for Beta(1,1)"
+
+println("PASSED: Low-concentration posterior fires with minimal data")
+println()
+
+# ── Test 6: Beta(50,50) with K=2 identical → does NOT fire ──
+
+println("=" ^ 60)
+println("TEST 6: Beta(50,50) prior with K=2 same outcome → does NOT fire")
+println("=" ^ 60)
+
+state6 = make_brain_state(bt)
+state6.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(50.0, 50.0)
+params6 = Dict{String,Any}("command" => "whoami")
+
+record_outcome!(state6, "Bash", params6, true)
+record_outcome!(state6, "Bash", params6, true)
+
+sr6 = check_stationarity(state6, read_tools, "Bash", params6, "generic")
+@assert sr6 === nothing "Beta(50,50) with only 2 observations should not have enough data (K=10)"
+
+println("PASSED: High-concentration posterior requires more observations")
+println()
+
+# ── Test 7: Prototype fallback removed ──
+
+println("=" ^ 60)
+println("TEST 7: Prototype fallback fields removed from BrainState")
+println("=" ^ 60)
+
+state7 = make_brain_state(bt)
+@assert !hasproperty(state7, :prototype_fallback_enabled) "prototype_fallback_enabled should be removed"
+@assert !hasproperty(state7, :max_repetitions) "max_repetitions should be removed"
+@assert hasproperty(state7, :tool_args_outcomes) "tool_args_outcomes should exist"
+
+println("PASSED: Prototype fallback replaced by stationarity detector")
+println()
+
+# ── Test 8: canonical_key still works ──
+
+println("=" ^ 60)
+println("TEST 8: canonical_key produces stable keys")
+println("=" ^ 60)
+
+k1 = canonical_key("Bash", Dict{String,Any}("command" => "ls", "timeout" => 5000))
+k2 = canonical_key("Bash", Dict{String,Any}("timeout" => 5000, "command" => "ls"))
+@assert k1 == k2 "Same params in different order should produce same key"
+
+k3 = canonical_key("Bash", Dict{String,Any}("command" => "ls"))
+@assert k1 != k3 "Different params should produce different keys"
+
+println("PASSED: canonical_key is order-independent")
+println()
+
+# ── Test 9: Insufficient observations → no result ──
+
+println("=" ^ 60)
+println("TEST 9: Insufficient observations returns nothing")
+println("=" ^ 60)
+
+state9 = make_brain_state(bt)
+state9.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(10.0, 10.0)
+params9 = Dict{String,Any}("command" => "pwd")
+
+record_outcome!(state9, "Bash", params9, true)
+
+sr9 = check_stationarity(state9, read_tools, "Bash", params9, "generic")
+@assert sr9 === nothing "1 observation when K>1 should return nothing"
+
+println("PASSED: Insufficient observations correctly handled")
+println()
+
+println("=" ^ 60)
+println("ALL STATIONARITY DETECTOR TESTS PASSED")
+println("=" ^ 60)

--- a/test/test_detector_65550.jl
+++ b/test/test_detector_65550.jl
@@ -1,0 +1,191 @@
+#!/usr/bin/env julia
+"""
+    test_detector_65550.jl — Tests for no-confidence dreaming-loop detector.
+
+Verifies: CV threshold fires after 5+ consecutive high-variance evaluations,
+does not fire at 4, threshold scales with posterior concentration, and
+stable trajectories do not trigger.
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, ".."))
+using Credence
+using JSON3
+
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "instruction_patterns.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "brain.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "detectors.jl"))
+
+config_path = joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "config", "budgets.json")
+bt = load_budget_table(config_path)
+
+# ── Test 1: Stable EU(proceed) → no-confidence does NOT fire ──
+
+println("=" ^ 60)
+println("TEST 1: Stable EU trajectory → no fire")
+println("=" ^ 60)
+
+state1 = make_brain_state(bt)
+state1.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(50.0, 2.0)
+window = 10
+
+result1 = false
+for _ in 1:15
+    global result1 = check_no_confidence(state1, "Bash", "generic", 0.85, window)
+end
+@assert !result1 "Stable EU(proceed)=0.85 should not fire no-confidence"
+
+println("PASSED: Stable trajectory does not trigger")
+println()
+
+# ── Test 2: High-variance EU for 5+ consecutive → fires ──
+
+println("=" ^ 60)
+println("TEST 2: High-variance EU for 5+ consecutive → fires")
+println("=" ^ 60)
+
+state2 = make_brain_state(bt)
+state2.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(2.0, 2.0)
+window2 = 10
+
+high_var_values = [0.9, -0.8, 0.7, -0.6, 0.5, -0.4, 0.3, -0.2, 0.1, -0.1,
+                   0.8, -0.7, 0.6, -0.5]
+result2 = false
+for v in high_var_values
+    global result2 = check_no_confidence(state2, "Bash", "generic", v, window2)
+end
+
+@assert result2 "High-variance trajectory with fresh posterior should fire after 5+ consecutive above threshold"
+
+println("PASSED: High-variance trajectory fires no-confidence")
+println()
+
+# ── Test 3: Consecutive span < 5 → does NOT fire ──
+
+println("=" ^ 60)
+println("TEST 3: 4 consecutive high-CV evaluations → does NOT fire")
+println("=" ^ 60)
+
+state3 = make_brain_state(bt)
+state3.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(2.0, 2.0)
+window3 = 10
+
+# Fill window with high-variance values to establish CV
+for v in [0.9, -0.8, 0.7, -0.6, 0.5, -0.4, 0.3, -0.2, 0.1, -0.1]
+    check_no_confidence(state3, "Bash", "generic", v, window3)
+end
+# Flush entire window with stable values to reset counter
+for _ in 1:10
+    check_no_confidence(state3, "Bash", "generic", 0.2, window3)
+end
+@assert state3.no_confidence_consecutive == 0 "Stable values should reset counter"
+
+# Now add exactly 4 high-variance values (high CV after mixing into window)
+for v in [0.9, -0.8, 0.7, -0.6]
+    global result3 = check_no_confidence(state3, "Bash", "generic", v, window3)
+end
+@assert state3.no_confidence_consecutive <= 4 "Should have at most 4 consecutive"
+@assert !result3 "4 consecutive should not fire (need 5)"
+
+println("PASSED: 4 consecutive high-CV does not fire")
+println()
+
+# ── Test 4: Concentrated posterior → demanding threshold ──
+
+println("=" ^ 60)
+println("TEST 4: Concentrated posterior needs very high CV to fire")
+println("=" ^ 60)
+
+state4 = make_brain_state(bt)
+state4.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(100.0, 100.0)
+window4 = 10
+
+# Low variance values — CV should be below 1/√200 ≈ 0.0707
+low_var = [0.200, 0.201, 0.199, 0.200, 0.201, 0.199, 0.200, 0.201, 0.199, 0.200,
+           0.201, 0.199, 0.200, 0.201]
+result4 = false
+for v in low_var
+    global result4 = check_no_confidence(state4, "Bash", "generic", v, window4)
+end
+
+# credence-lint: allow — precedent:display-arithmetic — test oracle CV computation
+μ4 = sum(low_var[end-9:end]) / 10
+σ4 = sqrt(sum((x - μ4)^2 for x in low_var[end-9:end]) / 10)
+cv4 = σ4 / abs(μ4)
+# credence-lint: allow — precedent:display-arithmetic — test oracle threshold
+threshold4 = 1.0 / sqrt(200.0)
+println("  CV = $(round(cv4, digits=6)), threshold = $(round(threshold4, digits=4))")
+@assert !result4 "Low-variance trajectory below concentrated threshold should not fire"
+println("PASSED: Low variance below concentrated-posterior threshold")
+println()
+
+# ── Test 5: Fresh posterior → permissive threshold, fires ──
+
+println("=" ^ 60)
+println("TEST 5: Fresh posterior fires at moderate CV")
+println("=" ^ 60)
+
+state5 = make_brain_state(bt)
+window5 = 10
+
+moderate_var_2 = [0.5, -0.1, 0.4, -0.2, 0.3, -0.1, 0.4, -0.2, 0.3, -0.1,
+                  0.5, -0.1, 0.4, -0.2]
+result5 = false
+for v in moderate_var_2
+    global result5 = check_no_confidence(state5, "Bash", "generic", v, window5)
+end
+
+# credence-lint: allow — precedent:expect-through-accessor — test oracle threshold
+m5 = get_posterior(state5, "Bash", "generic")
+threshold5 = 1.0 / sqrt(m5.alpha + m5.beta)  # credence-lint: allow — precedent:display-arithmetic — test oracle
+println("  Fresh posterior threshold = $(round(threshold5, digits=4))")
+println("  fired = $result5")
+
+@assert result5 "Fresh Beta(1,1) with high-variance trajectory should fire (threshold=1/√2≈0.707)"
+
+println("PASSED: Fresh posterior fires at moderate CV")
+println()
+
+# ── Test 6: Consecutive span resets on stable evaluation ──
+
+println("=" ^ 60)
+println("TEST 6: Consecutive counter resets on stable evaluation")
+println("=" ^ 60)
+
+state6 = make_brain_state(bt)
+state6.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(2.0, 2.0)
+window6 = 10
+
+for v in [0.9, -0.8, 0.7, -0.6, 0.5, -0.4, 0.3, -0.2, 0.1, -0.1]
+    check_no_confidence(state6, "Bash", "generic", v, window6)
+end
+@assert state6.no_confidence_consecutive >= 1 "Should have some consecutive count"
+
+for _ in 1:10
+    check_no_confidence(state6, "Bash", "generic", 0.5, window6)
+end
+@assert state6.no_confidence_consecutive == 0 "Stable values should reset consecutive counter, got $(state6.no_confidence_consecutive)"
+
+println("PASSED: Consecutive counter resets correctly")
+println()
+
+# ── Test 7: Window size insufficient → no fire ──
+
+println("=" ^ 60)
+println("TEST 7: Fewer values than window size → no fire")
+println("=" ^ 60)
+
+state7 = make_brain_state(bt)
+window7 = 10
+
+result7 = false
+for v in [0.9, -0.8, 0.7]
+    global result7 = check_no_confidence(state7, "Bash", "generic", v, window7)
+    @assert !result7 "Fewer than window_size values should not fire"
+end
+
+println("PASSED: Insufficient data prevents firing")
+println()
+
+println("=" ^ 60)
+println("ALL #65550 DETECTOR TESTS PASSED")
+println("=" ^ 60)

--- a/test/test_detectors_e2e.jl
+++ b/test/test_detectors_e2e.jl
@@ -1,0 +1,140 @@
+#!/usr/bin/env julia
+"""
+    test_detectors_e2e.jl — End-to-end integration test spanning all three detectors.
+
+Verifies: each detector fires correctly in a single sidecar session;
+cross-detector independence; reason strings distinguish detectors.
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, ".."))
+using Credence
+using JSON3
+using Dates
+
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "instruction_patterns.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "brain.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "detectors.jl"))
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "persistence.jl"))
+
+config_path = joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "config", "budgets.json")
+bt = load_budget_table(config_path)
+
+read_tools_path = joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "config", "read_tools.json")
+read_tools = load_read_tools(read_tools_path)
+
+# ── Test 1: Synthetic trajectory — each failure mode fires in turn ──
+
+println("=" ^ 60)
+println("TEST 1: Sequential failure-mode trajectory")
+println("=" ^ 60)
+
+state = make_brain_state(bt)
+
+# Phase 1: Build up some posterior with successful Bash calls
+for _ in 1:10
+    update_posterior!(state, "Bash", "generic", true)
+end
+println("  Phase 1: Built posterior Beta(11,1)")
+
+# Phase 2: Trigger #34574 (stationarity) via repeated identical tool calls
+params_repeat = Dict{String,Any}("command" => "echo stuck")
+for _ in 1:5
+    record_outcome!(state, "Bash", params_repeat, true)
+end
+sr = check_stationarity(state, read_tools, "Bash", params_repeat, "generic")
+@assert sr !== nothing && sr.fires "Phase 2: Stationarity detector should fire after 5 identical outcomes"
+println("  Phase 2: #34574 (stationarity) fires — outcome_var=$(round(sr.outcome_var, digits=4))")
+
+# Phase 3: Trigger #1084 (instruction-based escalation)
+register_instruction!(state, "negation-delete", "delete")
+state.tool_outcomes[PosteriorKey("Bash", "delete")] = BetaMeasure(50.0, 2.0)
+result_1084 = compute_eu(state, "Bash", "delete")
+@assert result_1084.decision == "escalate" "Phase 3: #1084 detector should escalate for delete class"
+println("  Phase 3: #1084 (instruction escalation) fires — decision=$(result_1084.decision)")
+
+# Phase 4: Trigger #65550 (no-confidence) via high-variance EU trajectory
+state.tool_outcomes[PosteriorKey("Edit", "code")] = BetaMeasure(2.0, 2.0)
+high_var_eu = [0.8, -0.5, 0.6, -0.4, 0.7, -0.3, 0.5, -0.6, 0.4, -0.5,
+               0.8, -0.5, 0.6, -0.4]
+nc_fired = false
+for v in high_var_eu
+    global nc_fired = check_no_confidence(state, "Edit", "code", v, 10)
+end
+@assert nc_fired "Phase 4: #65550 no-confidence should fire"
+println("  Phase 4: #65550 (no-confidence) fires")
+
+println("PASSED: All three detectors fire in sequence")
+println()
+
+# ── Test 2: Cross-detector independence ──
+
+println("=" ^ 60)
+println("TEST 2: Cross-detector independence")
+println("=" ^ 60)
+
+state2 = make_brain_state(bt)
+
+# Set up conditions for both #34574 and #65550 simultaneously
+state2.tool_outcomes[PosteriorKey("Bash", "generic")] = BetaMeasure(2.0, 2.0)
+params_both = Dict{String,Any}("command" => "echo loop")
+for _ in 1:5
+    record_outcome!(state2, "Bash", params_both, true)
+end
+
+high_var_eu2 = [0.9, -0.8, 0.7, -0.6, 0.5, -0.4, 0.3, -0.2, 0.1, -0.1,
+                0.8, -0.7, 0.6, -0.5]
+for v in high_var_eu2
+    check_no_confidence(state2, "Bash", "generic", v, 10)
+end
+
+sr2 = check_stationarity(state2, read_tools, "Bash", params_both, "generic")
+nc2 = state2.no_confidence_consecutive >= NO_CONFIDENCE_SPAN
+
+@assert sr2 !== nothing && sr2.fires "#34574 should fire independently"
+@assert nc2 "#65550 should fire independently"
+println("  Both #34574 and #65550 fire simultaneously — independence verified")
+
+println("PASSED: Cross-detector independence")
+println()
+
+# ── Test 3: Reason strings distinguish detectors ──
+
+println("=" ^ 60)
+println("TEST 3: Reason strings are distinguishable")
+println("=" ^ 60)
+
+sr_reason = "Posterior stationary on repeated tool call"
+nc_reason = "Posterior over next-action value is flat"
+esc_reason = "uncertain expected utility"
+
+@assert sr_reason != nc_reason "Stationarity and no-confidence reasons must differ"
+@assert sr_reason != esc_reason "Stationarity and escalation reasons must differ"
+@assert nc_reason != esc_reason "No-confidence and escalation reasons must differ"
+
+println("PASSED: Reason strings are distinct")
+println()
+
+# ── Test 4: Read tools unaffected by any detector ──
+
+println("=" ^ 60)
+println("TEST 4: Read tools unaffected across all detectors")
+println("=" ^ 60)
+
+state4 = make_brain_state(bt)
+read_params = Dict{String,Any}("file_path" => "/etc/hosts")
+for _ in 1:100
+    record_outcome!(state4, "Read", read_params, true)
+end
+
+sr4 = check_stationarity(state4, read_tools, "Read", read_params, "code")
+@assert sr4 === nothing "Read tool exempt from #34574"
+
+result_read = compute_eu(state4, "Read", "code")
+@assert result_read.decision != "halt" "Read tool should not be halted"
+
+println("PASSED: Read tools exempt from destructive detectors")
+println()
+
+println("=" ^ 60)
+println("ALL END-TO-END DETECTOR TESTS PASSED")
+println("=" ^ 60)

--- a/test/test_governance_brain.jl
+++ b/test/test_governance_brain.jl
@@ -11,6 +11,7 @@ push!(LOAD_PATH, joinpath(@__DIR__, ".."))
 using Credence
 using JSON3
 
+include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "instruction_patterns.jl"))
 include(joinpath(@__DIR__, "..", "apps", "credence-governance-sidecar", "brain.jl"))
 
 # ── Test 1: Category inference ──
@@ -188,36 +189,10 @@ parsed = JSON3.read(json_str, Dict{String,Any})
 println("PASSED: Response shape serialises cleanly, action/reason present for Move 1 plugin")
 println()
 
-# ── Test 8: Prototype fallback ──
+# ── Test 8: Observation count tracks correctly ──
 
 println("=" ^ 60)
-println("TEST 8: Prototype repetition-counter fallback")
-println("=" ^ 60)
-
-fb_state = make_brain_state(bt; prototype_fallback_enabled=true, max_repetitions=3)
-history = Dict{String,Any}[]
-for i in 1:3
-    push!(history, Dict{String,Any}("toolName" => "Bash", "params" => Dict{String,Any}("command" => "ls")))
-end
-fb_result = check_prototype_fallback(fb_state, history, "Bash", Dict{String,Any}("command" => "ls"))
-@assert fb_result !== nothing "Fallback should trigger after 3 identical calls"
-@assert fb_result["action"] == "block"
-@assert fb_result["decision"] == "halt"
-
-read_result = check_prototype_fallback(fb_state, history, "Read", Dict{String,Any}("file_path" => "/etc/hosts"))
-@assert read_result === nothing "Read tools should be exempt from fallback"
-
-fb_off_state = make_brain_state(bt; prototype_fallback_enabled=false)
-fb_off_result = check_prototype_fallback(fb_off_state, history, "Bash", Dict{String,Any}("command" => "ls"))
-@assert fb_off_result === nothing "Fallback disabled should return nothing"
-
-println("PASSED: Prototype fallback gating works")
-println()
-
-# ── Test 9: Observation count tracks correctly ──
-
-println("=" ^ 60)
-println("TEST 9: Observation count")
+println("TEST 8: Observation count")
 println("=" ^ 60)
 
 count_state = make_brain_state(bt)
@@ -229,10 +204,10 @@ update_posterior!(count_state, "Edit", "code", false)
 println("PASSED: Observation count increments correctly")
 println()
 
-# ── Test 10: Category precedence — delete before version-control ──
+# ── Test 9: Category precedence — delete before version-control ──
 
 println("=" ^ 60)
-println("TEST 10: Category precedence")
+println("TEST 9: Category precedence")
 println("=" ^ 60)
 
 @assert infer_category("Bash", Dict{String,Any}("command" => "git rm file.txt")) == "delete"


### PR DESCRIPTION
## Summary

Three commits, one per detector, completing the v0.1 feature set:

- **Commit 1 (#34574 exec-repetition):** Per-(tool, argument-hash) outcome tracking with stationarity detection. Window size K = ceil(sqrt(α+β)) scales with posterior concentration. Outcome variance below threshold fires EU(halt). Read-tool exemption via `config/read_tools.json`. Removes prototype fallback (`prototype_fallback_enabled`, `check_prototype_fallback`).
- **Commit 2 (#1084 compaction-wipes-confirm-instruction):** Dedicated test suite for the instruction-based escalation detector. The detector logic was wired into `compute_eu` in sub-PR 4; this commit adds tests verifying the detector as a named concept with decay tracking.
- **Commit 3 (#65550 no-confidence dreaming-loop):** CV of EU(proceed) across a sliding window (size 10). Fires when CV exceeds 1/√(α+β) for 5 consecutive evaluations. End-to-end integration test verifies all three detectors fire independently and simultaneously.

## Test plan

- [x] `test_detector_34574.jl` — 9 tests (stationarity, read-tool exemption, window scaling)
- [x] `test_detector_1084.jl` — 8 tests (instruction escalation, decay, lifecycle)
- [x] `test_detector_65550.jl` — 7 tests (CV threshold, consecutive span, reset)
- [x] `test_detectors_e2e.jl` — 4 tests (sequential trajectory, cross-detector independence)
- [x] All existing tests pass (brain, persistence, compaction-survival, instruction-decay, instruction-patterns)
- [x] `credence-lint check apps/` — 0 violations
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)