### PR TITLE
credence-pi: pin HTTP to ~1.11 to fix serve! stream= drift on CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+HTTP = "~1.11"
 LibPQ = "1.18.0"
 SpecialFunctions = "2.7.2"
 julia = "1.9"

--- a/apps/credence-pi/daemon/server.jl
+++ b/apps/credence-pi/daemon/server.jl
@@ -423,6 +423,9 @@ function start_daemon(; port::Int,
         end
     end
 
+    # `dispatch` is a streaming handler (takes an HTTP.Stream). The
+    # `stream=true` kwarg requires HTTP 1.11.x; newer/older builds removed
+    # it, which is why HTTP is pinned to ~1.11 in Project.toml [compat].
     server = HTTP.serve!(dispatch, host, port; stream=true)
     (server, state)
 end


### PR DESCRIPTION
**Fixes the red CI on master** that blocks every PR (including #103 and #104).

### Root cause
HTTP is unpinned in `Project.toml`, so CI's `Pkg.instantiate()` resolved an HTTP build whose `serve!` dropped the `stream=true` keyword → `MethodError` in `apps/credence-pi/daemon/server.jl:start_daemon` (`test_server.jl:251`). Nothing in any open PR touches credence-pi or HTTP; it's pure version drift.

### Fix
Pin `HTTP = "~1.11"` in `[compat]`. `stream=true` is the correct streaming-handler call for HTTP 1.11.x (the handler takes an `HTTP.Stream`); the bare `serve!` form is *not* a fix — it dispatches the handler as a `Request` handler and 500s. So the drift is the bug, and pinning is the fix. `server.jl` is unchanged apart from an explanatory comment.

### Verification (local, `julia --project=.`)
All credence-pi Julia tests pass: `test_bdsl` 13, `test_bdsl_primitives` 14, `test_observation_log` 7, `test_server` 20 (incl. the HTTP POST /sensor and SSE /signals streaming assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)