### PR TITLE
openclaw-plugin: packaging verification against OpenClaw 2026.4.27

### DIFF
--- a/apps/openclaw-plugin/PACKAGING-AUDIT.md
+++ b/apps/openclaw-plugin/PACKAGING-AUDIT.md
@@ -1,0 +1,135 @@
+# Packaging Audit: Credence Governance Plugin
+
+Audited 2026-04-30 against OpenClaw 2026.4.27 plugin documentation
+(docs.openclaw.ai/plugins/{building-plugins,manifest,hooks,sdk-overview}).
+
+## Matches documentation
+
+- **Hook names.** `before_tool_call`, `after_tool_call`, `before_compaction`,
+  `agent_end` all exist with the same semantics the plugin assumes.
+- **Hook registration.** `api.on(name, handler, opts?)` is the documented API.
+- **Hook priority.** `{ priority: 100 }` is valid (higher runs first).
+- **`before_tool_call` return shape.** `{ block, blockReason, requireApproval }`
+  matches the documented `BeforeToolCallResult` type.
+- **`requireApproval` fields.** `title`, `description`, `severity`, `timeoutMs`,
+  `timeoutBehavior` are all documented.
+- **Manifest required fields.** `openclaw.plugin.json` has `id` and `configSchema`
+  (both required per docs).
+- **`activation.onStartup: true`.** Documented and correct.
+- **Fail-open pattern.** No documentation requires fail-closed; fail-open is the
+  expected default for non-security plugins.
+- **`package.json` `type: "module"`.** Correct for ESM plugins.
+- **`openclaw.extensions`.** Array of entry files pointing at `./src/index.ts`.
+
+## Drift identified
+
+### D1. `package.json` missing `openclaw.runtimeExtensions`
+
+When `extensions` points at TypeScript source (`./src/index.ts`), docs require
+`runtimeExtensions` containing the built JS peer (`./dist/index.js`). Without
+this, the loader may fail to resolve the runtime entry.
+
+**Fix:** Add `"runtimeExtensions": ["./dist/index.js"]` to `openclaw` key.
+
+### D2. `package.json` missing `openclaw.compat`
+
+Docs show `compat.pluginApi` (semver range) and `compat.minGatewayVersion` as
+standard metadata. Absence may cause install warnings or `plugins doctor` flags.
+
+**Fix:** Add `compat` with `pluginApi` and `minGatewayVersion` values.
+
+### D3. `package.json` missing `openclaw.build`
+
+Docs show `build.openclawVersion` and `build.pluginSdkVersion` as informational
+metadata expected by `plugins doctor`.
+
+**Fix:** Add `build` with current versions.
+
+### D4. Config access: `api.config` should be `api.pluginConfig`
+
+`api.config` is the full OpenClaw config object. Plugin-specific config from
+`plugins.entries.<id>.config` is exposed via `api.pluginConfig`. The plugin reads
+`api.config.sidecarUrl` which resolves to `undefined` because `sidecarUrl` lives
+under the plugin's config subtree, not at the OpenClaw config root.
+
+**Impact:** Functional bug — plugin always falls back to hardcoded defaults
+regardless of user configuration.
+
+**Fix:** Replace `api.config` with `api.pluginConfig` on line 66 of `src/index.ts`.
+
+### D5. Logging: `api.log` should be `api.logger`
+
+`api.log` is not in the documented plugin API. The documented logging interface
+is `api.logger` with `.debug()`, `.info()`, `.warn()`, `.error()` methods.
+The current code uses `api.log?.(level, message)` — optional chaining prevents
+a crash, but logging silently no-ops.
+
+**Fix:** Replace `api.log` calls with `api.logger` method calls.
+
+### D6. `RequireApprovalPayload` severity enum mismatch
+
+Docs define `severity?: "info" | "warning" | "critical"`. Plugin type uses
+`"error"` instead of `"critical"`. If the sidecar sends severity `"error"`,
+OpenClaw may ignore it or fall back to a default.
+
+**Fix:** Change `"error"` to `"critical"` in `RequireApprovalPayload` type.
+
+### D7. Unused `maxRepetitions` config in manifest
+
+`openclaw.plugin.json` declares `maxRepetitions` in `configSchema.properties`
+but the plugin code never reads it. Dead config confuses users inspecting the
+plugin via `openclaw plugins inspect`.
+
+**Fix:** Remove `maxRepetitions` from `configSchema.properties`.
+
+### D8. Timeout default mismatch
+
+`openclaw.plugin.json` declares default 200ms; `src/index.ts` hardcodes fallback
+50ms. These should agree. The manifest value (200ms) is the documented default.
+
+**Fix:** Change the hardcoded fallback in `src/index.ts` from 50 to 200.
+
+### D9. README references YAML config format
+
+OpenClaw config is `~/.openclaw/openclaw.json` (JSON5 format). The README
+references `config.yaml` which doesn't exist.
+
+**Fix:** Rewrite README with correct JSON5 config format and path.
+
+### D10. README install command uses wrong flag
+
+README says `openclaw plugins install . --link`; docs show the link flag as
+`-l` (short form): `openclaw plugins install -l <path>`.
+
+**Fix:** Correct in README rewrite.
+
+### D11. Entry point pattern: raw export vs `definePluginEntry()`
+
+Plugin uses `export default { id, name, description, register }`. Docs show
+`definePluginEntry()` from `"openclaw/plugin-sdk/plugin-entry"`. The shapes are
+structurally equivalent, but `definePluginEntry` may add runtime markers the
+loader checks.
+
+**Status:** Needs empirical verification during smoke test. If the loader
+rejects the raw export, an additional commit switches to `definePluginEntry()`.
+
+### D12. `dist/` not built
+
+No compiled output exists. The plugin needs `npm install && npm run build`
+before it can be loaded by OpenClaw.
+
+**Fix:** Build step added to README prerequisites. `dist/` stays gitignored.
+
+## Noted but out of scope
+
+- **`onResolution` callback.** Docs show `requireApproval.onResolution` as the
+  way to receive user approval/denial decisions. Plugin currently correlates via
+  `event.userApproval` on `after_tool_call`. This may be an older pattern. Not a
+  packaging item — changing it would alter hook behavior.
+- **`after_tool_call` `event.userApproval` field.** Not explicitly documented in
+  the hook event reference. May work via OpenClaw's internal forwarding. Verify
+  during deployment, not here.
+
+## Smoke test results
+
+_To be appended after Task 5._

--- a/apps/openclaw-plugin/PACKAGING-AUDIT.md
+++ b/apps/openclaw-plugin/PACKAGING-AUDIT.md
@@ -132,4 +132,58 @@ before it can be loaded by OpenClaw.
 
 ## Smoke test results
 
-_To be appended after Task 5._
+Tested 2026-04-30 against OpenClaw 2026.4.27 (cbc2ba0).
+
+### Build
+
+```
+$ npm run build
+> credence-governance@0.1.0 build
+> tsc
+```
+
+No errors. `dist/index.js`, `dist/sidecar-client.js` + declaration files produced.
+
+### Install
+
+```
+$ openclaw plugins install -l /home/g/git/credence/apps/openclaw-plugin
+Linked plugin path: ~/git/credence/apps/openclaw-plugin
+Restart the gateway to load plugins.
+```
+
+### Verify
+
+```
+$ openclaw plugins list
+Credence Governance | credence-governance | openclaw | enabled | 0.1.0
+
+$ openclaw plugins inspect credence-governance
+Status: loaded
+Format: openclaw
+Shape: hook-only
+Typed hooks:
+  after_tool_call
+  before_compaction
+  before_tool_call (priority 100)
+Diagnostics:
+  WARN: typed hook "agent_end" blocked — requires allowConversationAccess=true
+
+$ openclaw plugins doctor
+credence-governance is hook-only [info]
+```
+
+### Entry point pattern (D11 verification)
+
+**Confirmed: raw `export default { register }` is accepted.** The loader
+loaded the plugin without requiring `definePluginEntry()`. No fix needed.
+
+### New finding: `agent_end` hook requires `allowConversationAccess`
+
+OpenClaw classifies `agent_end` as a conversation-access hook. Non-bundled
+plugins need `hooks.allowConversationAccess: true` in config for it to fire.
+Without this, the plugin's history buffer cleanup doesn't run at agent-turn
+boundaries. Impact is minor — the buffer is bounded (50 entries) and stale
+entries naturally age out. But the config key should be documented.
+
+**Fix:** Added `allowConversationAccess` to README config example.

--- a/apps/openclaw-plugin/README.md
+++ b/apps/openclaw-plugin/README.md
@@ -1,54 +1,102 @@
 # Credence Governance Plugin for OpenClaw
 
-Prototype OpenClaw plugin that intercepts tool calls via a Credence governance
-sidecar. The sidecar evaluates each candidate tool call and can veto it when
-the expected utility calculation indicates intervention (e.g., loop detection).
+Intercepts tool calls via a Bayesian governance sidecar. The sidecar evaluates
+each candidate tool call by expected utility and can veto runaway loops,
+escalate uncertain actions to the user, or suggest alternatives.
 
 ## Prerequisites
 
-- OpenClaw installed and configured
-- Credence governance sidecar running (see `../credence-governance-sidecar/`)
+- [OpenClaw](https://openclaw.ai) installed (`npm install -g openclaw@latest`)
 - Node.js >= 22
+- Julia >= 1.9 (for the governance sidecar)
 
-## Install
+## Setup
+
+### 1. Start the governance sidecar
 
 ```bash
-# From this directory
-openclaw plugins install . --link
+cd apps/credence-governance-sidecar
+julia --project=. server.jl
 ```
 
-## Configure
+The sidecar listens on `http://localhost:3100` by default. If the sidecar is not
+running when the plugin loads, the plugin warns once and fails open (no
+governance protection until the sidecar comes back).
 
-In `~/.openclaw/config.yaml` (or equivalent):
+### 2. Build and install the plugin
 
-```yaml
-plugins:
-  entries:
-    credence-governance:
-      enabled: true
-      config:
-        sidecarUrl: "http://localhost:3100"
-        timeoutMs: 200
+```bash
+cd apps/openclaw-plugin
+npm install
+npm run build
+
+# Developer (link mode — picks up source changes after gateway restart):
+openclaw plugins install -l "$(pwd)"
+
+# User (copy mode):
+openclaw plugins install "$(pwd)"
+```
+
+### 3. Configure
+
+Add to `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  plugins: {
+    entries: {
+      "credence-governance": {
+        enabled: true,
+        config: {
+          sidecarUrl: "http://localhost:3100",
+          timeoutMs: 200
+        }
+      }
+    }
+  }
+}
+```
+
+Both config values are optional — the defaults shown above apply if omitted.
+
+### 4. Restart the gateway
+
+```bash
+openclaw gateway restart
+```
+
+### 5. Verify
+
+```bash
+openclaw plugins list                          # should show credence-governance enabled
+openclaw plugins inspect credence-governance   # should show all 4 hooks registered
+openclaw plugins doctor                        # should report no errors for this plugin
 ```
 
 ## How it works
 
-1. Plugin registers on `before_tool_call` and `after_tool_call` hooks.
-2. Before each tool call, the plugin sends the candidate call and recent
-   history to the sidecar at `POST /evaluate`.
-3. The sidecar returns an enriched response with a `decision` field
-   (`proceed`, `halt`, `downgrade`, `route`, or `escalate`) and optional
-   `signals` (alpha, beta, EU values) plus `requireApproval` payload.
-4. The plugin renders the decision as an OpenClaw hook return value:
-   - **proceed / route** — no intervention (`undefined`).
-   - **halt** — block with reason (`{ block: true, blockReason: "..." }`).
-   - **downgrade** — block with reason suggesting an alternative tool.
-   - **escalate** — request user approval (`{ requireApproval: { ... } }`).
-5. After each tool call, the plugin sends the outcome to the sidecar at
-   `POST /observe` (fire-and-forget). If the call was an escalation, the
-   user's approval decision is forwarded as `userApproval: boolean`.
-6. If the sidecar is unavailable, the plugin fails open (no intervention).
+1. `before_tool_call`: sends the candidate tool call + recent history to the
+   sidecar at `POST /evaluate`.
+2. Sidecar returns a decision: **proceed**, **halt** (block with reason),
+   **downgrade** (block suggesting alternative), or **escalate** (request user
+   approval).
+3. `after_tool_call`: sends outcome to `POST /observe` (fire-and-forget) so the
+   sidecar can update its posterior.
+4. `before_compaction`: sends messages about to be compacted to
+   `POST /compaction-preview` so the sidecar can detect instruction patterns.
+5. `agent_end`: clears the local history buffer.
 
-The sidecar response is backwards-compatible with the Move 1 `action`
-field: if `decision` is absent, the plugin falls back to mapping
-`action: "block"` to `halt` and `action: "proceed"` to `proceed`.
+## Troubleshooting
+
+**Sidecar not running.** The plugin warns once in the gateway logs and proceeds
+without governance. Start the sidecar and the plugin resumes automatically.
+
+**Plugin not loading.** Run `openclaw plugins doctor` to surface manifest issues.
+Ensure `npm run build` completed successfully (check that `dist/index.js` exists).
+
+**Config not taking effect.** Verify config is under `plugins.entries.credence-governance.config`
+in `~/.openclaw/openclaw.json` (JSON5 format), not at the top level. Restart the
+gateway after config changes.
+
+**Gateway hasn't picked up changes.** After installing or updating the plugin,
+run `openclaw gateway restart`.

--- a/apps/openclaw-plugin/README.md
+++ b/apps/openclaw-plugin/README.md
@@ -47,6 +47,9 @@ Add to `~/.openclaw/openclaw.json`:
     entries: {
       "credence-governance": {
         enabled: true,
+        hooks: {
+          allowConversationAccess: true  // needed for agent_end cleanup hook
+        },
         config: {
           sidecarUrl: "http://localhost:3100",
           timeoutMs: 200
@@ -57,7 +60,10 @@ Add to `~/.openclaw/openclaw.json`:
 }
 ```
 
-Both config values are optional — the defaults shown above apply if omitted.
+`sidecarUrl` and `timeoutMs` are optional — the defaults shown above apply if
+omitted. `allowConversationAccess` is required for the `agent_end` hook (clears
+the history buffer between agent turns); without it, the buffer is bounded at 50
+entries and stale entries age out naturally.
 
 ### 4. Restart the gateway
 

--- a/apps/openclaw-plugin/openclaw.plugin.json
+++ b/apps/openclaw-plugin/openclaw.plugin.json
@@ -18,11 +18,6 @@
         "type": "number",
         "description": "Timeout for sidecar requests in milliseconds",
         "default": 200
-      },
-      "maxRepetitions": {
-        "type": "number",
-        "description": "Maximum identical tool calls before veto (prototype only)",
-        "default": 3
       }
     }
   }

--- a/apps/openclaw-plugin/package.json
+++ b/apps/openclaw-plugin/package.json
@@ -6,7 +6,16 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "openclaw": {
-    "extensions": ["./src/index.ts"]
+    "extensions": ["./src/index.ts"],
+    "runtimeExtensions": ["./dist/index.js"],
+    "compat": {
+      "pluginApi": ">=2026.3.24-beta.2",
+      "minGatewayVersion": "2026.3.24-beta.2"
+    },
+    "build": {
+      "openclawVersion": "2026.4.27",
+      "pluginSdkVersion": "2026.3.24-beta.2"
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/apps/openclaw-plugin/src/index.ts
+++ b/apps/openclaw-plugin/src/index.ts
@@ -63,10 +63,10 @@ export default {
     "Bayesian governance sidecar — intercepts tool calls via expected utility",
 
   register(api: any) {
-    const config = api.config ?? {};
+    const config = api.pluginConfig ?? {};
     const sidecarUrl =
       (config.sidecarUrl as string) ?? "http://localhost:3100";
-    const timeoutMs = (config.timeoutMs as number) ?? 50;
+    const timeoutMs = (config.timeoutMs as number) ?? 200;
     const silentMode = (config.silentMode as boolean) ?? false;
 
     const client = new SidecarClient(sidecarUrl, timeoutMs);
@@ -79,7 +79,8 @@ export default {
 
     const log = (level: string, message: string) => {
       if (silentMode) return;
-      api.log?.(level, message);
+      if (level === "warn") api.logger?.warn(message);
+      else api.logger?.info(message);
     };
 
     api.on(

--- a/apps/openclaw-plugin/src/sidecar-client.ts
+++ b/apps/openclaw-plugin/src/sidecar-client.ts
@@ -22,7 +22,7 @@ export type EvaluateSignals = {
 export type RequireApprovalPayload = {
   title: string;
   description: string;
-  severity: "warning" | "error" | "info";
+  severity: "info" | "warning" | "critical";
   timeoutMs: number;
   timeoutBehavior: "deny" | "allow";
 };


### PR DESCRIPTION
## Summary

- Audited the governance plugin at `apps/openclaw-plugin/` against current OpenClaw plugin documentation (2026.4.27)
- Found and fixed 10 drift items (D1–D10), confirmed 2 more empirically (D11 no-fix-needed, D12 documented)
- Smoke-tested: plugin builds, installs in link mode, and loads with 3/4 hooks active

## Drift fixes

| Commit | Fixes | What |
|--------|-------|------|
| 1 | D1, D2, D3 | `package.json`: add `runtimeExtensions`, `compat`, `build` |
| 2 | D4, D5, D8 | `api.config` → `api.pluginConfig`, `api.log` → `api.logger`, timeout 50→200 |
| 3 | D6 | Severity enum `"error"` → `"critical"` |
| 4 | D7 | Remove unused `maxRepetitions` from manifest |
| 5 | D9, D10 | README rewrite (JSON5 config, `-l` flag, verification steps) |
| 6 | — | Smoke test results + `allowConversationAccess` config for `agent_end` hook |

## Key finding: `api.pluginConfig` bug (D4)

The plugin was reading `api.config` (full OpenClaw config) instead of `api.pluginConfig` (plugin-specific config). This meant user-configured `sidecarUrl` and `timeoutMs` were silently ignored — the plugin always used hardcoded defaults.

## Smoke test

- `openclaw plugins list` — plugin shows enabled
- `openclaw plugins inspect credence-governance` — 3 hooks registered (`before_tool_call` at priority 100, `after_tool_call`, `before_compaction`); `agent_end` blocked without `allowConversationAccess` config
- `openclaw plugins doctor` — no errors, one info-level "hook-only" note
- `npm run typecheck` — clean

## Out of scope (noted in audit, not fixed)

- `onResolution` callback vs `event.userApproval` — different approval-tracking mechanism, would change hook behavior
- `definePluginEntry()` migration — empirically verified as unnecessary (raw export accepted)

## Test plan

- [ ] `npm run build` and `npm run typecheck` pass
- [ ] `openclaw plugins install -l` succeeds
- [ ] `openclaw plugins inspect credence-governance` shows 3+ hooks
- [ ] `openclaw plugins doctor` reports no errors
- [ ] No changes to hook logic, sidecar communication, or intervention rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)