### PR TITLE
[paper1] B2b: Gaussian-NB category inference module + LOO calibration

### DIFF
--- a/apps/julia/qa_benchmark/category_inference.jl
+++ b/apps/julia/qa_benchmark/category_inference.jl
@@ -1,0 +1,178 @@
+# Role: brain-side application
+"""
+    category_inference.jl — Gaussian Naive Bayes category classifier.
+
+Paper 1, Phase B2b (`docs/paper1/move-2-design.md` §3.1;
+`docs/paper1/master-plan.md` §4a). Infers a soft category posterior
+`P(category | embedding)` for a question, so the same inferred category
+information is available to every agent and fairness can be enforced
+(master-plan OQ1(c), OQ5).
+
+Model — option (b-NB): per-(class, dimension) Normal-Gamma conjugate
+posteriors over the embedding coordinates, plus a Dirichlet class prior.
+The class posterior for a new embedding is computed by `condition`-ing a
+`CategoricalMeasure` (built from the Dirichlet-Categorical predictive
+over classes) through a naive-Bayes kernel whose per-dimension
+log-density is the Normal-Gamma marginal predictive (Student-t). Every
+belief update is a `condition` call — no host-side weight surgery
+(Invariant 1).
+
+State is held at the Prevision level (master-plan D4): a
+`DirichletPrevision` plus a `Matrix{NormalGammaPrevision}`. The public
+`infer` / `loo_category_inference` return `Dict{Symbol, Float64}`.
+
+Model-agnostic in the embeddings (D5): takes a `Matrix{Float64}` of shape
+`(N, D)`; producing real sentence embeddings for the question bank is a
+later move.
+
+Tests: `test/test_qa_benchmark_category_inference.jl`.
+"""
+
+using Credence
+using Credence: DirichletPrevision, NormalGammaPrevision, log_predictive
+using SpecialFunctions: lgamma
+
+# Vague priors. Class prior: symmetric Dirichlet(1, …, 1) — one
+# pseudo-count per class. Per-(class, dim) Normal-Gamma: κ=1 (one
+# pseudo-observation), μ=0, α=2, β=2.
+const _NG_PRIOR = (κ = 1.0, μ = 0.0, α = 2.0, β = 2.0)
+
+# Scalar-observation kernel: drives the Normal-Gamma conjugate update.
+# Source: the (μ, σ²) hypothesis space the Normal-Gamma declares.
+# Target: a single observed scalar (one embedding coordinate). `condition`
+# uses the conjugate path (maybe_conjugate → update); the log-density
+# below is the honest observation model and is not consulted on that path.
+const SCALAR_OBS_KERNEL = Kernel(
+    ProductSpace(Space[Euclidean(1), PositiveReals()]),
+    Euclidean(1),
+    h -> error("SCALAR_OBS_KERNEL.generate not exercised (conjugate path)"),
+    (h, o) -> begin
+        μ_val, σ² = h[1], h[2]
+        -0.5 * log(2π * σ²) - (Float64(o) - μ_val)^2 / (2.0 * σ²)
+    end;
+    likelihood_family = NormalGammaLikelihood(),
+)
+
+# Class-observation kernel: drives the Dirichlet conjugate update. Built
+# per category vocabulary (the simplex dimension depends on K).
+_class_obs_kernel(cats::Vector{Symbol}) = Kernel(
+    Simplex(length(cats)),
+    Finite(cats),
+    h -> error("class kernel generate not exercised (conjugate path)"),
+    (h, o) -> begin
+        idx = findfirst(==(o), cats)
+        idx === nothing && error("unknown category $o")
+        log(h[idx])
+    end;
+    likelihood_family = Categorical(Finite(cats)),
+)
+
+# Normal-Gamma marginal predictive (Student-t). NormalGamma(κ, μ, α, β)
+# predictive for x_new is t_{2α}(x; μ, β(κ+1)/(ακ)). This is the
+# Normal-Gamma conjugate family's own closed form — the conjugate-
+# machinery vocabulary category of the `expect-through-accessor`
+# precedent — not a bypass of `expect` for a probabilistic property the
+# stdlib already exposes. Uses SpecialFunctions.lgamma.
+function student_t_logpdf(x::Real, ν::Real, m::Real, s²::Real)
+    z = (x - m)^2 / s²
+    lgamma((ν + 1) / 2) - lgamma(ν / 2) -
+        0.5 * (log(ν) + log(π) + log(s²)) -
+        ((ν + 1) / 2) * log(1 + z / ν)
+end
+
+function ng_predictive_logpdf(ng::NormalGammaPrevision, x::Real)
+    ν = 2 * ng.α
+    s² = ng.β * (ng.κ + 1) / (ng.α * ng.κ)
+    student_t_logpdf(x, ν, ng.μ, s²)
+end
+
+# Inference kernel: Finite(cats) → Euclidean(D). Its log-density is the
+# naive-Bayes per-dimension Student-t sum. `Flat()` because
+# CategoricalMeasure's `condition` uses the per-hypothesis density loop
+# and never consults maybe_conjugate.
+_inference_kernel(params::Matrix{NormalGammaPrevision}, cats::Vector{Symbol}) = Kernel(
+    Finite(cats),
+    Euclidean(size(params, 2)),
+    c -> error("inference kernel generate not exercised (density path)"),
+    (c, e) -> begin
+        cidx = findfirst(==(c), cats)
+        cidx === nothing && error("unknown category $c")
+        sum(ng_predictive_logpdf(params[cidx, j], e[j]) for j in 1:size(params, 2))
+    end;
+    likelihood_family = Flat(),
+)
+
+"""
+    CategoryClassifier
+
+A fitted Gaussian-NB category classifier. `class_prior` is the Dirichlet
+posterior over the K categories; `params` is the K×D matrix of
+per-(class, dimension) Normal-Gamma posteriors; `categories` is the
+sorted category vocabulary (length K).
+"""
+struct CategoryClassifier
+    class_prior::DirichletPrevision
+    params::Matrix{NormalGammaPrevision}   # K × D
+    categories::Vector{Symbol}             # sorted, length K
+end
+
+"""
+    fit(embeddings::Matrix{Float64}, categories::Vector{Symbol}) -> CategoryClassifier
+
+Fit per-(class, dim) Normal-Gamma posteriors and a Dirichlet class prior
+by conditioning on each (embedding, category) pair. `embeddings` is
+shape `(N, D)`; `categories` is length `N`. Every belief update is a
+`condition` call.
+"""
+function fit(embeddings::Matrix{Float64}, categories::Vector{Symbol})
+    N = size(embeddings, 1)
+    N == length(categories) ||
+        error("CategoryClassifier.fit: embeddings rows ($N) must match categories length ($(length(categories)))")
+    N >= 1 ||
+        error("CategoryClassifier.fit: empty training set; need at least one (embedding, category) pair")
+
+    cats = sort(unique(categories))
+    K = length(cats)
+    D = size(embeddings, 2)
+
+    class_prior = DirichletPrevision(ones(K))
+    params = [NormalGammaPrevision(_NG_PRIOR.κ, _NG_PRIOR.μ, _NG_PRIOR.α, _NG_PRIOR.β)
+              for _ in 1:K, _ in 1:D]
+    class_kernel = _class_obs_kernel(cats)
+
+    for i in 1:N
+        c = categories[i]
+        cidx = findfirst(==(c), cats)
+        class_prior = condition(class_prior, class_kernel, c)
+        for j in 1:D
+            params[cidx, j] = condition(params[cidx, j], SCALAR_OBS_KERNEL, embeddings[i, j])
+        end
+    end
+
+    CategoryClassifier(class_prior, params, cats)
+end
+
+"""
+    infer(clf::CategoryClassifier, embedding::Vector{Float64}) -> Dict{Symbol, Float64}
+
+Soft category posterior `P(category | embedding)`; sums to 1.0. Computed
+by `condition`-ing the Dirichlet-Categorical class predictive through the
+naive-Bayes kernel.
+"""
+function infer(clf::CategoryClassifier, embedding::Vector{Float64})
+    length(embedding) == size(clf.params, 2) ||
+        error("CategoryClassifier.infer: embedding length $(length(embedding)) ≠ classifier dim $(size(clf.params, 2))")
+
+    cats = clf.categories
+    class_kernel = _class_obs_kernel(cats)
+    # Dirichlet-Categorical predictive over classes via the sanctioned
+    # log_predictive accessor (not a raw α read).
+    log_class = [log_predictive(clf.class_prior, class_kernel, c) for c in cats]
+    cat_prior = CategoricalMeasure(Finite(cats), log_class)
+
+    nb_k = _inference_kernel(clf.params, cats)
+    post = condition(cat_prior, nb_k, embedding)
+
+    w = weights(post)
+    Dict(cats[i] => w[i] for i in eachindex(cats))
+end

--- a/apps/julia/qa_benchmark/category_inference.jl
+++ b/apps/julia/qa_benchmark/category_inference.jl
@@ -176,3 +176,30 @@ function infer(clf::CategoryClassifier, embedding::Vector{Float64})
     w = weights(post)
     Dict(cats[i] => w[i] for i in eachindex(cats))
 end
+
+"""
+    loo_category_inference(embeddings::Matrix{Float64}, categories::Vector{Symbol})
+        -> Vector{Dict{Symbol, Float64}}
+
+Leave-one-out cross-validated category inference (master-plan OQ3(c)).
+For each row `i`, fit a classifier on every other row and infer on row
+`i`. Returns one soft posterior per input row, in input order. Cost is
+`N` fits of `O(N·D)` each, i.e. `O(N²·D)`.
+"""
+function loo_category_inference(embeddings::Matrix{Float64}, categories::Vector{Symbol})
+    N = size(embeddings, 1)
+    N == length(categories) ||
+        error("loo_category_inference: embeddings rows ($N) must match categories length ($(length(categories)))")
+    N >= 2 ||
+        error("loo_category_inference: need at least two (embedding, category) pairs for leave-one-out")
+
+    out = Vector{Dict{Symbol,Float64}}(undef, N)
+    keep = trues(N)
+    for i in 1:N
+        keep[i] = false
+        clf = fit(embeddings[keep, :], categories[keep])
+        out[i] = infer(clf, embeddings[i, :])
+        keep[i] = true
+    end
+    out
+end

--- a/docs/paper1/master-plan.md
+++ b/docs/paper1/master-plan.md
@@ -441,11 +441,17 @@ categories) and the update. The exact posterior is a mixture
 non-conjugate → a K-way split per observation); its growth is a
 *computational* cost handled by **metacomputation** (EU over
 computational strategies — the spec's "On metareasoning"), not by a
-bolted-on approximation. The mechanism, the substrate extension it needs,
-and the depth of the metacomputation for Paper 1 are specified in the B2c
-design doc (`docs/paper1/move-2c-design.md`). Both agents still receive
-the identical soft posterior (OQ5); the agent's exact internal update is
-not an asymmetry in the information surface.
+bolted-on approximation. **Resolved (2026-05-31):** the metacomputation's
+conclusion is the **full-posterior-weighted update** — credit each
+category by its posterior weight (`α_{t,c} += π_c·correct`,
+`β_{t,c} += π_c·wrong`), a genuine `condition` via a new
+`WeightedBernoulli` conjugate family. It uses the *whole* posterior
+(unlike MAP, which discards it) and is the resource-rational realisation
+of the exact mixture (exact retention costs `K^n` for negligible gain).
+Mechanism, substrate, and the worked example: B2c design doc
+(`docs/paper1/move-2c-design.md`). Both agents still receive the
+identical soft posterior (OQ5); the agent's internal update is not an
+asymmetry in the information surface.
 
 **B2b execution split.** B2b lands as a split: **B2b.1–B2b.3**
 (this master-plan addendum, the `category_inference` module, and LOO

--- a/docs/paper1/master-plan.md
+++ b/docs/paper1/master-plan.md
@@ -218,6 +218,13 @@ auditability (b). Each option also has a different relationship with the
 "learnable observation model" claim in `SPEC.md` §4.2, which Guy may want
 to weigh in resolution.
 
+> **Resolved (2026-05-31): (c) body-side, identical implementation.**
+> Each agent runs the *same* category-inference machinery on the
+> question's embedding; fairness is enforced by identical
+> implementation, audited per evaluation. Aligns with `SPEC.md` §6
+> (perception in the body). The shared module is
+> `apps/julia/qa_benchmark/category_inference.jl` (B2b).
+
 ### OQ2 — what is the form of the Bayesian multinomial logistic?
 
 The paper claim is "Bayesian." Three candidates:
@@ -248,6 +255,17 @@ implementation cost. The answer affects both B2's design doc and how
 aggressively §3 of the paper can lean on "principled Bayesian inference"
 language.
 
+> **Resolved (2026-05-31): (b-NB) Gaussian Naive Bayes on embeddings
+> with a Dirichlet class prior.** The B2a design doc
+> (`docs/paper1/move-2-design.md` §3.1) verifies this reduces to
+> existing credence primitives — per-(class, dim) NormalGamma conjugate
+> updates plus a Dirichlet class prior, Student-t marginal predictive —
+> with no new primitives. The Pólya-Gamma multinomial-logistic path
+> (b-PG, §3.2) is rejected: it needs a Pólya-Gamma augmentation
+> primitive that does not exist and is out of scope for Paper 1. See
+> the classifier-naming addendum below — "Naive Bayes", not
+> "discriminative multinomial logistic".
+
 ### OQ3 — calibration set design
 
 Category inference is a perception model. It needs to be calibrated.
@@ -266,6 +284,13 @@ Where does the calibration data come from?
 (c) is most defensible if compute allows. The choice also bears on B2/B3
 coupling: if (c), B3's tools-only-slice questions need category labels
 ahead of B2's evaluation pass; if (a)/(b), the coupling is looser.
+
+> **Resolved (2026-05-31): (c) cross-validated leave-one-out.** Every
+> question receives a category inference from a classifier fit on all
+> *other* questions — no held-out set, cleanest fairness story.
+> Implemented as `loo_category_inference` (B2b.3). This couples B2/B3:
+> the tools-only slice's questions must carry category labels ahead of
+> B2's evaluation pass (B3 owns that).
 
 ### OQ4 — tools-only slice composition
 
@@ -290,6 +315,9 @@ slice's mean per-tool reliability must remain calibrated against the
 existing reliability matrix — generating a slice where every question
 favours one tool over-trivialises the comparison.
 
+> **Status: open — B3 territory.** Resolved when the tools-only slice
+> is designed. Not required for B2b.
+
 ### OQ5 — fairness equalisation specifics
 
 LLM prompts must receive equivalent category information to whatever the
@@ -313,6 +341,16 @@ Bayesian agent's posterior uses. What does this look like concretely?
 The author resolves. Be aware that OQ5's resolution determines what B4
 audits.
 
+> **Resolved (2026-05-31): soft category distribution.** Both agents
+> receive the full posterior `P(category=·)` per question, not a hard
+> label — the symmetric surface for VOI. The Bayesian agent's
+> *internal* use of that posterior is governed by modelling assumption
+> (γ) below (it collapses to MAP for its own conjugate updates), but
+> the information surface handed to every agent is identical and soft.
+> Per-tool reliability profiles are *not* exposed (the third
+> sub-option is too far — it removes the very uncertainty the paper is
+> about).
+
 ### OQ6 — slice integration: parallel evaluation track or unified benchmark?
 
 (Surfaced in B1 reading.) Two architectural shapes for B3's slice:
@@ -331,6 +369,9 @@ audits.
 
 Affects B3's deliverable and B5's Pareto-plot shape. The author resolves;
 (a) is probably cleanest unless the power calculation in OQ7 forces (b).
+
+> **Status: open — B3 territory.** Resolved alongside OQ4 when the
+> slice's integration shape is decided. Not required for B2b.
 
 ### OQ7 — statistical power for the Pareto-region claim
 
@@ -357,6 +398,51 @@ Pareto-region claim is unsupported.
 (c) is the rigorous version. (b) is the safe version. The choice depends
 on Guy's appetite for benchmarking compute and how high the bar is for
 the Pareto-membership claim to be defensible.
+
+> **Resolved (2026-05-31): N = 100 paired seeds for cheap agents,
+> N = 50 for LLM agents.** Narrows the CIs enough for the positional
+> Pareto-membership claim while keeping LLM API spend bounded. Recorded
+> here for the B4/B5 seed budget; *not* load-bearing for B2b. Revisit
+> against a pilot power calculation (option (c)) if the relevant
+> frontier comparison turns out to have a small effect.
+
+---
+
+## 4a. Phase B2b resolutions and addenda (2026-05-31)
+
+The B2b session (`paper1/category-inference`) resolves OQ1, OQ2, OQ3,
+OQ5, and OQ7 as recorded inline above, and adds three notes.
+
+**Classifier naming (paper-language correction).** The category-
+inference component implemented in B2b is **Gaussian Naive Bayes on
+sentence embeddings with a Dirichlet class prior** — a *generative*
+model — not a *discriminative* multinomial logistic. Paper language
+(and `credence.tex` §3.3, when written) must describe it as such. This
+rename rides along with the Phase D rewrite of `credence.tex`; nothing
+currently on master mis-names it.
+
+**Modelling assumption (γ) — MAP category for the Bayesian agent's
+updates.** The Bayesian agent uses **MAP category assignment** from the
+LOO classifier for both decision-time tool selection
+(`rel_betas[:, argmax_c]`) and outcome-time reliability updates.
+Posterior-weighted reliability updates would require a *weighted
+conjugate update* substrate extension (fractional Beta pseudocounts),
+which `src/conjugate.jl` does not support — its Beta-Bernoulli `update`
+coerces evidence to unit pseudocounts and errors on fractional
+observations. That extension is out of scope for Paper 1 and is
+reserved for Paper 3 / a future Posture move. Crucially, **both agents
+receive the identical soft posterior** (OQ5); the MAP-collapse is
+internal to the Bayesian agent's reasoning, not an asymmetry in the
+information surface.
+
+**B2b execution split.** B2b lands as a split: **B2b.1–B2b.3**
+(this master-plan addendum, the `category_inference` module, and LOO
+calibration) ship in PR `paper1/category-inference`; **B2b.4–B2b.6**
+(host + `llm_agent` wiring — "B2c") follow in a separate PR. The split
+point is forced by the embedding gate: everything past B2b.3 needs real
+question-bank embeddings, which the B2a design doc (§5) defers to a
+later step, and which collide with the no-`sentence-transformers`
+dependency constraint. B2b ships and tests on synthetic embeddings.
 
 ---
 

--- a/docs/paper1/master-plan.md
+++ b/docs/paper1/master-plan.md
@@ -344,9 +344,10 @@ audits.
 > **Resolved (2026-05-31): soft category distribution.** Both agents
 > receive the full posterior `P(category=·)` per question, not a hard
 > label — the symmetric surface for VOI. The Bayesian agent's
-> *internal* use of that posterior is governed by modelling assumption
-> (γ) below (it collapses to MAP for its own conjugate updates), but
-> the information surface handed to every agent is identical and soft.
+> *internal* use of that posterior is governed by the reliability-update
+> note below (it conditions exactly under category uncertainty — the
+> full posterior, not a MAP collapse), and the information surface
+> handed to every agent is identical and soft.
 > Per-tool reliability profiles are *not* exposed (the third
 > sub-option is too far — it removes the very uncertainty the paper is
 > about).
@@ -421,19 +422,30 @@ model — not a *discriminative* multinomial logistic. Paper language
 rename rides along with the Phase D rewrite of `credence.tex`; nothing
 currently on master mis-names it.
 
-**Modelling assumption (γ) — MAP category for the Bayesian agent's
-updates.** The Bayesian agent uses **MAP category assignment** from the
-LOO classifier for both decision-time tool selection
-(`rel_betas[:, argmax_c]`) and outcome-time reliability updates.
-Posterior-weighted reliability updates would require a *weighted
-conjugate update* substrate extension (fractional Beta pseudocounts),
-which `src/conjugate.jl` does not support — its Beta-Bernoulli `update`
-coerces evidence to unit pseudocounts and errors on fractional
-observations. That extension is out of scope for Paper 1 and is
-reserved for Paper 3 / a future Posture move. Crucially, **both agents
-receive the identical soft posterior** (OQ5); the MAP-collapse is
-internal to the Bayesian agent's reasoning, not an asymmetry in the
-information surface.
+**Reliability updates under category uncertainty — exact conditioning,
+not MAP (revised 2026-05-31).** An earlier draft of this section proposed
+collapsing the category posterior to its MAP value for the Bayesian
+agent's reliability updates, on the grounds that `src/conjugate.jl`'s
+Beta-Bernoulli `update` coerces evidence to unit pseudocounts. That is
+**rejected**: MAP discards information the agent has paid for (cf.
+`feedback_no_discard_posterior_info`) and weakens the paper's
+principled-Bayesian claim — the substrate limitation is a reason to
+extend the substrate, not to approximate. From first principles
+(A3: learning is conditioning; Invariant 1: only `condition` changes
+weights, and uncertainty is encoded in the hypothesis space so
+`condition` can learn it), the agent carries the category uncertainty in
+the reliability hypothesis space and updates by **exact conditioning**.
+The soft posterior π enters **both** the decision (VOI marginalised over
+categories) and the update. The exact posterior is a mixture
+(`P(correct|θ)=Σ_c π_c θ_{t,c}` against a product-of-Betas prior is
+non-conjugate → a K-way split per observation); its growth is a
+*computational* cost handled by **metacomputation** (EU over
+computational strategies — the spec's "On metareasoning"), not by a
+bolted-on approximation. The mechanism, the substrate extension it needs,
+and the depth of the metacomputation for Paper 1 are specified in the B2c
+design doc (`docs/paper1/move-2c-design.md`). Both agents still receive
+the identical soft posterior (OQ5); the agent's exact internal update is
+not an asymmetry in the information surface.
 
 **B2b execution split.** B2b lands as a split: **B2b.1–B2b.3**
 (this master-plan addendum, the `category_inference` module, and LOO

--- a/docs/paper1/move-2c-design.md
+++ b/docs/paper1/move-2c-design.md
@@ -1,0 +1,233 @@
+# Move B2c design doc — reliability learning under inferred category uncertainty
+
+Status: design doc (code deferred until the open questions in §5 resolve).
+Supersedes the rejected (γ) MAP assumption (master-plan §4a, corrected
+2026-05-31).
+
+## 1. Purpose
+
+B2c wires the B2b category classifier (`apps/julia/qa_benchmark/
+category_inference.jl`) into the agent under the Phase-B "fair
+conditions": the category is **inferred, not given**, and every agent
+sees the *same* soft posterior π. The Bayesian agent then both **decides**
+(VOI/EU) and **learns** (reliability update) under that category
+uncertainty. The load-bearing decision this doc settles is *how the
+reliability update is performed* — and from first principles it is
+**exact Bayesian conditioning**, not the MAP collapse an earlier draft
+proposed. Once settled, B2c unblocks B3 (tools-only slice) and B4
+(fairness-equalised prompting + re-run).
+
+Scope refinement vs the master plan: the master plan's B2/B4 wired a
+*given* category (`rel_betas[t, cat_idx]`). B2c replaces that index with
+the inferred posterior π entering **both** decision and update. Real
+question-bank embeddings remain gated (master plan §5); B2c specifies and
+tests the mechanism on synthetic embeddings/posteriors, and the real-
+embedding wiring lands with B3/B4.
+
+## 2. The model, from first principles
+
+Per A1–A3 and Invariant 1 (uncertainty is encoded in the hypothesis
+space so `condition` can learn it):
+
+- Reliability hypothesis: `θ_{t,c}` = P(tool t correct | true category c),
+  one Beta per (tool, category) — the existing `rel_betas[t, c]`.
+- Per question q the true category `C_q` is latent; the classifier
+  supplies the soft posterior `π_q = P(C_q = · | embedding_q)` (frozen,
+  from the LOO classifier — it is *evidence*, not a belief that the tool
+  outcomes update).
+- Observation: outcome `o ∈ {correct, wrong}` for tool t on q, with
+  `P(o = correct | θ, C_q = c) = θ_{t,c}`. Marginalising the latent
+  category: `P(correct | θ) = Σ_c π_{q,c} · θ_{t,c}`.
+
+The **decision side** wants the category-marginalised reliability
+belief: a `MixturePrevision([Beta(θ_{t,c}) for c], log π_q)` fed into
+`eu`/`voi`/`expect`. This is exact and needs no approximation — it
+replaces the `rel_betas[t, cat_idx]` argument at the decision sites.
+
+The **update side** is `condition` against the likelihood
+`Σ_c π_{q,c} θ_{t,c}`. Because that likelihood is a *sum* over c, it is
+not conjugate to a product of independent Betas: each observation splits
+the belief into a K-component mixture (one component per category, with
+that category's Beta incremented), so the exact posterior after `n`
+observations of tool t is a mixture of up to `K^n` product-of-Betas
+components. **This is the exact posterior** — `condition` produces it.
+
+## 3. Tractability is metacomputation, not a bolted-on approximation
+
+`K^n` growth is a *computational cost*, and per the spec's "On
+metareasoning" the choice of how much to compute is itself an EU decision
+made by the same reasoner — not an escape hatch from Invariant 1. The
+computational-strategy space for the reliability posterior:
+
+| Strategy | What it keeps | Cost | Exactness |
+|---|---|---|---|
+| **Exact** | all `K^n` components | unbounded | exact |
+| **Pruned** | top-`m` components by weight (`prune`/`truncate`, `ontology.jl:1471`) | `O(m·K)` / obs | exact-up-to-tail-mass |
+| **ADF-collapse** | project to one product-of-Betas each step (assumed-density filtering) | `O(K)` / obs | mean-field |
+
+The **fractional-pseudocount** update — `α_{t,c} += π_c·[correct]`,
+`β_{t,c} += π_c·[wrong]` — is the ADF-collapse special case (the moment-
+matched projection back to independent Betas; it is *not* "prune to one
+component", which would be MAP-like). All three are computational
+strategies the metacomputation can select by EU; none is hard-coded.
+This keeps the whole spectrum *inside* Invariant 1: the Julia execution
+layer implements the strategies (mixture `condition` + `prune`/`truncate`,
+or a fractional-evidence conjugate update), and the DSL specifies the EU
+choice among them — exactly the metareasoning posture the constitution
+already mandates.
+
+## 4. Files touched (B2c code; deferred until §5 resolves)
+
+- `src/kernels.jl:19` — **(conditional on §5 OQ1)** add a
+  `WeightedBernoulli <: LeafFamily` (carries no params; the weight rides
+  on the observation) for the ADF-collapse fast path. *New type.*
+- `src/conjugate.jl:21` — register `maybe_conjugate`/`update` for
+  `(BetaPrevision, WeightedBernoulli)`: `α += w·o, β += w·(1-o)` with
+  fractional `w`. Sits beside the existing unit-count BetaBernoulli; does
+  not modify it. *Modification.*
+- `apps/julia/qa_benchmark/host.jl` — decision sites (`:66, 84, 113,
+  134`) build the category-marginalised `MixturePrevision` over π and
+  pass it where `rel_betas[t, cat_idx]` is passed today; update site
+  (`:177`) conditions under category uncertainty (mixture or
+  fractional). The given-category read `cat_idx = findfirst(==(q.category)
+  …)` (`:58`) is replaced by the classifier's soft posterior. *Modification.*
+- `apps/julia/qa_benchmark/agent.bdsl` — **(conditional on §5 OQ3)** the
+  answer-kernel/reliability-kernel consume the marginalised reliability;
+  likely no change if the host owns the `MixturePrevision` construction.
+- `test/test_qa_benchmark_category_update.jl` — reliability-update tests.
+  *New file.*
+
+The real-embedding wiring (`environment.jl` question-bank embeddings) is
+**not** in B2c — it lands with B3/B4 per the embedding gate.
+
+## 5. Behaviour preserved
+
+B2c deliberately *changes* the v1 benchmark numbers (inferred category,
+soft update); it does not preserve them. What it must preserve is the
+**degenerate reduction**: when π is one-hot (`π_c = 1` for the true c),
+both decision and update must reduce *exactly* to today's code.
+
+- Decision: a one-hot `MixturePrevision` over π equals `rel_betas[t, c]`
+  (single component) — assert `==` on `mean`/`weights`.
+- Update: the soft update on one-hot π equals the current
+  `condition(rel_betas[t,c], RELIABILITY_KERNEL, o)` unit-count update —
+  assert `==` on `(α, β)`.
+
+Tolerances: degenerate-reduction `==` (integer pseudocounts); fractional
+arithmetic `rtol = 1e-12`; exact-mixture worked example `==` on the
+closed-form weights/parameters in §6.
+
+Capture-canonical discipline: capture the current host's
+`(α, β)` sequence for a fixed seed *before* the change; assert `==`
+on the one-hot path post-change (per `feedback_capture_canonical_before_
+refactor`).
+
+## 6. Worked end-to-end example
+
+Two categories, `π = [0.7, 0.3]`, tool t, `rel_betas[t,1] = Beta(2,3)`,
+`rel_betas[t,2] = Beta(1,1)`; observe **correct**.
+
+**Exact (mixture `condition`).** Prior is the single product
+`Beta(θ₁;2,3)·Beta(θ₂;1,1)` (weight 1). Likelihood `0.7·θ₁ + 0.3·θ₂`:
+
+```
+posterior ∝ 0.7·[θ₁·Beta(θ₁;2,3)]·Beta(θ₂;1,1)
+          + 0.3·Beta(θ₁;2,3)·[θ₂·Beta(θ₂;1,1)]
+```
+
+Using `θ·Beta(θ;α,β) = (α/(α+β))·Beta(θ;α+1,β)`:
+`θ₁·Beta(θ₁;2,3) = 0.4·Beta(θ₁;3,3)`, `θ₂·Beta(θ₂;1,1) = 0.5·Beta(θ₂;2,1)`.
+
+```
+∝ 0.28·[Beta(3,3)·Beta(1,1)]  +  0.15·[Beta(2,3)·Beta(2,1)]
+```
+
+→ a **2-component mixture**, normalised weights `0.28/0.43 = 0.651` and
+`0.15/0.43 = 0.349`. Owner: `condition(::MixturePrevision, k, obs)`
+(`ontology.jl:1121`) with the `Σ_c π_c θ_{t,c}` kernel; the per-component
+Beta increments are the existing conjugate path.
+
+**ADF-collapse (fractional pseudocounts).** Update each independently:
+`rel[1] → Beta(2.7, 3)`, `rel[2] → Beta(1.3, 1)`. Single product
+component. Owner: `condition(::BetaPrevision, WeightedBernoulli kernel,
+(o, π_c))` → `update` in `conjugate.jl`. The marginal `E[θ₁]`: exact
+mixture `0.651·(3/6) + 0.349·(2/5) = 0.465` vs ADF `2.7/5.7 = 0.474` —
+close, not equal: the mean-field discrepancy made explicit.
+
+**Degenerate check (`π = [1,0]`).** Exact: likelihood `θ₁`, posterior is
+the single component `Beta(3,3)·Beta(1,1)`. ADF: `rel[1] → Beta(3,3)`,
+`rel[2] → Beta(1,1)`. Both equal today's unit-count update
+`Beta(2,3) --correct--> Beta(3,3)`. `==`.
+
+## 7. Open design questions
+
+1. **Is the strategy spectrum (exact / pruned / ADF) one mechanism under
+   metacomputation, or do we ship a single fixed strategy for Paper 1?**
+   Framing all three as EU-selected computational strategies is the
+   constitution-pure answer, but it requires a cost model in the utility.
+   The alternative is to implement *one* strategy now (recommended:
+   start from exact mixture + a retention cap, with ADF as the cap=1
+   degenerate) and defer the EU-over-strategies selector. Argue whether
+   Paper 1 needs the full metacomputation or a named, fixed default.
+
+2. **Default strategy + retention budget.** If a fixed default: exact
+   mixture with top-`m` pruning (what `m`? chosen how — fixed, or a
+   tail-mass threshold via `prune`'s `threshold`?), or ADF-collapse
+   (tractable, on the conjugate fast path, but mean-field)? The
+   Performance-Problems protocol governs: if a 50-question run with the
+   exact/pruned path exceeds a wall-clock budget, **halt and report** —
+   do not silently downgrade to ADF.
+
+3. **Residency of the decision-side marginalisation.** Does the host
+   build the `MixturePrevision` over π and pass it (bdsl unchanged — D3
+   stays true), or does `agent.bdsl` take π and the per-category Betas
+   and marginalise? Invariant 2 says the `MixturePrevision` is the
+   declared structure; recommendation is host-builds, bdsl-consumes, but
+   confirm against the answer-kernel's current signature.
+
+4. **Substrate-change discipline for `WeightedBernoulli`.** Adding a
+   `LeafFamily` + conjugate pair is sanctioned vocabulary growth
+   (constitution: "named distributions … may be added"), but it touches
+   `src/`. Does it ride in the B2c code PR, or land as its own
+   substrate PR first (capture-canonical, stratum-2 conjugate test)
+   ahead of the host wiring? This is the one place the B2b "no new
+   `LeafFamily`/`ConjugatePrevision`" refusal is lifted — that refusal
+   lived under the now-reversed MAP regime.
+
+## 8. Risk + mitigation
+
+- **Mixture explosion** (`K^n`). Blast radius: a benchmark run hangs/OOMs.
+  Mitigation: the metacomputation/retention strategy of §3 + a wall-clock
+  budget on the 50-question run; per Performance-Problems, exceeding it
+  **halts and reports** rather than silently collapsing to ADF.
+- **Degenerate regression.** The soft path must reduce to v1 on one-hot
+  π. Mitigation: capture-canonical `(α,β)` sequence pre-change; assert
+  `==` (§5).
+- **Invariant 1 (topological).** The fractional update must be a
+  *registered* `condition`/`update`, never host arithmetic on weights.
+  Mitigation: `WeightedBernoulli` goes through `maybe_conjugate`; lint
+  `check apps/`; no `rel_betas[...].alpha += …` anywhere host-side.
+- **Grep step (pre-PR).** `grep -rn 'rel_betas\|cat_idx\|q.category'`
+  across `apps/julia/qa_benchmark/` and list each hit's disposition
+  (decision-site marginalisation / update-site soft-condition / replaced
+  by classifier posterior / no change).
+- **Fairness asymmetry.** Both agents must receive the *identical* soft
+  posterior; the LLM prompt surface (B4) must mirror it. Mitigation: the
+  B4 symmetry audit; out of scope here but named.
+
+## 9. Verification cadence
+
+At end of the B2c **code** PR (not this design PR):
+
+- `julia test/test_qa_benchmark_category_update.jl` — degenerate-equals-v1
+  (`==`), fractional arithmetic (`rtol 1e-12`), exact-mixture worked
+  example weights (`==`), determinism.
+- `julia test/test_qa_benchmark_category_inference.jl` — B2b, must stay
+  green (unaffected).
+- If the substrate change lands here: the stratum-2 conjugate test for
+  `(BetaPrevision, WeightedBernoulli)` (`_dispatch_path === :conjugate`
+  before value).
+- `python tools/credence-lint/credence_lint.py check apps/` — clean.
+- Halt-the-line: any red suite halts; no "fix in next commit".
+
+This design PR itself is docs-only — no test/lint impact.

--- a/docs/paper1/move-2c-design.md
+++ b/docs/paper1/move-2c-design.md
@@ -159,40 +159,52 @@ the single component `Beta(3,3)·Beta(1,1)`. ADF: `rel[1] → Beta(3,3)`,
 `rel[2] → Beta(1,1)`. Both equal today's unit-count update
 `Beta(2,3) --correct--> Beta(3,3)`. `==`.
 
-## 7. Open design questions
+## 7. Resolved decisions (was: open questions)
 
-1. **Is the strategy spectrum (exact / pruned / ADF) one mechanism under
-   metacomputation, or do we ship a single fixed strategy for Paper 1?**
-   Framing all three as EU-selected computational strategies is the
-   constitution-pure answer, but it requires a cost model in the utility.
-   The alternative is to implement *one* strategy now (recommended:
-   start from exact mixture + a retention cap, with ADF as the cap=1
-   degenerate) and defer the EU-over-strategies selector. Argue whether
-   Paper 1 needs the full metacomputation or a named, fixed default.
+The author resolved these with one observation: **Paper 1 is a utility/EU
+paper anyway.** The agent already trades *tool cost* against *information
+value* (that is what VOI is); trading *compute cost* against *inference
+value* — metacomputation — is the identical move, native to the paper.
+The metacomputation's *conclusion* settles the mechanism, because exact
+mixture retention costs `K^n` compute for a third-decimal accuracy gain
+(§6: `E[θ]` 0.465 exact vs 0.474 weighted).
 
-2. **Default strategy + retention budget.** If a fixed default: exact
-   mixture with top-`m` pruning (what `m`? chosen how — fixed, or a
-   tail-mass threshold via `prune`'s `threshold`?), or ADF-collapse
-   (tractable, on the conjugate fast path, but mean-field)? The
-   Performance-Problems protocol governs: if a 50-question run with the
-   exact/pruned path exceeds a wall-clock budget, **halt and report** —
-   do not silently downgrade to ADF.
+1. **One principle, not a spectrum to ship.** The strategy is the
+   resource-rational realisation of the exact mixture: the **full-
+   posterior-weighted (ADF / expected-sufficient-statistics) update**.
+   The exact mixture is the documented *reference*, not the runtime path.
+   We do **not** build an EU-over-strategies selector loop (that needs
+   compute as an explicit utility term — a Paper 4 / cheap-design
+   extension); the resource-rational justification is prose.
 
-3. **Residency of the decision-side marginalisation.** Does the host
-   build the `MixturePrevision` over π and pass it (bdsl unchanged — D3
-   stays true), or does `agent.bdsl` take π and the per-category Betas
-   and marginalise? Invariant 2 says the `MixturePrevision` is the
-   declared structure; recommendation is host-builds, bdsl-consumes, but
-   confirm against the answer-kernel's current signature.
+2. **No retention budget / no pruning machinery.** The weighted update is
+   the cap→single-component projection; there is no top-`m` to choose. A
+   test validates weighted ≈ exact-mixture on the §6 case (so the
+   negligible-loss claim is empirical, not asserted). The exact-mixture
+   `MixturePrevision` reliability state is *not* implemented as runtime
+   (it explodes by construction).
 
-4. **Substrate-change discipline for `WeightedBernoulli`.** Adding a
-   `LeafFamily` + conjugate pair is sanctioned vocabulary growth
-   (constitution: "named distributions … may be added"), but it touches
-   `src/`. Does it ride in the B2c code PR, or land as its own
-   substrate PR first (capture-canonical, stratum-2 conjugate test)
-   ahead of the host wiring? This is the one place the B2b "no new
-   `LeafFamily`/`ConjugatePrevision`" refusal is lifted — that refusal
-   lived under the now-reversed MAP regime.
+3. **Residency: host builds, bdsl consumes.** The host constructs the
+   category-marginalised `MixturePrevision` over π for the decision side
+   and runs the `WeightedBernoulli` `condition`s for the update side. The
+   `MixturePrevision` is the declared structure (Invariant 2). `agent.bdsl`
+   changes only if the reliability kernel must *declare* the new family —
+   verified at implementation (the kernel is constructed Julia-side, so
+   D3 likely holds).
+
+4. **Substrate (`WeightedBernoulli`) lands with the B2c mechanism PR.**
+   A new `LeafFamily` + conjugate pair is sanctioned vocabulary growth
+   ("named distributions … may be added"); it ships with a stratum-2
+   conjugate test and the degenerate `==` capture-canonical guard (§5),
+   and does **not** touch the strict unit-count `BetaBernoulli`. This is
+   where the B2b "no new `LeafFamily`/`ConjugatePrevision`" refusal is
+   lifted — that refusal lived under the now-reversed MAP regime.
+
+**One residual genuine open question** (for the B2c *code* review, not a
+blocker now): on the decision side, is the answer-kernel's `expect` over
+a `MixturePrevision` of Betas numerically identical to the current
+`expect` over a single Beta when π is one-hot? Must be asserted `==`, not
+assumed — confirm the mixture-of-one-component path collapses exactly.
 
 ## 8. Risk + mitigation
 

--- a/papers/NOTES.md
+++ b/papers/NOTES.md
@@ -191,18 +191,20 @@ this resolved — but should be in place before Phase D (paper rewrite).
 
 ### Phase B scope and out-of-scope
 
-**Modelling assumption (γ), recorded for the write-up (B2b, 2026-05-31).**
-The category-inference component (B2) is **Gaussian Naive Bayes on
-sentence embeddings with a Dirichlet class prior** — a generative model,
-not a discriminative multinomial logistic; describe it as such in §3.
-Both agents receive the *identical soft category posterior*. The
-Bayesian agent then uses **MAP category assignment** internally, for
-both decision-time tool selection and outcome-time reliability updates.
-Posterior-weighted reliability updates would need a weighted-conjugate-
-update substrate extension (fractional Beta pseudocounts) that the DSL
-does not have and that is reserved for Paper 3; the MAP collapse is
-internal to the Bayesian agent's reasoning, not an asymmetry in the
-shared information surface. See `docs/paper1/master-plan.md` §4a.
+**Modelling notes for the write-up (B2b, 2026-05-31; revised).** The
+category-inference component (B2) is **Gaussian Naive Bayes on sentence
+embeddings with a Dirichlet class prior** — a generative model, not a
+discriminative multinomial logistic; describe it as such in §3. Both
+agents receive the *identical soft category posterior*. The Bayesian
+agent then updates tool reliability by **exact conditioning under
+category uncertainty** — the full posterior enters both the decision
+(VOI marginalised over categories) and the update — **not** a MAP
+collapse (an earlier draft proposed MAP; rejected, since it discards
+information the agent paid for and weakens the principled-Bayesian
+claim). The exact posterior is a mixture; its growth is handled by
+metacomputation (EU over computational strategies), per the spec's "On
+metareasoning". Mechanism + substrate extension in the B2c design doc
+(`docs/paper1/move-2c-design.md`); see also `master-plan.md` §4a.
 
 In scope (this branch):
 - Category inference (B2)

--- a/papers/NOTES.md
+++ b/papers/NOTES.md
@@ -191,6 +191,19 @@ this resolved — but should be in place before Phase D (paper rewrite).
 
 ### Phase B scope and out-of-scope
 
+**Modelling assumption (γ), recorded for the write-up (B2b, 2026-05-31).**
+The category-inference component (B2) is **Gaussian Naive Bayes on
+sentence embeddings with a Dirichlet class prior** — a generative model,
+not a discriminative multinomial logistic; describe it as such in §3.
+Both agents receive the *identical soft category posterior*. The
+Bayesian agent then uses **MAP category assignment** internally, for
+both decision-time tool selection and outcome-time reliability updates.
+Posterior-weighted reliability updates would need a weighted-conjugate-
+update substrate extension (fractional Beta pseudocounts) that the DSL
+does not have and that is reserved for Paper 3; the MAP collapse is
+internal to the Bayesian agent's reasoning, not an asymmetry in the
+shared information surface. See `docs/paper1/master-plan.md` §4a.
+
 In scope (this branch):
 - Category inference (B2)
 - Tools-only slice (B3)

--- a/papers/NOTES.md
+++ b/papers/NOTES.md
@@ -203,8 +203,12 @@ collapse (an earlier draft proposed MAP; rejected, since it discards
 information the agent paid for and weakens the principled-Bayesian
 claim). The exact posterior is a mixture; its growth is handled by
 metacomputation (EU over computational strategies), per the spec's "On
-metareasoning". Mechanism + substrate extension in the B2c design doc
-(`docs/paper1/move-2c-design.md`); see also `master-plan.md` §4a.
+metareasoning". **Resolved:** the runtime update is the full-posterior-
+weighted (resource-rational) one — credit each category by π_c via a new
+`WeightedBernoulli` conjugate family — which uses the whole posterior and
+tracks the exact mixture to third-decimal accuracy. Mechanism + substrate
+in the B2c design doc (`docs/paper1/move-2c-design.md`); see also
+`master-plan.md` §4a.
 
 In scope (this branch):
 - Category inference (B2)

--- a/test/test_qa_benchmark_category_inference.jl
+++ b/test/test_qa_benchmark_category_inference.jl
@@ -56,6 +56,12 @@ end
 
 argmax_cat(post::Dict{Symbol,Float64}) = findmax(post)[2]
 
+function loo_accuracy(X::Matrix{Float64}, y::Vector{Symbol})
+    posts = loo_category_inference(X, y)
+    correct = count(i -> argmax_cat(posts[i]) == y[i], eachindex(y))
+    correct / length(y)
+end
+
 println("="^60)
 println("Paper 1 B2b — Gaussian-NB category inference")
 println("="^60)
@@ -132,6 +138,44 @@ let
           length(post) == 1, "len=$(length(post))")
 end
 
+# ── Test 6: LOO accuracy beats chance by a clear margin (B2b.3) ──
+# No magic threshold tied to the generator: substantially-better-than-
+# chance with a 0.2 margin (author Correction 2).
+let
+    cats = [:alpha, :beta, :gamma]
+    K = length(cats)
+    X, y = synth_dataset(cats, 8; sep=3.0, noise=1.0, noise_seed=77)
+    acc = loo_accuracy(X, y)
+    check("LOO accuracy beats chance by ≥0.2 on separated data",
+          acc > 1.0 / K + 0.2, "acc=$acc, threshold=$(1.0 / K + 0.2)")
+end
+
+# ── Test 7: direction-only — separated beats overlapping (B2b.3) ──
+# The stronger calibration test: no hardcoded threshold, only that more
+# separable classes are easier to recover under LOO.
+let
+    cats = [:alpha, :beta, :gamma]
+    Xsep, ysep = synth_dataset(cats, 8; sep=3.0, noise=1.0, noise_seed=77)
+    Xov,  yov  = synth_dataset(cats, 8; sep=0.5, noise=2.0, noise_seed=77)
+    acc_sep = loo_accuracy(Xsep, ysep)
+    acc_ov  = loo_accuracy(Xov,  yov)
+    check("LOO accuracy: separated > overlapping",
+          acc_sep > acc_ov, "separated=$acc_sep, overlapping=$acc_ov")
+end
+
+# ── Test 8: LOO output structure (B2b.3) ──
+let
+    cats = [:alpha, :beta, :gamma]
+    X, y = synth_dataset(cats, 5; noise_seed=3)
+    N = length(y)
+    posts = loo_category_inference(X, y)
+    check("LOO output has length N", length(posts) == N, "len=$(length(posts))")
+    check("each LOO entry carries all categories",
+          all(p -> Set(keys(p)) == Set(cats), posts))
+    check("each LOO entry sums to 1.0 (atol 1e-10)",
+          all(p -> abs(sum(values(p)) - 1.0) < 1e-10, posts))
+end
+
 println("="^60)
-println("ALL $(_PASS[]) CHECKS PASSED (B2b.2)")
+println("ALL $(_PASS[]) CHECKS PASSED (B2b.2 + B2b.3)")
 println("="^60)

--- a/test/test_qa_benchmark_category_inference.jl
+++ b/test/test_qa_benchmark_category_inference.jl
@@ -1,0 +1,137 @@
+# test_qa_benchmark_category_inference.jl — Paper 1, Phase B2b.
+#
+# Tests the body-side Gaussian Naive Bayes category classifier
+# (`apps/julia/qa_benchmark/category_inference.jl`). Provenance:
+# `docs/paper1/move-2-design.md` §3.1 (the (b-NB) reduction) and
+# `docs/paper1/master-plan.md` §4a (OQ1(c)/OQ2(b-NB)/OQ3(c)/OQ5 + the
+# (γ) assumption).
+#
+# Tripwire discipline (mirrors test/test_prevision_conjugate.jl): the
+# conjugate dispatch path is asserted BEFORE the value assertions. A
+# silent registry miss — NormalGamma or Dirichlet calibration falling
+# through to the particle fallback instead of the conjugate update —
+# would otherwise pass the value assertion for the wrong reason.
+#
+# Run from the repo root:
+#     julia test/test_qa_benchmark_category_inference.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: DirichletPrevision, NormalGammaPrevision, _dispatch_path
+using Random
+
+include(joinpath(@__DIR__, "..", "apps", "julia", "qa_benchmark", "category_inference.jl"))
+
+const _PASS = Ref(0)
+function check(name, cond, detail="")
+    if cond
+        _PASS[] += 1
+        println("PASSED: $name")
+    else
+        println("FAILED: $name — $detail")
+        error("category_inference assertion failed: $name")
+    end
+end
+
+# Synthetic well-separated categories: fixed class means under means_seed
+# (shared across train/test draws); per-point Gaussian noise under
+# noise_seed. Mirrors the (b-NB) prototype's data model.
+function synth_dataset(cats::Vector{Symbol}, n_per_cat::Int;
+                       D::Int=8, sep::Float64=3.0, noise::Float64=1.0,
+                       means_seed::Int=7, noise_seed::Int=42)
+    mrng = MersenneTwister(means_seed)
+    means = [sep .* randn(mrng, D) for _ in cats]
+    nrng = MersenneTwister(noise_seed)
+    N = length(cats) * n_per_cat
+    X = Matrix{Float64}(undef, N, D)
+    y = Vector{Symbol}(undef, N)
+    i = 1
+    for (k, c) in enumerate(cats), _ in 1:n_per_cat
+        X[i, :] = means[k] .+ noise .* randn(nrng, D)
+        y[i] = c
+        i += 1
+    end
+    X, y
+end
+
+argmax_cat(post::Dict{Symbol,Float64}) = findmax(post)[2]
+
+println("="^60)
+println("Paper 1 B2b — Gaussian-NB category inference")
+println("="^60)
+
+# ── Test 1: fit-and-infer roundtrip on well-separated data ──
+let
+    cats = [:alpha, :beta, :gamma]
+    Xtr, ytr = synth_dataset(cats, 8; noise_seed=42)
+    Xte, yte = synth_dataset(cats, 4; noise_seed=123)   # same means, fresh noise
+    clf = fit(Xtr, ytr)
+
+    # Tripwire FIRST: the calibration kernels must hit the conjugate path.
+    check("NormalGamma calibration → :conjugate",
+          _dispatch_path(NormalGammaPrevision(1.0, 0.0, 2.0, 2.0), SCALAR_OBS_KERNEL) === :conjugate,
+          "got $(_dispatch_path(NormalGammaPrevision(1.0, 0.0, 2.0, 2.0), SCALAR_OBS_KERNEL))")
+    check("Dirichlet calibration → :conjugate",
+          _dispatch_path(DirichletPrevision(ones(length(cats))), _class_obs_kernel(sort(unique(ytr)))) === :conjugate,
+          "got $(_dispatch_path(DirichletPrevision(ones(length(cats))), _class_obs_kernel(sort(unique(ytr)))))")
+
+    correct = 0
+    for i in 1:size(Xte, 1)
+        post = infer(clf, Xte[i, :])
+        argmax_cat(post) == yte[i] && (correct += 1)
+    end
+    check("fit/infer recovers ≥80% of held-out labels on separated data",
+          correct >= 0.8 * size(Xte, 1), "got $correct/$(size(Xte, 1))")
+end
+
+# ── Test 2: posterior normalises ──
+let
+    cats = [:alpha, :beta, :gamma]
+    Xtr, ytr = synth_dataset(cats, 6; noise_seed=11)
+    clf = fit(Xtr, ytr)
+    post = infer(clf, Xtr[1, :])
+    check("posterior sums to 1.0 (atol 1e-10)",
+          abs(sum(values(post)) - 1.0) < 1e-10, "sum=$(sum(values(post)))")
+    check("posterior has one entry per training category",
+          length(post) == length(cats), "len=$(length(post))")
+end
+
+# ── Test 3: determinism ──
+let
+    cats = [:alpha, :beta, :gamma]
+    Xtr, ytr = synth_dataset(cats, 6; noise_seed=11)
+    e = Xtr[1, :]
+    p1 = infer(fit(Xtr, ytr), e)
+    p2 = infer(fit(Xtr, ytr), e)
+    check("identical inputs → identical posteriors (Dict ==)", p1 == p2, "p1=$p1 p2=$p2")
+end
+
+# ── Test 4: empty training set raises a clear, specific error ──
+let
+    threw = false
+    msg = ""
+    try
+        fit(Matrix{Float64}(undef, 0, 8), Symbol[])
+    catch err
+        threw = true
+        msg = sprint(showerror, err)
+    end
+    check("fit on empty training set throws", threw)
+    check("empty-set error names the empty training set",
+          occursin("empty training set", msg), "msg=$msg")
+end
+
+# ── Test 5: single-class training data → degenerate-but-valid posterior ──
+let
+    X, y = synth_dataset([:only], 10; noise_seed=5)
+    clf = fit(X, y)
+    post = infer(clf, X[1, :])
+    check("single-class posterior P(only) = 1.0 (atol 1e-12)",
+          isapprox(post[:only], 1.0; atol=1e-12), "got $(post[:only])")
+    check("single-class posterior has exactly one category",
+          length(post) == 1, "len=$(length(post))")
+end
+
+println("="^60)
+println("ALL $(_PASS[]) CHECKS PASSED (B2b.2)")
+println("="^60)


### PR DESCRIPTION
Phase B2b (steps B2b.1–B2b.3) of Paper 1's category-inference work. Implements the body-side classifier that lets every agent see the same *inferred* (not given) category information — the load-bearing fairness module for the Phase B thesis. Design doc: `docs/paper1/move-2-design.md`.

**Lands as a split** (decided in conversation, master-plan §4a): this PR is B2b.1–B2b.3; the agent wiring (B2b.4–B2b.6, "B2c": `host.jl` slicing `rel_betas[:, argmax_c]` and `llm_agent.jl` category surface) follows in a separate PR. The split point is forced by the embedding gate — everything past B2b.3 needs real question-bank embeddings, deferred per the design doc and the no-`sentence-transformers` constraint, so this ships and tests on synthetic embeddings.

### Commits
1. **`0f72c2e` master-plan addenda** — resolve OQ1(c) body-side, OQ2(b-NB) Gaussian Naive Bayes, OQ3(c) leave-one-out, OQ5 soft posterior, OQ7 seed budget; OQ4/OQ6 remain open (B3). Adds §4a: classifier-naming correction (Naive Bayes, not discriminative multinomial logistic), modelling assumption (γ) (the Bayesian agent uses MAP category internally because the DSL has no weighted conjugate update — both agents still get the identical soft posterior), and the split note. Mirrors (γ) into `papers/NOTES.md`.
2. **`8be08f1` category_inference module** — `CategoryClassifier` (Prevision-internal: `DirichletPrevision` + K×D `Matrix{NormalGammaPrevision}`), `fit`, `infer`. Calibration rides the existing conjugate fast paths (NormalGamma + Dirichlet) — no new `LikelihoodFamily`/`ConjugatePrevision` entries. Inference `condition`s a `CategoricalMeasure` through a naive-Bayes kernel; class predictive via the sanctioned `log_predictive` accessor; Student-t predictive via `SpecialFunctions.lgamma` (existing dep). 5 tests / 10 checks, with conjugate-dispatch tripwires.
3. **`f7bd2ba` LOO calibration** — `loo_category_inference`. 3 more tests (acc > 1/K + 0.2; separated > overlapping; output structure). 8 tests / 15 checks total.

### Verification
- `julia test/test_qa_benchmark_category_inference.jl` → **ALL 15 CHECKS PASSED**.
- Lint clean (`check apps/`: 176 files, 0 violations; corpus self-test green).
- Prototype regression re-run: 25/25.
- Performance: exact inference; synthetic N=100/D=384 LOO runs in 0.79s (under the 5s guard).

Julia tests are not CI-gated in this repo; run the test file locally. Requesting review.