### PR TITLE
[paper1] B2c: reliability learning under inferred category uncertainty (WeightedBernoulli)

### DIFF
--- a/apps/julia/qa_benchmark/category_update.jl
+++ b/apps/julia/qa_benchmark/category_update.jl
@@ -1,0 +1,69 @@
+# Role: brain-side application
+"""
+    category_update.jl — reliability learning under inferred category uncertainty.
+
+Paper 1, B2c (`docs/paper1/move-2c-design.md`). Tool reliability `θ_{t,c}`
+is per (tool, category). When a question's category is uncertain (soft
+posterior π from the classifier), both the decision and the update
+marginalise over π:
+
+- `marginal_reliability(row, π)` — the category-marginalised reliability
+  belief for the decision side: a `MixturePrevision` over the per-category
+  Betas weighted by π, fed to the existing `eu`/`voi`/`expect`.
+- `update_reliability(row, π, outcome)` — the resource-rational update:
+  credit *every* category by its posterior weight via the
+  `WeightedBernoulli` conjugate `condition`
+  (`α_{t,c} += π_c·correct, β_{t,c} += π_c·wrong`). Uses the whole
+  posterior (not MAP); reduces *exactly* to the unit-count update when π
+  is one-hot.
+
+`row` is a tool's reliability row `[θ_{t,c} for c]::Vector{BetaPrevision}`;
+`π` is the category posterior (same length). Pure functions — no embedding
+dependency; the host supplies π from the classifier (wired in B3/B4).
+"""
+
+using Credence
+using Credence: BetaPrevision
+
+# Reliability observation kernel declaring the fractional family. Source =
+# reliability ∈ [0,1]; target = the binary correctness outcome. The
+# conjugate path is registry-driven; generate/log_density are placeholders.
+const WEIGHTED_RELIABILITY_KERNEL = Kernel(
+    Interval(0.0, 1.0),
+    Finite([0, 1]),
+    r -> error("WEIGHTED_RELIABILITY_KERNEL.generate not exercised (conjugate path)"),
+    (r, o) -> 0.0;
+    likelihood_family = WeightedBernoulli(),
+)
+
+"""
+    update_reliability(row, π, outcome) -> Vector{BetaPrevision}
+
+Full-posterior-weighted reliability update. `outcome ∈ {0,1}` (1 = tool
+correct). Each category's Beta is conditioned on the same outcome with
+weight `π_c`, via `WeightedBernoulli`. One-hot π reduces exactly to the
+unit-count update.
+"""
+function update_reliability(row::Vector{BetaPrevision}, π::Vector{Float64}, outcome)
+    length(row) == length(π) ||
+        error("update_reliability: row length $(length(row)) ≠ π length $(length(π))")
+    o = Float64(outcome)
+    BetaPrevision[
+        condition(row[c], WEIGHTED_RELIABILITY_KERNEL, (o, π[c])) for c in eachindex(row)
+    ]
+end
+
+"""
+    marginal_reliability(row, π) -> MixturePrevision
+
+Category-marginalised reliability belief for the decision side: the
+mixture `Σ_c π_c · Beta(θ_{t,c})`. Zero-weight categories are dropped (a
+category with `π_c = 0` contributes nothing). Fed to `eu`/`voi`/`expect`.
+"""
+function marginal_reliability(row::Vector{BetaPrevision}, π::Vector{Float64})
+    length(row) == length(π) ||
+        error("marginal_reliability: row length $(length(row)) ≠ π length $(length(π))")
+    keep = π .> 0.0
+    any(keep) || error("marginal_reliability: π has no positive mass")
+    MixturePrevision(row[keep], log.(π[keep]))
+end

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -38,7 +38,7 @@ export run_dsl, load_dsl, parse_sexpr, parse_all
 export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals, support
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, EnumerationMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target
-export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
+export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, WeightedBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
 export NormalNormal, Categorical, NormalGammaLikelihood, Exponential
 export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
 export indicator_kernel, feature_value, BOOLEAN_SPACE

--- a/src/conjugate.jl
+++ b/src/conjugate.jl
@@ -12,6 +12,8 @@
 function maybe_conjugate(p::BetaPrevision, k::Kernel)
     if k.likelihood_family isa BetaBernoulli
         return ConjugatePrevision(p, k.likelihood_family)
+    elseif k.likelihood_family isa WeightedBernoulli
+        return ConjugatePrevision(p, k.likelihood_family)
     elseif k.likelihood_family isa Flat
         return ConjugatePrevision(p, k.likelihood_family)
     end
@@ -30,6 +32,22 @@ end
 
 function update(cp::ConjugatePrevision{BetaPrevision, Flat}, obs)
     cp  # no-op
+end
+
+# Fractional / soft-evidence update. `obs = (outcome, weight)` with
+# outcome ∈ {0, 1} and weight ≥ 0 (a category posterior π_c). Credits
+# `weight` pseudo-counts: α += weight·outcome, β += weight·(1-outcome).
+# Reduces exactly to the unit-count BetaBernoulli update at weight = 1.
+function update(cp::ConjugatePrevision{BetaPrevision, WeightedBernoulli}, obs)
+    outcome, weight = obs
+    o = Float64(outcome)
+    w = Float64(weight)
+    (o == 0.0 || o == 1.0) || error("WeightedBernoulli update: outcome must be ∈ {0, 1}, got $outcome")
+    w >= 0.0 || error("WeightedBernoulli update: weight must be ≥ 0, got $weight")
+    ConjugatePrevision(
+        BetaPrevision(cp.prior.alpha + w * o, cp.prior.beta + w * (1.0 - o)),
+        cp.likelihood,
+    )
 end
 
 # ── Pair: (GaussianPrevision, NormalNormal) ──

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -17,6 +17,13 @@ abstract type LikelihoodFamily end
 abstract type LeafFamily <: LikelihoodFamily end
 
 struct BetaBernoulli <: LeafFamily end
+# Fractional / soft-evidence Bernoulli. The observation is a pair
+# `(outcome, weight)` with `weight ∈ [0,1]` (e.g. a category posterior
+# π_c); the conjugate update credits `weight` pseudo-counts:
+# `α += weight·outcome, β += weight·(1-outcome)`. The strict unit-count
+# `BetaBernoulli` above is left untouched (it still errors on non-{0,1}).
+# Rationale + worked example: docs/paper1/move-2c-design.md.
+struct WeightedBernoulli <: LeafFamily end
 struct Flat <: LeafFamily end
 struct PushOnly <: LikelihoodFamily end
 

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -34,7 +34,7 @@ import ..Previsions: Indicator, apply
 export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals, support
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, EnumerationMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target, kernel_params
-export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
+export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, WeightedBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
 export NormalNormal, Categorical, NormalGammaLikelihood, Exponential
 export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
 export indicator_kernel, feature_value, BOOLEAN_SPACE

--- a/test/test_prevision_weighted_bernoulli.jl
+++ b/test/test_prevision_weighted_bernoulli.jl
@@ -1,0 +1,104 @@
+# test_prevision_weighted_bernoulli.jl — Stratum-2 for the
+# (BetaPrevision, WeightedBernoulli) conjugate pair (Paper 1, B2c).
+#
+# WeightedBernoulli is the fractional / soft-evidence Beta update:
+# obs = (outcome, weight), α += weight·outcome, β += weight·(1-outcome).
+# It is the resource-rational realisation of the exact category-uncertain
+# reliability update (docs/paper1/move-2c-design.md). The strict
+# unit-count BetaBernoulli is untouched.
+#
+# Discipline (per test_prevision_conjugate.jl): assert `_dispatch_path ==
+# :conjugate` BEFORE the value, so a silent registry miss is caught. The
+# degenerate weight=1 case must reduce EXACTLY (==) to the unit-count
+# BetaBernoulli update — the substrate-change equivalence guard.
+#
+# Run from the repo root:
+#     julia test/test_prevision_weighted_bernoulli.jl
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: ConjugatePrevision, maybe_conjugate, update, _dispatch_path
+using Credence: BetaPrevision
+using Credence.Ontology: wrap_in_measure
+
+function check(name, cond, detail="")
+    if cond
+        println("PASSED: $name")
+    else
+        println("FAILED: $name — $detail")
+        error("Stratum-2 assertion failed: $name")
+    end
+end
+
+# Conjugate path is registry-driven; the kernel's generate/log_density are
+# not consulted (update() routes through the registry). likelihood_family
+# is the load-bearing declaration.
+wbern_kernel() = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
+    h -> wrap_in_measure(CategoricalPrevision([0.0, 0.0]), Finite([0, 1])),
+    (h, o) -> 0.0;
+    likelihood_family = WeightedBernoulli())
+
+bbern_kernel() = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
+    h -> wrap_in_measure(CategoricalPrevision([0.0, 0.0]), Finite([0, 1])),
+    (h, o) -> o == 1 ? log(max(h, 1e-300)) : log(max(1 - h, 1e-300));
+    likelihood_family = BetaBernoulli())
+
+println("="^60)
+println("Stratum 2 — (BetaPrevision, WeightedBernoulli)")
+println("="^60)
+
+let k = wbern_kernel()
+    p = BetaPrevision(2.0, 3.0)
+
+    # Dispatch path FIRST.
+    check("BetaPrevision + WeightedBernoulli → :conjugate",
+          _dispatch_path(p, k) === :conjugate, "got $(_dispatch_path(p, k))")
+
+    cp = maybe_conjugate(p, k)
+    check("maybe_conjugate returns ConjugatePrevision{BetaPrevision, WeightedBernoulli}",
+          cp isa ConjugatePrevision{BetaPrevision, WeightedBernoulli}, "got $(typeof(cp))")
+
+    # Fractional correct: α += w, β unchanged.
+    u = update(cp, (1, 0.7)).prior
+    check("Beta(2,3) ×(correct, w=0.7) → Beta(2.7, 3)",
+          isapprox(u.alpha, 2.7; rtol=1e-12) && u.beta == 3.0,
+          "got α=$(u.alpha), β=$(u.beta)")
+
+    # Fractional wrong: α unchanged, β += w.
+    u0 = update(cp, (0, 0.3)).prior
+    check("Beta(2,3) ×(wrong, w=0.3) → Beta(2, 3.3)",
+          u0.alpha == 2.0 && isapprox(u0.beta, 3.3; rtol=1e-12),
+          "got α=$(u0.alpha), β=$(u0.beta)")
+
+    # Zero weight: no-op (a category with π_c = 0 contributes nothing).
+    uz = update(cp, (1, 0.0)).prior
+    check("Beta(2,3) ×(correct, w=0.0) → Beta(2, 3) (no-op)",
+          uz.alpha == 2.0 && uz.beta == 3.0, "got α=$(uz.alpha), β=$(uz.beta)")
+
+    # Bad outcome rejected.
+    threw = false
+    try; update(cp, (2, 0.5)); catch; threw = true; end
+    check("WeightedBernoulli rejects outcome ∉ {0,1}", threw)
+end
+
+# ── Degenerate equivalence: weight=1 == unit-count BetaBernoulli (==) ──
+let wp = BetaPrevision(2.0, 3.0)
+    wcp = maybe_conjugate(wp, wbern_kernel())
+    bcp = maybe_conjugate(wp, bbern_kernel())
+
+    w1 = update(wcp, (1, 1.0)).prior
+    b1 = update(bcp, 1).prior
+    check("(correct, w=1) ≡ BetaBernoulli(correct): Beta(3,3) exactly",
+          w1.alpha == b1.alpha && w1.beta == b1.beta && w1.alpha == 3.0 && w1.beta == 3.0,
+          "weighted=($(w1.alpha),$(w1.beta)) unit=($(b1.alpha),$(b1.beta))")
+
+    w0 = update(wcp, (0, 1.0)).prior
+    b0 = update(bcp, 0).prior
+    check("(wrong, w=1) ≡ BetaBernoulli(wrong): Beta(2,4) exactly",
+          w0.alpha == b0.alpha && w0.beta == b0.beta && w0.alpha == 2.0 && w0.beta == 4.0,
+          "weighted=($(w0.alpha),$(w0.beta)) unit=($(b0.alpha),$(b0.beta))")
+end
+
+println("="^60)
+println("ALL CHECKS PASSED — (BetaPrevision, WeightedBernoulli)")
+println("="^60)

--- a/test/test_qa_benchmark_category_update.jl
+++ b/test/test_qa_benchmark_category_update.jl
@@ -1,0 +1,118 @@
+# test_qa_benchmark_category_update.jl — Paper 1, B2c.
+#
+# Tests the reliability-update mechanism under inferred category
+# uncertainty (`apps/julia/qa_benchmark/category_update.jl`):
+# `update_reliability` (full-posterior-weighted condition) and
+# `marginal_reliability` (category-marginalised MixturePrevision).
+# Provenance: `docs/paper1/move-2c-design.md`.
+#
+# Key guards: (1) one-hot π reduces the update EXACTLY (`==`) to today's
+# unit-count learning; (2) the weighted update tracks the closed-form
+# exact mixture (the negligible-loss / resource-rational claim); (3) the
+# one-hot marginal expect collapses to the single-category belief.
+#
+# Run from the repo root:
+#     julia test/test_qa_benchmark_category_update.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: BetaPrevision
+
+include(joinpath(@__DIR__, "..", "apps", "julia", "qa_benchmark", "category_update.jl"))
+
+const _PASS = Ref(0)
+function check(name, cond, detail="")
+    if cond
+        _PASS[] += 1
+        println("PASSED: $name")
+    else
+        println("FAILED: $name — $detail")
+        error("category_update assertion failed: $name")
+    end
+end
+
+# Clean Beta mean via the BetaMeasure view (no raw field read).
+betamean(p::BetaPrevision) = mean(wrap_in_measure(p))
+
+println("="^60)
+println("Paper 1 B2c — reliability update under category uncertainty")
+println("="^60)
+
+# ── Test 1: one-hot π reduces the update to today's unit-count learning ──
+let
+    row = [BetaPrevision(2.0, 3.0), BetaPrevision(1.0, 1.0), BetaPrevision(4.0, 1.0)]
+    out = update_reliability(row, [1.0, 0.0, 0.0], 1)   # correct; category 1 certain
+    check("one-hot correct: cat1 Beta(2,3) → Beta(3,3) (==)",
+          out[1].alpha == 3.0 && out[1].beta == 3.0, "got ($(out[1].alpha),$(out[1].beta))")
+    check("one-hot: zero-weight categories untouched (==)",
+          out[2].alpha == 1.0 && out[2].beta == 1.0 &&
+          out[3].alpha == 4.0 && out[3].beta == 1.0)
+
+    outw = update_reliability(row, [1.0, 0.0, 0.0], 0)  # wrong; category 1 certain
+    check("one-hot wrong: cat1 Beta(2,3) → Beta(2,4) (==)",
+          outw[1].alpha == 2.0 && outw[1].beta == 4.0, "got ($(outw[1].alpha),$(outw[1].beta))")
+end
+
+# ── Test 2: fractional updates use the whole posterior ──
+let
+    row = [BetaPrevision(2.0, 3.0), BetaPrevision(1.0, 1.0)]
+    c = update_reliability(row, [0.7, 0.3], 1)          # correct
+    check("fractional correct: cat1 α 2→2.7, cat2 α 1→1.3 (rtol 1e-12)",
+          isapprox(c[1].alpha, 2.7; rtol=1e-12) && c[1].beta == 3.0 &&
+          isapprox(c[2].alpha, 1.3; rtol=1e-12) && c[2].beta == 1.0,
+          "got ($(c[1].alpha),$(c[1].beta)),($(c[2].alpha),$(c[2].beta))")
+    w = update_reliability(row, [0.7, 0.3], 0)          # wrong
+    check("fractional wrong: cat1 β 3→3.7, cat2 β 1→1.3 (rtol 1e-12)",
+          w[1].alpha == 2.0 && isapprox(w[1].beta, 3.7; rtol=1e-12) &&
+          w[2].alpha == 1.0 && isapprox(w[2].beta, 1.3; rtol=1e-12),
+          "got ($(w[1].alpha),$(w[1].beta)),($(w[2].alpha),$(w[2].beta))")
+end
+
+# ── Test 3: the weighted update tracks the exact mixture (negligible loss) ──
+# Design-doc §6 oracle: row=[Beta(2,3),Beta(1,1)], π=[0.7,0.3], observe
+# correct. Exact posterior marginal mean of θ₁:
+#   component c=1 weight ∝ 0.7·(2/5)=0.28 → θ₁~Beta(3,3), mean 0.5
+#   component c=2 weight ∝ 0.3·(1/2)=0.15 → θ₁~Beta(2,3), mean 0.4
+let
+    row = [BetaPrevision(2.0, 3.0), BetaPrevision(1.0, 1.0)]
+    out = update_reliability(row, [0.7, 0.3], 1)
+    weighted_mean = betamean(out[1])                    # mean(Beta(2.7,3)) = 0.4737
+    w1 = 0.28 / (0.28 + 0.15)
+    exact_mean = w1 * 0.5 + (1 - w1) * 0.4              # = 0.4651 (closed-form oracle)
+    check("weighted update tracks exact-mixture mean (|Δ| < 0.02)",
+          abs(weighted_mean - exact_mean) < 0.02,
+          "weighted=$weighted_mean exact=$exact_mean Δ=$(abs(weighted_mean - exact_mean))")
+end
+
+# ── Test 4: determinism ──
+let
+    row = [BetaPrevision(2.0, 3.0), BetaPrevision(1.0, 1.0)]
+    a = update_reliability(row, [0.6, 0.4], 1)
+    b = update_reliability(row, [0.6, 0.4], 1)
+    check("determinism: identical (α,β) across calls (==)",
+          all(i -> a[i].alpha == b[i].alpha && a[i].beta == b[i].beta, eachindex(a)))
+end
+
+# ── Test 5: marginal_reliability — one-hot collapses, general = Σ π_c E[θ_c] ──
+# NOTE: expect over a MixturePrevision uses a coarser quadrature than
+# expect over a bare Beta, so the one-hot marginal is NOT bit-identical to
+# the single-category expect (≈5e-5 apart) — only the *update* side is
+# bit-exact on one-hot. We assert against the analytic per-category means
+# (Beta(2,3)=0.4, Beta(1,1)=0.5) at a decision-irrelevant quadrature
+# tolerance. (Recorded as the design-doc §7 residual finding.)
+let
+    row = [BetaPrevision(2.0, 3.0), BetaPrevision(1.0, 1.0)]
+    f = r -> r                                          # identity → mean
+
+    m1 = marginal_reliability(row, [1.0, 0.0])          # collapses to category 1
+    check("one-hot marginal expect ≈ category-1 mean 0.4 (atol 1e-3)",
+          isapprox(expect(m1, f), 0.4; atol=1e-3), "got $(expect(m1, f))")
+
+    m = marginal_reliability(row, [0.7, 0.3])           # Σ π_c·mean_c = 0.7·0.4+0.3·0.5
+    check("marginal expect ≈ Σ π_c·mean_c = 0.43 (atol 1e-3)",
+          isapprox(expect(m, f), 0.43; atol=1e-3), "got $(expect(m, f))")
+end
+
+println("="^60)
+println("ALL $(_PASS[]) CHECKS PASSED (B2c update mechanism)")
+println("="^60)


### PR DESCRIPTION
Implements the principled, MAP-free reliability update from the B2c design doc (`docs/paper1/move-2c-design.md`, merged in #104). The agent learns per-(tool, category) reliability; when the question's category is uncertain it credits **every** category by its inferred posterior weight π_c — the full-posterior-weighted update — rather than collapsing to the MAP category.

**Why this update (resolved from first principles + the author's steer):** Paper 1 is a utility/EU paper — VOI already trades tool cost against information value, so trading *compute* against *inference value* (metacomputation) is native, not extra machinery. Its conclusion: the exact category-uncertain posterior is a `K^n` mixture, intractable, and exact retention buys third-decimal accuracy over the weighted update (design-doc §6: E[θ] 0.465 exact vs 0.474 weighted). So the resource-rational agent uses the weighted update. It uses the *whole* posterior (unlike MAP, which discards it) and is still a genuine `condition`.

### Commits
1. **`0b67b7b` substrate** — `WeightedBernoulli` `LeafFamily` + the `(BetaPrevision, WeightedBernoulli)` conjugate update (`α += w·outcome, β += w·(1-outcome)`). The strict unit-count `BetaBernoulli` is untouched. Stratum-2 test with the degenerate `(w=1) ==` unit-count equivalence guard.
2. **`4cf490e` mechanism** — `update_reliability` / `marginal_reliability` host helpers (pure; π supplied by the host) + 9-check test.

### Verification
- `julia test/test_prevision_weighted_bernoulli.jl` → all pass (8 checks incl. degenerate `==`).
- `julia test/test_qa_benchmark_category_update.jl` → ALL 9 CHECKS PASSED (one-hot `==` unit-count; fractional rtol 1e-12; weighted tracks exact-mixture within 0.02; determinism; analytic marginal mean).
- Regression: `test_core`, `test_prevision_conjugate`, `test_qa_benchmark_category_inference` green.
- Lint clean (`check apps/` 177 files / 0 violations; corpus self-test green).

### Finding (design-doc §7 residual)
`expect` over a `MixturePrevision` uses a coarser quadrature than over a bare Beta, so the one-hot *decision* side matches only to ~5e-5 (not bit-exact); the *update* side is the bit-exact one. Decision-irrelevant.

### Deferred (B3/B4, embedding gate)
Host-loop wiring — replacing `cat_idx = findfirst(==(q.category)…)` with `infer(classifier, embedding_q)` and calling these helpers in `run_bayesian_seed` — needs real question-bank embeddings (no `sentence-transformers` runtime dep), so it lands with the tools-only slice and the fairness-equalised re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)