### PR TITLE
credence-pi Pass 2 MVP — installable agentic-spend governance (Moves 1–2 + demo)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -76,6 +76,13 @@ jobs:
           npm run build
           npm test
 
+      - name: credence-pi OpenClaw-plugin build + tests
+        working-directory: apps/credence-pi/openclaw-plugin
+        run: |
+          npm install
+          npm run build
+          npm test
+
   smoke-build:
     name: Build amd64 + smoke test
     runs-on: ubuntu-latest

--- a/apps/credence-pi/SPEC.md
+++ b/apps/credence-pi/SPEC.md
@@ -218,6 +218,22 @@ Wire shape:
 
 `usd` is `null` when the provider reports zero cost or the model cannot be priced; the Move-2 surface applies a token×price fallback. Only the envelope is snake_case; there is no `features` dict here — cost is not a declared brain feature in Move 1 (it feeds the host-side savings surface and, in Move 2, a cost-denominated Functional).
 
+### `decision` records (Pass 2 — Move 2, daemon-emitted)
+
+Not a sensor event — the daemon writes one to the observation log whenever
+it emits an effector signal, so the dollars-saved surface can account for
+governance the body never reports back (chiefly silent auto-blocks /
+auto-proceeds, which produce no `user-responded`). Shape:
+
+```json
+{ "event_type": "decision", "in_response_to": "<tool-proposed event_id>", "action": "ask" }
+```
+
+`action` is one of `ask` / `proceed` / `block`. DERIVED: replay
+reconstructs the posterior (and hence the decisions) from the logged
+sensor events, so `replay_user_responses` ignores `decision` records and
+they do not affect replay correctness.
+
 ## Effector signals
 
 One outbound message type, parameterised by effector name.

--- a/apps/credence-pi/SPEC.md
+++ b/apps/credence-pi/SPEC.md
@@ -195,6 +195,29 @@ Wire shape:
 
 Pass 1's BDSL does nothing with this event — it's collected for forward compatibility with Pass 2's secondary-signal observation model. The brain logs it and returns no signal. Worth shipping it now so the observation log contains the data Pass 2 will want.
 
+### `turn-cost` (Pass 2 — Move 1)
+
+Emitted by the OpenClaw-plugin body's `llm_output` hook once per agent turn, carrying the turn's token usage and the reconstructed USD cost (`calculateCost(model, usage)` from `openclaw/plugin-sdk/llm`; pi/OpenClaw do not hand plugins a dollar figure directly). The daemon logs it; the brain does not condition on it and emits no signal. It is the cost signal the dollars-saved surface and the cost-denominated utility (both Move 2) read back from the log.
+
+Wire shape:
+```json
+{
+  "event_type": "turn-cost",
+  "event_id": "evt_a1b2c3",
+  "session_id": "sess_xyz",
+  "timestamp": "2026-06-02T14:22:11.421Z",
+  "usd": 0.0123,
+  "total_tokens": 1500,
+  "input_tokens": 1200,
+  "output_tokens": 300,
+  "cache_read": 0,
+  "cache_write": 0,
+  "model": "claude-opus-4-8"
+}
+```
+
+`usd` is `null` when the provider reports zero cost or the model cannot be priced; the Move-2 surface applies a token×price fallback. Only the envelope is snake_case; there is no `features` dict here — cost is not a declared brain feature in Move 1 (it feeds the host-side savings surface and, in Move 2, a cost-denominated Functional).
+
 ## Effector signals
 
 One outbound message type, parameterised by effector name.

--- a/apps/credence-pi/daemon/server.jl
+++ b/apps/credence-pi/daemon/server.jl
@@ -289,6 +289,15 @@ function handle_sensor_event(state::DaemonState,
     elseif event_type == "tool-completed"
         # Pass 1: log only. Pass 2 will condition on outcome features.
 
+    elseif event_type == "turn-cost"
+        # Pass 2 / Move 1: per-turn token + USD cost, emitted by the
+        # OpenClaw-plugin body's llm_output hook. Logged for the
+        # dollars-saved surface (Move 2) and the cost-denominated
+        # utility; the brain does not condition on it and emits no
+        # signal. Logged-first like every event (step 1 above), so the
+        # branch only documents intent and suppresses the unknown-type
+        # warning.
+
     else
         @warn "handle_sensor_event: unknown event_type" event_type
     end

--- a/apps/credence-pi/daemon/server.jl
+++ b/apps/credence-pi/daemon/server.jl
@@ -223,6 +223,19 @@ the enqueued signal (with `signal_type`, `signal_id`, `in_response_to`,
 function emit_signal!(state::DaemonState, in_response_to::AbstractString,
                       action::Symbol, sensor_event::AbstractDict)::Dict{String, Any}
     eff = action_to_signal(action, sensor_event)
+    # Log the decision (event_type "decision") before emitting, so the
+    # dollars-saved surface (savings.jl) can account for governance the
+    # body never reports back — chiefly silent auto-blocks/auto-proceeds
+    # that produce no user-responded event. Decision records are DERIVED
+    # (replay reconstructs the posterior and hence the decisions from the
+    # logged sensor events), so they do not affect replay correctness:
+    # replay_user_responses ignores them. action_to_signal above has
+    # already validated `action`, so only manifest actions are logged.
+    append_event!(state.log_path, Dict{String, Any}(
+        "event_type"     => "decision",
+        "in_response_to" => string(in_response_to),
+        "action"         => string(action),
+    ))
     n = Threads.atomic_add!(_SIGNAL_ID_COUNTER, 1)
     signal = Dict{String, Any}(
         "signal_type"     => "effector",

--- a/apps/credence-pi/demo/governance_demo.jl
+++ b/apps/credence-pi/demo/governance_demo.jl
@@ -1,0 +1,105 @@
+#!/usr/bin/env julia
+# Role: demo (display-only; exercises the real Pass-1 brain end-to-end)
+"""
+    governance_demo.jl — credence-pi governance, end to end, on a synthetic
+    session (no live OpenClaw, no real data required).
+
+Scenario: the agent keeps proposing the same wasteful `bash` call. At cold
+start credence-pi is uncertain, so it ASKS (the VOI gate). The user denies
+the call each time. The global approval posterior concentrates toward
+"refuse", and once it is confident enough the brain AUTO-BLOCKS the call by
+expected-utility maximisation — no hard-coded rule. Finally the
+dollars-saved surface reports the spend governance flagged.
+
+HONEST FRAMING: the Pass-1 brain holds a single GLOBAL approval posterior.
+It learns this user's tool-approval rate; it does NOT yet detect loops
+per-context (that is feature-conditioned learning — Pass-2 Phase 2, which
+needs accumulated real data). What this demonstrates is the real product
+mechanic — govern, learn from the user, auto-block when confident, and
+report the caught spend — on the actual brain + wire + log, end to end.
+
+Run:  julia --project=. apps/credence-pi/demo/governance_demo.jl
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "src"))
+using Credence
+using Credence.Previsions: Identity
+
+include(joinpath(@__DIR__, "..", "daemon", "server.jl"))
+using .Server: init_state, handle_sensor_event, snapshot, drain!
+
+include(joinpath(@__DIR__, "..", "savings.jl"))
+using .Savings: savings_report, format_report
+
+const BDSL_DIR = joinpath(@__DIR__, "..", "bdsl")
+
+# Post one sensor event through the real daemon dispatcher and return the
+# effector the brain emitted (or nothing).
+function step!(state, event)::Union{String, Nothing}
+    drain!(state.signal_queue)                  # clear any prior follow-up
+    handle_sensor_event(state, event)
+    sigs = snapshot(state.signal_queue)
+    isempty(sigs) ? nothing : string(sigs[1]["effector"])
+end
+
+function run_demo(io::IO = stdout)
+    path = tempname() * ".jsonl"
+    state = init_state(; bdsl_dir = BDSL_DIR, log_path = path)
+
+    println(io, "credence-pi governance demo — the agent repeats a wasteful call;")
+    println(io, "the brain asks, the user denies, the brain learns to auto-block.\n")
+    println(io, "round | P(approve) | brain decision")
+    println(io, "------+------------+----------------")
+
+    first_block = 0
+    for k in 1:10
+        eid = "evt_$k"
+        eff = step!(state, Dict{String, Any}(
+            "event_type" => "tool-proposed",
+            "event_id" => eid,
+            "session_id" => "demo",
+            "proposed_call" => Dict("tool_name" => "bash",
+                                    "input" => Dict("command" => "npm run build")),
+        ))
+        p = expect(state.posterior[], Identity())
+        decision = eff === nothing ? "(none)" : eff
+        println(io, lpad(k, 5), " |   ", rpad(round(p; digits = 3), 7), "  | ", decision)
+
+        if eff == "ask"
+            # The user denies the wasteful call; the brain conditions on it.
+            step!(state, Dict{String, Any}(
+                "event_type" => "user-responded",
+                "event_id" => "resp_$k",
+                "in_response_to" => eid,
+                "response" => "no",
+            ))
+        elseif eff == "block" && first_block == 0
+            first_block = k
+        end
+
+        # The turn burned tokens regardless.
+        step!(state, Dict{String, Any}(
+            "event_type" => "turn-cost",
+            "session_id" => "demo",
+            "usd" => 0.12,
+            "total_tokens" => 1500,
+            "model" => "claude-opus-4-8",
+        ))
+    end
+
+    println(io)
+    if first_block > 0
+        println(io, ">> By round $first_block the brain had learned enough to AUTO-BLOCK")
+        println(io, "   the call by expected-utility maximisation — no hard-coded rule.\n")
+    else
+        println(io, ">> The brain stayed in ask/learn mode over these rounds.\n")
+    end
+
+    format_report(io, savings_report(path))
+    rm(path; force = true)
+    return first_block
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_demo()
+end

--- a/apps/credence-pi/openclaw-plugin/.gitignore
+++ b/apps/credence-pi/openclaw-plugin/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/apps/credence-pi/openclaw-plugin/README.md
+++ b/apps/credence-pi/openclaw-plugin/README.md
@@ -1,0 +1,83 @@
+# credence-pi — OpenClaw plugin body
+
+The **body** that lets the credence-pi Bayesian brain govern a real
+pi/OpenClaw agent. It registers an OpenClaw `before_tool_call` hook,
+forwards each proposed tool call to the credence-pi daemon (the opaque
+brain), and maps the brain's decision back to OpenClaw:
+
+| brain effector | OpenClaw result |
+|---|---|
+| `proceed` | allow |
+| `block`   | `{ block: true, blockReason }` |
+| `ask`     | `{ requireApproval }` — OpenClaw's native approval dialog; the user's choice is posted back so the brain learns |
+
+It also logs tool **outcomes** (`after_tool_call`) and reconstructs
+**per-turn cost** (`llm_output` token counts × a price table) so the
+observation log accumulates the data the dollars-saved surface needs.
+
+**Fail-open:** if the daemon is unreachable or slow, the tool proceeds
+(one warning per outage). Governance never blocks the agent on
+infrastructure failure.
+
+This is one of two bodies over the same brain; the other,
+`apps/credence-pi/extension/`, targets the pi coding agent directly.
+Brain + wire (POST `/sensor`, SSE `/signals`) are shared and unchanged.
+
+## Why a plugin (not a pi extension)
+
+Current OpenClaw vendors pi's coding-agent and runs its gateway agent with
+`noExtensions: true`, so a pi `ExtensionFactory` never loads. The supported
+interception point is an OpenClaw **plugin** `before_tool_call` hook. See
+`docs/credence-pi-pass-2/move-1-design.md`.
+
+## Install (operator)
+
+1. Start the brain daemon (see `apps/credence-pi/daemon/README.md`):
+   it listens on `http://127.0.0.1:8787`.
+2. Build the plugin: `cd apps/credence-pi/openclaw-plugin && npm install && npm run build`.
+3. Link it into OpenClaw: `openclaw plugins install -l apps/credence-pi/openclaw-plugin`
+   then `openclaw plugins enable credence-pi`.
+4. For the **cost signal**, enable conversation hooks for this plugin in
+   OpenClaw config:
+   ```jsonc
+   { "plugins": { "entries": { "credence-pi": { "hooks": { "allowConversationAccess": true } } } } }
+   ```
+   (Governance — allow/block/ask — works without this; only the per-turn
+   cost logging needs it.)
+5. Restart the gateway: `openclaw gateway restart`.
+6. Verify: `openclaw plugins inspect credence-pi --runtime --json`.
+
+## Config (`openclaw.plugin.json` → `configSchema`)
+
+| key | default | meaning |
+|---|---|---|
+| `daemonUrl` | `http://127.0.0.1:8787` | credence-pi daemon base URL |
+| `hookTimeoutMs` | `3000` | max wait for the daemon decision before failing open |
+| `silent` | `false` | suppress info/warn logs |
+| `pricing` | — | per-model USD/Mtok overrides: `{ "<model>": { "input": n, "output": n, "cacheRead": n, "cacheWrite": n } }` |
+
+The built-in price table is approximate; set `pricing` for an exact
+dollars-saved figure for your providers. Unknown/unpriced models log
+`usd: null` (token counts still recorded; the Move-2 surface applies a
+token×price fallback).
+
+## Develop
+
+```
+npm install
+npm run build      # tsc → dist/
+npm run typecheck  # tsc --noEmit
+npm test           # node --test (tsx) over tests/*.test.ts
+```
+
+## Known limitations (Move 1 / MVP-0)
+
+- `working-directory-relative` and `time-since-last-user-message` features
+  are best-effort (OpenClaw doesn't put cwd or message timestamps on the
+  tool ctx); the loop-relevant features (tool-name, parent, repetition)
+  are exact. In Move 1 the brain does not condition on features at decision
+  time, so this only affects future feature-conditioned learning.
+- Cost USD is reconstructed from a local price table (no host
+  `calculateCost` dependency); override via `pricing`.
+- The per-run feature buffer is bounded per run but the run map is not
+  evicted on a long-lived gateway — a PASS-2 cleanup item.

--- a/apps/credence-pi/openclaw-plugin/README.md
+++ b/apps/credence-pi/openclaw-plugin/README.md
@@ -53,8 +53,14 @@ interception point is an OpenClaw **plugin** `before_tool_call` hook. See
 |---|---|---|
 | `daemonUrl` | `http://127.0.0.1:8787` | credence-pi daemon base URL |
 | `hookTimeoutMs` | `3000` | max wait for the daemon decision before failing open |
+| `approvalTimeoutMs` | `120000` | how long OpenClaw waits for the user on an `ask` before denying |
+| `redactToolInputs` | `false` | omit tool-call inputs from sensor events (they can carry secrets); ask-preview becomes generic |
 | `silent` | `false` | suppress info/warn logs |
 | `pricing` | — | per-model USD/Mtok overrides: `{ "<model>": { "input": n, "output": n, "cacheRead": n, "cacheWrite": n } }` |
+
+**Privacy:** by default the daemon logs `proposed_call.input` (commands, paths) to
+`~/.credence-pi/observations.jsonl`. Set `redactToolInputs: true` to keep inputs out of the log.
+Fail-open warnings are emitted once per outage (re-armed when the daemon recovers).
 
 The built-in price table is approximate; set `pricing` for an exact
 dollars-saved figure for your providers. Unknown/unpriced models log

--- a/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
+++ b/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
@@ -1,0 +1,34 @@
+{
+  "id": "credence-pi",
+  "name": "credence-pi governance",
+  "description": "Bayesian in-loop governance for the pi/OpenClaw agent — intercepts tool calls and halts/asks on low expected-value spend; logs outcomes and per-turn cost for the dollars-saved surface.",
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "daemonUrl": {
+        "type": "string",
+        "description": "Base URL of the credence-pi Julia daemon (POST /sensor, GET /signals).",
+        "default": "http://127.0.0.1:8787"
+      },
+      "hookTimeoutMs": {
+        "type": "number",
+        "description": "Max time to await the daemon's decision before failing open (proceeding without governance).",
+        "default": 3000
+      },
+      "silent": {
+        "type": "boolean",
+        "description": "Suppress info/warn logging.",
+        "default": false
+      },
+      "pricing": {
+        "type": "object",
+        "description": "Optional per-model USD price overrides in $/million tokens: { \"<model-id>\": { \"input\": <num>, \"output\": <num>, \"cacheRead\": <num>, \"cacheWrite\": <num> } }. Merged over the built-in table.",
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
+++ b/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
@@ -19,6 +19,16 @@
         "description": "Max time to await the daemon's decision before failing open (proceeding without governance).",
         "default": 3000
       },
+      "approvalTimeoutMs": {
+        "type": "number",
+        "description": "How long OpenClaw waits for the user on an `ask` (requireApproval) before applying timeoutBehavior=deny.",
+        "default": 120000
+      },
+      "redactToolInputs": {
+        "type": "boolean",
+        "description": "Omit tool-call inputs from sensor events sent to the daemon (they can carry secrets/commands). Governance still works; the ask-dialog preview becomes generic.",
+        "default": false
+      },
       "silent": {
         "type": "boolean",
         "description": "Suppress info/warn logging.",

--- a/apps/credence-pi/openclaw-plugin/package-lock.json
+++ b/apps/credence-pi/openclaw-plugin/package-lock.json
@@ -1,0 +1,569 @@
+{
+  "name": "credence-pi-openclaw",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "credence-pi-openclaw",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/credence-pi/openclaw-plugin/package.json
+++ b/apps/credence-pi/openclaw-plugin/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "credence-pi-openclaw",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "credence-pi body: OpenClaw plugin that governs tool calls via the credence-pi Bayesian brain (before_tool_call -> allow/block/ask) and logs outcomes + per-turn cost.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "openclaw": {
+    "runtimeExtensions": ["./dist/index.js"],
+    "compat": {
+      "pluginApi": ">=2026.3.24-beta.2",
+      "minGatewayVersion": "2026.3.24-beta.2"
+    },
+    "build": {
+      "openclawVersion": "2026.6.2",
+      "pluginSdkVersion": "2026.3.24-beta.2"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test tests/*.test.ts"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/apps/credence-pi/openclaw-plugin/src/cost.ts
+++ b/apps/credence-pi/openclaw-plugin/src/cost.ts
@@ -1,0 +1,123 @@
+// cost.ts — reconstruct per-turn USD from llm_output token counts.
+//
+// OpenClaw does not hand plugins a dollar figure (only token counts +
+// model id on llm_output). The host computes USD internally via
+// calculateCost(model, usage), but does not expose it to plugins, and we
+// stay dependency-free (no `openclaw` runtime import). So we reconstruct
+// USD from a small, CONFIG-OVERRIDABLE price table (USD per million
+// tokens). The built-in numbers are approximate defaults — the operator
+// should verify/override via the plugin's `pricing` config for an exact
+// dollars-saved figure. When a model can't be priced, usd is null and the
+// Move-2 surface falls back to token counts.
+
+import type { LlmOutputEvent } from "./openclaw-types.js";
+
+export interface ModelPrice {
+  input: number; // USD / million input tokens
+  output: number; // USD / million output tokens
+  cacheRead?: number; // USD / million cache-read tokens
+  cacheWrite?: number; // USD / million cache-write tokens
+}
+
+export type PriceTable = Record<string, ModelPrice>;
+
+// Built-in defaults, keyed by a lowercase family substring matched against
+// the model id. Approximate; override via config `pricing`. Ordered by
+// specificity is not required — we pick the longest matching key.
+export const DEFAULT_PRICES: PriceTable = {
+  "claude-opus": { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  "claude-sonnet": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  "claude-haiku": { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
+  "gpt-4o-mini": { input: 0.15, output: 0.6 },
+  "gpt-4o": { input: 2.5, output: 10 },
+  "gpt-4.1": { input: 2, output: 8 },
+  "o3": { input: 2, output: 8 },
+  "gemini-2.5-pro": { input: 1.25, output: 10 },
+  "gemini-2.5-flash": { input: 0.3, output: 2.5 },
+};
+
+export interface TurnCost {
+  usd: number | null;
+  total_tokens: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read: number | null;
+  cache_write: number | null;
+  model: string | null;
+}
+
+function resolvePrice(
+  model: string | undefined,
+  table: PriceTable,
+): ModelPrice | undefined {
+  if (!model) return undefined;
+  const m = model.toLowerCase();
+  // Exact match first.
+  if (table[m]) return table[m];
+  // Longest family-substring match.
+  let best: { key: string; price: ModelPrice } | undefined;
+  for (const [key, price] of Object.entries(table)) {
+    if (m.includes(key) && (best === undefined || key.length > best.key.length)) {
+      best = { key, price };
+    }
+  }
+  return best?.price;
+}
+
+/** Merge operator `pricing` config over the built-in table. */
+export function buildPriceTable(overrides: unknown): PriceTable {
+  const table: PriceTable = { ...DEFAULT_PRICES };
+  if (overrides && typeof overrides === "object") {
+    for (const [k, v] of Object.entries(overrides as Record<string, unknown>)) {
+      if (v && typeof v === "object") {
+        const o = v as Record<string, unknown>;
+        const input = typeof o.input === "number" ? o.input : undefined;
+        const output = typeof o.output === "number" ? o.output : undefined;
+        if (input !== undefined && output !== undefined) {
+          table[k.toLowerCase()] = {
+            input,
+            output,
+            cacheRead: typeof o.cacheRead === "number" ? o.cacheRead : undefined,
+            cacheWrite:
+              typeof o.cacheWrite === "number" ? o.cacheWrite : undefined,
+          };
+        }
+      }
+    }
+  }
+  return table;
+}
+
+export function computeTurnCost(
+  event: LlmOutputEvent,
+  table: PriceTable,
+): TurnCost {
+  const u = event.usage ?? {};
+  const input = u.input ?? 0;
+  const output = u.output ?? 0;
+  const cacheRead = u.cacheRead ?? 0;
+  const cacheWrite = u.cacheWrite ?? 0;
+  const total = u.total ?? input + output + cacheRead + cacheWrite;
+  const model = event.model ?? null;
+
+  const price = resolvePrice(event.model, table);
+  let usd: number | null = null;
+  if (price) {
+    usd =
+      (input * price.input +
+        output * price.output +
+        cacheRead * (price.cacheRead ?? price.input) +
+        cacheWrite * (price.cacheWrite ?? price.input)) /
+      1_000_000;
+  }
+
+  return {
+    usd,
+    total_tokens: total,
+    input_tokens: input,
+    output_tokens: output,
+    cache_read: cacheRead,
+    cache_write: cacheWrite,
+    model,
+  };
+}

--- a/apps/credence-pi/openclaw-plugin/src/cost.ts
+++ b/apps/credence-pi/openclaw-plugin/src/cost.ts
@@ -46,6 +46,10 @@ export interface TurnCost {
   model: string | null;
 }
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function resolvePrice(
   model: string | undefined,
   table: PriceTable,
@@ -54,10 +58,13 @@ function resolvePrice(
   const m = model.toLowerCase();
   // Exact match first.
   if (table[m]) return table[m];
-  // Longest family-substring match.
+  // Longest key that appears as a SEGMENT of the id — anchored at the
+  // start or after a non-alphanumeric separator. So "o3" matches
+  // "o3-mini" and "openai/o3" but NOT "foo3"; longest match wins.
   let best: { key: string; price: ModelPrice } | undefined;
   for (const [key, price] of Object.entries(table)) {
-    if (m.includes(key) && (best === undefined || key.length > best.key.length)) {
+    const re = new RegExp(`(^|[^a-z0-9])${escapeRegExp(key)}`);
+    if (re.test(m) && (best === undefined || key.length > best.key.length)) {
       best = { key, price };
     }
   }

--- a/apps/credence-pi/openclaw-plugin/src/daemon-client.ts
+++ b/apps/credence-pi/openclaw-plugin/src/daemon-client.ts
@@ -1,0 +1,204 @@
+// daemon-client.ts — body-side HTTP client for the credence-pi daemon.
+//
+// shared-source: apps/credence-pi/extension/src/client.ts
+//   This is a vendored copy (verbatim behaviour) so the OpenClaw plugin
+//   is a self-contained, installable package. The pi-extension body and
+//   this OpenClaw body MUST keep the same daemon wire (POST /sensor,
+//   GET /signals SSE). If you change one, change the other; client.test.ts
+//   in the extension covers the reference behaviour.
+//
+// Two responsibilities, both fail-open:
+//   postSensor(event)              — POST /sensor with a timeout; never
+//                                    throws, never hangs; logs once on
+//                                    failure and returns {ok:false}.
+//   connectSignalsStream(onSignal) — streaming GET /signals consumer;
+//                                    parses `data:` SSE frames; auto-
+//                                    reconnects with exponential backoff
+//                                    until close().
+
+export interface SignalEnvelope {
+  signal_type: string;
+  signal_id: string;
+  in_response_to: string;
+  effector: string;
+  parameters: Record<string, unknown>;
+}
+
+export type Logger = (msg: string, err?: unknown) => void;
+
+export interface ClientOptions {
+  baseUrl: string;
+  timeoutMs?: number;
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+  logger?: Logger;
+}
+
+export interface PostResult {
+  ok: boolean;
+}
+
+export interface DaemonClient {
+  postSensor: (event: object) => Promise<PostResult>;
+  connectSignalsStream: (
+    onSignal: (sig: SignalEnvelope) => void,
+  ) => SignalsConnection;
+}
+
+export interface SignalsConnection {
+  close: () => void;
+  done: Promise<void>;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_INITIAL_BACKOFF_MS = 500;
+const DEFAULT_MAX_BACKOFF_MS = 30_000;
+
+export function createDaemonClient(opts: ClientOptions): DaemonClient {
+  const baseUrl = opts.baseUrl.replace(/\/+$/, "");
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const initialBackoff = opts.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS;
+  const maxBackoff = opts.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
+  const log: Logger =
+    opts.logger ??
+    ((m, e) => (e === undefined ? console.warn(m) : console.warn(m, e)));
+
+  return {
+    postSensor: (event) => postSensor(baseUrl, event, timeoutMs, log),
+    connectSignalsStream: (onSignal) =>
+      connectSignalsStream(baseUrl, onSignal, initialBackoff, maxBackoff, log),
+  };
+}
+
+async function postSensor(
+  baseUrl: string,
+  event: object,
+  timeoutMs: number,
+  log: Logger,
+): Promise<PostResult> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const resp = await fetch(`${baseUrl}/sensor`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+      signal: ctrl.signal,
+    });
+    try {
+      await resp.text();
+    } catch {
+      /* noop */
+    }
+    if (!resp.ok) {
+      log(`credence-pi: daemon /sensor returned status ${resp.status}; failing open`);
+      return { ok: false };
+    }
+    return { ok: true };
+  } catch (err) {
+    log("credence-pi: daemon unreachable on /sensor; failing open", err);
+    return { ok: false };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function connectSignalsStream(
+  baseUrl: string,
+  onSignal: (sig: SignalEnvelope) => void,
+  initialBackoff: number,
+  maxBackoff: number,
+  log: Logger,
+): SignalsConnection {
+  const ctrl = new AbortController();
+  let closed = false;
+
+  const done = (async () => {
+    let backoff = initialBackoff;
+    while (!closed) {
+      try {
+        await consumeOnce(baseUrl, onSignal, ctrl.signal, log);
+        if (closed) break;
+        log("credence-pi: /signals stream ended; reconnecting");
+      } catch (err) {
+        if (closed) break;
+        log("credence-pi: /signals stream error; reconnecting", err);
+      }
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, backoff);
+        ctrl.signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(t);
+            resolve();
+          },
+          { once: true },
+        );
+      });
+      backoff = Math.min(backoff * 2, maxBackoff);
+    }
+  })();
+
+  return {
+    close: () => {
+      closed = true;
+      ctrl.abort();
+    },
+    done,
+  };
+}
+
+async function consumeOnce(
+  baseUrl: string,
+  onSignal: (sig: SignalEnvelope) => void,
+  signal: AbortSignal,
+  log: Logger,
+): Promise<void> {
+  const resp = await fetch(`${baseUrl}/signals`, {
+    method: "GET",
+    headers: { Accept: "text/event-stream" },
+    signal,
+  });
+  if (!resp.ok || !resp.body) {
+    throw new Error(`/signals returned ${resp.status}`);
+  }
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      buffer += decoder.decode(value, { stream: true });
+      let idx: number;
+      while ((idx = buffer.indexOf("\n\n")) >= 0) {
+        const frame = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        dispatchFrame(frame, onSignal, log);
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      /* noop */
+    }
+  }
+}
+
+function dispatchFrame(
+  frame: string,
+  onSignal: (sig: SignalEnvelope) => void,
+  log: Logger,
+): void {
+  for (const line of frame.split("\n")) {
+    if (line.startsWith("data: ")) {
+      const payload = line.slice(6);
+      try {
+        onSignal(JSON.parse(payload) as SignalEnvelope);
+      } catch (err) {
+        log("credence-pi: /signals dispatch dropped malformed frame", err);
+      }
+    }
+  }
+}

--- a/apps/credence-pi/openclaw-plugin/src/features.ts
+++ b/apps/credence-pi/openclaw-plugin/src/features.ts
@@ -1,0 +1,150 @@
+// features.ts — the body's sensory periphery for the OpenClaw plugin.
+//
+// Produces the brain's declared kebab-case feature vocabulary
+// (apps/credence-pi/bdsl/features.bdsl) from the before_tool_call event +
+// a small per-run history buffer. In Move 1 the brain does NOT condition
+// on features at decision time (global Beta), so these are logged for the
+// dollars-saved surface and future feature-conditioned learning; the
+// loop-relevant ones (tool-name, parent, repetition) are exact, while
+// working-directory-relative and time-since-last-user-message are
+// best-effort (OpenClaw does not put cwd or message timestamps on the
+// tool ctx — see move-1-design.md OQ-d).
+
+import type { BeforeToolCallEvent, ToolContext } from "./openclaw-types.js";
+
+export type Features = Record<string, string>;
+
+const KNOWN_TOOLS = new Set([
+  "read",
+  "write",
+  "edit",
+  "bash",
+  "grep",
+  "find",
+  "ls",
+]);
+
+const HISTORY_CAP = 50;
+const REPETITION_WINDOW = 5;
+
+interface Entry {
+  tool: string;
+  ts: number;
+}
+
+interface RunState {
+  history: Entry[];
+  lastUserTs?: number;
+}
+
+function bucketTool(name: string | undefined): string {
+  if (!name) return "other";
+  const t = name.toLowerCase();
+  return KNOWN_TOOLS.has(t) ? t : "other";
+}
+
+function runKey(ctx: ToolContext): string {
+  return ctx.runId ?? ctx.sessionKey ?? ctx.sessionId ?? "default";
+}
+
+function timeSinceUserBucket(elapsedMs: number | undefined): string {
+  if (elapsedMs === undefined) return "gt-10m";
+  const s = elapsedMs / 1000;
+  if (s < 30) return "lt-30s";
+  if (s < 120) return "lt-2m";
+  if (s < 600) return "lt-10m";
+  return "gt-10m";
+}
+
+function workingDirRelative(
+  ctx: ToolContext,
+  event: BeforeToolCallEvent,
+  nowTool: string,
+): string {
+  const root = ctx.workspaceDir;
+  const paths = event.derivedPaths ?? [];
+  if (paths.length === 0) {
+    // No path-bearing tool (e.g. a bare bash with no file args we can see).
+    return nowTool === "bash" || nowTool === "other" ? "no-path" : "no-path";
+  }
+  if (!root) return "no-path";
+  const norm = (p: string) => p.replace(/\/+$/, "");
+  const r = norm(root);
+  let sawOutside = false;
+  let sawRootExact = false;
+  let sawSub = false;
+  for (const raw of paths) {
+    const p = norm(raw);
+    if (p === r) {
+      sawRootExact = true;
+    } else if (p.startsWith(r + "/")) {
+      sawSub = true;
+    } else {
+      sawOutside = true;
+    }
+  }
+  if (sawOutside) return "outside-project";
+  if (sawRootExact && !sawSub) return "project-root";
+  return "subdirectory";
+}
+
+export class FeatureTracker {
+  private runs = new Map<string, RunState>();
+
+  /** Stamp the most recent user message for a run (best-effort; wired
+   *  from a message hook if one is available). */
+  markUserMessage(ctx: ToolContext, ts: number): void {
+    const k = runKey(ctx);
+    const st = this.runs.get(k) ?? { history: [] };
+    st.lastUserTs = ts;
+    this.runs.set(k, st);
+  }
+
+  /** Compute features from the run's history BEFORE this call, then record
+   *  the current call. `now` is injectable for deterministic tests. */
+  extractAndRecord(
+    event: BeforeToolCallEvent,
+    ctx: ToolContext,
+    now: number = Date.now(),
+  ): Features {
+    const k = runKey(ctx);
+    const st = this.runs.get(k) ?? { history: [] };
+    const tool = bucketTool(event.toolName);
+
+    const parent =
+      st.history.length > 0 ? st.history[st.history.length - 1].tool : "none";
+
+    const recent = st.history.slice(-REPETITION_WINDOW);
+    const reps = recent.filter((e) => e.tool === tool).length;
+    const repBucket =
+      reps === 0 ? "rep-0" : reps === 1 ? "rep-1" : reps === 2 ? "rep-2" : "rep-3plus";
+
+    const elapsed =
+      st.lastUserTs === undefined ? undefined : now - st.lastUserTs;
+
+    const features: Features = {
+      "tool-name": tool,
+      "working-directory-relative": workingDirRelative(ctx, event, tool),
+      "parent-tool-call-name": parent,
+      "recent-repetition-count": repBucket,
+      "time-since-last-user-message": timeSinceUserBucket(elapsed),
+    };
+
+    // Record current call.
+    st.history.push({ tool, ts: now });
+    if (st.history.length > HISTORY_CAP) st.history.shift();
+    this.runs.set(k, st);
+
+    return features;
+  }
+
+  /** Drop a run's buffer (call on agent_end to bound memory). */
+  clearRun(ctx: ToolContext): void {
+    this.runs.delete(runKey(ctx));
+  }
+
+  /** Test/inspection accessor. */
+  runCount(): number {
+    return this.runs.size;
+  }
+}

--- a/apps/credence-pi/openclaw-plugin/src/features.ts
+++ b/apps/credence-pi/openclaw-plugin/src/features.ts
@@ -59,13 +59,12 @@ function timeSinceUserBucket(elapsedMs: number | undefined): string {
 function workingDirRelative(
   ctx: ToolContext,
   event: BeforeToolCallEvent,
-  nowTool: string,
 ): string {
   const root = ctx.workspaceDir;
   const paths = event.derivedPaths ?? [];
   if (paths.length === 0) {
     // No path-bearing tool (e.g. a bare bash with no file args we can see).
-    return nowTool === "bash" || nowTool === "other" ? "no-path" : "no-path";
+    return "no-path";
   }
   if (!root) return "no-path";
   const norm = (p: string) => p.replace(/\/+$/, "");
@@ -124,7 +123,7 @@ export class FeatureTracker {
 
     const features: Features = {
       "tool-name": tool,
-      "working-directory-relative": workingDirRelative(ctx, event, tool),
+      "working-directory-relative": workingDirRelative(ctx, event),
       "parent-tool-call-name": parent,
       "recent-repetition-count": repBucket,
       "time-since-last-user-message": timeSinceUserBucket(elapsed),

--- a/apps/credence-pi/openclaw-plugin/src/index.ts
+++ b/apps/credence-pi/openclaw-plugin/src/index.ts
@@ -16,6 +16,10 @@
 //     itself decide proceed/block on the reply.
 //   - Fail-open everywhere: daemon unreachable / slow ⇒ the tool proceeds,
 //     with one warning per outage.
+//
+// The orchestration lives in `createGovernor`, separated from `register`
+// so it can be unit-tested with an injected DaemonClient (see
+// tests/index.test.ts).
 
 import { randomUUID } from "node:crypto";
 
@@ -26,10 +30,14 @@ import {
   type Logger,
 } from "./daemon-client.js";
 import { FeatureTracker } from "./features.js";
-import { buildPriceTable, computeTurnCost } from "./cost.js";
+import { buildPriceTable, computeTurnCost, type PriceTable } from "./cost.js";
 import type {
   PluginEntry,
+  BeforeToolCallEvent,
   BeforeToolCallResult,
+  AfterToolCallEvent,
+  LlmOutputEvent,
+  ToolContext,
   RequireApprovalPayload,
 } from "./openclaw-types.js";
 
@@ -100,6 +108,162 @@ export function mapSignal(
   }
 }
 
+export interface GovernorOpts {
+  hookTimeoutMs: number;
+  approvalTimeoutMs: number;
+  priceTable: PriceTable;
+  redactToolInputs: boolean;
+  log: Logger;
+}
+
+export interface Governor {
+  beforeToolCall: (
+    event: BeforeToolCallEvent,
+    ctx: ToolContext,
+  ) => Promise<BeforeToolCallResult | undefined>;
+  afterToolCall: (event: AfterToolCallEvent, ctx: ToolContext) => Promise<void>;
+  llmOutput: (event: LlmOutputEvent, ctx: ToolContext) => Promise<void>;
+  cleanup: () => void;
+  /** Test/inspection accessor: in-flight tool_call awaiters. */
+  pendingCount: () => number;
+}
+
+// The governance orchestration over an injected DaemonClient. register()
+// wires this to the OpenClaw hook API; tests drive it with a fake client.
+export function createGovernor(
+  client: DaemonClient,
+  opts: GovernorOpts,
+): Governor {
+  const { hookTimeoutMs, approvalTimeoutMs, priceTable, redactToolInputs, log } =
+    opts;
+  const tracker = new FeatureTracker();
+
+  // event_id -> resolver for the awaited effector signal. The single SSE
+  // consumer dispatches signals here by in_response_to. Unmatched signals
+  // (e.g. an ask-followup after the hook already resolved) find no resolver
+  // and are dropped.
+  const awaiters = new Map<string, (sig: SignalEnvelope | undefined) => void>();
+
+  const sse = client.connectSignalsStream((sig) => {
+    const resolve = awaiters.get(sig.in_response_to);
+    if (resolve) resolve(sig);
+  });
+
+  let warnedDown = false;
+  let announcedUp = false;
+  let down = false;
+
+  async function beforeToolCall(
+    event: BeforeToolCallEvent,
+    ctx: ToolContext,
+  ): Promise<BeforeToolCallResult | undefined> {
+    const eventId = newEventId();
+    const signalPromise = new Promise<SignalEnvelope | undefined>((resolve) => {
+      const timer = setTimeout(() => {
+        awaiters.delete(eventId);
+        resolve(undefined);
+      }, hookTimeoutMs);
+      awaiters.set(eventId, (sig) => {
+        clearTimeout(timer);
+        awaiters.delete(eventId);
+        resolve(sig);
+      });
+    });
+
+    const features = tracker.extractAndRecord(event, ctx);
+    const post = await client.postSensor({
+      event_type: "tool-proposed",
+      event_id: eventId,
+      session_id: ctx.sessionId ?? ctx.sessionKey ?? "",
+      timestamp: new Date().toISOString(),
+      features,
+      // Tool inputs can carry secrets (commands, tokens). Operators may
+      // redact them; the brain does not condition on input (Move 1), only
+      // the daemon's ask-text preview uses it.
+      proposed_call: {
+        tool_name: event.toolName,
+        input: redactToolInputs ? null : event.params,
+      },
+    });
+
+    if (!post.ok) {
+      const r = awaiters.get(eventId);
+      if (r) r(undefined); // clean up timer + awaiter
+      if (!warnedDown) {
+        log(
+          `credence-pi: daemon unreachable at the configured URL; proceeding without governance`,
+        );
+        warnedDown = true;
+      }
+      down = true;
+      announcedUp = false;
+      return undefined; // fail open
+    }
+    if (down && !announcedUp) {
+      log("credence-pi: daemon reachable again; governance resumed");
+      announcedUp = true;
+      down = false;
+      warnedDown = false; // re-arm the unreachable warning for the next outage
+    }
+
+    const sig = await signalPromise;
+    return mapSignal(sig, eventId, client, approvalTimeoutMs);
+  }
+
+  async function afterToolCall(
+    event: AfterToolCallEvent,
+    _ctx: ToolContext,
+  ): Promise<void> {
+    // Correlate by the stable toolCallId (tools run in parallel).
+    await client.postSensor({
+      event_type: "tool-completed",
+      event_id: newEventId(),
+      in_response_to: event.toolCallId ?? "",
+      timestamp: new Date().toISOString(),
+      outcome: {
+        success: event.error == null,
+        duration_ms: event.durationMs ?? null,
+        result_summary: null,
+        error: event.error ?? null,
+      },
+    });
+  }
+
+  async function llmOutput(
+    event: LlmOutputEvent,
+    ctx: ToolContext,
+  ): Promise<void> {
+    const tc = computeTurnCost(event, priceTable);
+    await client.postSensor({
+      event_type: "turn-cost",
+      event_id: newEventId(),
+      session_id: ctx.sessionId ?? event.sessionId ?? "",
+      timestamp: new Date().toISOString(),
+      usd: tc.usd,
+      total_tokens: tc.total_tokens,
+      input_tokens: tc.input_tokens,
+      output_tokens: tc.output_tokens,
+      cache_read: tc.cache_read,
+      cache_write: tc.cache_write,
+      model: tc.model,
+    });
+  }
+
+  function cleanup(): void {
+    sse.close();
+    for (const resolve of awaiters.values()) resolve(undefined);
+    awaiters.clear();
+  }
+
+  return {
+    beforeToolCall,
+    afterToolCall,
+    llmOutput,
+    cleanup,
+    pendingCount: () => awaiters.size,
+  };
+}
+
 const plugin: PluginEntry = {
   id: "credence-pi",
   name: "credence-pi governance",
@@ -119,6 +283,7 @@ const plugin: PluginEntry = {
         ? cfg.approvalTimeoutMs
         : DEFAULT_APPROVAL_TIMEOUT_MS;
     const silent = cfg.silent === true;
+    const redactToolInputs = cfg.redactToolInputs === true;
     const priceTable = buildPriceTable(cfg.pricing);
 
     const log: Logger = (m, e) => {
@@ -132,120 +297,44 @@ const plugin: PluginEntry = {
       timeoutMs: hookTimeoutMs,
       logger: log,
     });
-    const tracker = new FeatureTracker();
-
-    // event_id -> resolver for the awaited effector signal. The single SSE
-    // consumer dispatches signals here by in_response_to. Unmatched
-    // signals (e.g. an ask-followup after the hook already resolved) find
-    // no resolver and are dropped.
-    const awaiters = new Map<string, (sig: SignalEnvelope | undefined) => void>();
-
-    const sse = client.connectSignalsStream((sig) => {
-      const resolve = awaiters.get(sig.in_response_to);
-      if (resolve) resolve(sig);
-    });
-    void sse; // SSE runs for the plugin's lifetime; OpenClaw owns shutdown.
-
-    let warnedDown = false;
-    let announcedUp = false;
-    let down = false;
-
-    // 1. Tool-call interception (no allowConversationAccess needed).
-    api.on(
-      "before_tool_call",
-      async (event, ctx): Promise<BeforeToolCallResult | void> => {
-        const eventId = newEventId();
-        const signalPromise = new Promise<SignalEnvelope | undefined>(
-          (resolve) => {
-            const timer = setTimeout(() => {
-              awaiters.delete(eventId);
-              resolve(undefined);
-            }, hookTimeoutMs);
-            awaiters.set(eventId, (sig) => {
-              clearTimeout(timer);
-              awaiters.delete(eventId);
-              resolve(sig);
-            });
-          },
-        );
-
-        const features = tracker.extractAndRecord(event, ctx);
-        const post = await client.postSensor({
-          event_type: "tool-proposed",
-          event_id: eventId,
-          session_id: ctx.sessionId ?? ctx.sessionKey ?? "",
-          timestamp: new Date().toISOString(),
-          features,
-          proposed_call: { tool_name: event.toolName, input: event.params },
-        });
-
-        if (!post.ok) {
-          const r = awaiters.get(eventId);
-          if (r) r(undefined); // clean up timer + awaiter
-          if (!warnedDown) {
-            log(
-              `credence-pi: daemon unreachable at ${daemonUrl}; proceeding without governance`,
-            );
-            warnedDown = true;
-          }
-          down = true;
-          announcedUp = false;
-          return undefined; // fail open
-        }
-        if (down && !announcedUp) {
-          log("credence-pi: daemon reachable again; governance resumed");
-          announcedUp = true;
-          down = false;
-        }
-
-        const sig = await signalPromise;
-        return mapSignal(sig, eventId, client, approvalTimeoutMs);
-      },
-      { priority: 100, timeoutMs: hookTimeoutMs + 1_000 },
-    );
-
-    // 2. Tool outcome (no allowConversationAccess needed). Correlate by
-    //    the stable toolCallId (tools run in parallel).
-    api.on("after_tool_call", async (event, _ctx) => {
-      await client.postSensor({
-        event_type: "tool-completed",
-        event_id: newEventId(),
-        in_response_to: event.toolCallId ?? "",
-        timestamp: new Date().toISOString(),
-        outcome: {
-          success: event.error == null,
-          duration_ms: event.durationMs ?? null,
-          result_summary: null,
-          error: event.error ?? null,
-        },
-      });
+    const gov = createGovernor(client, {
+      hookTimeoutMs,
+      approvalTimeoutMs,
+      priceTable,
+      redactToolInputs,
+      log,
     });
 
-    // 3. Per-turn cost (REQUIRES plugins.entries.credence-pi.hooks
-    //    .allowConversationAccess: true). Wrapped so a blocked
-    //    registration never breaks governance — cost is just absent.
+    api.on("before_tool_call", gov.beforeToolCall, {
+      priority: 100,
+      timeoutMs: hookTimeoutMs + 1_000,
+    });
+    api.on("after_tool_call", gov.afterToolCall);
+
+    // Per-turn cost REQUIRES plugins.entries.credence-pi.hooks
+    // .allowConversationAccess: true. Wrapped so a blocked registration
+    // never breaks governance — cost is just absent.
     try {
-      api.on("llm_output", async (event, ctx) => {
-        const tc = computeTurnCost(event, priceTable);
-        await client.postSensor({
-          event_type: "turn-cost",
-          event_id: newEventId(),
-          session_id: ctx.sessionId ?? event.sessionId ?? "",
-          timestamp: new Date().toISOString(),
-          usd: tc.usd,
-          total_tokens: tc.total_tokens,
-          input_tokens: tc.input_tokens,
-          output_tokens: tc.output_tokens,
-          cache_read: tc.cache_read,
-          cache_write: tc.cache_write,
-          model: tc.model,
-        });
-      });
+      api.on("llm_output", gov.llmOutput);
     } catch (err) {
       log(
         "credence-pi: llm_output hook unavailable (set hooks.allowConversationAccess:true for the cost signal)",
         err,
       );
+    }
+
+    // Close the SSE stream + drain awaiters on reset/delete/reload so a
+    // hot-reload does not accumulate daemon connections. Optional-chained
+    // for hosts predating the lifecycle API.
+    try {
+      api.lifecycle?.registerRuntimeLifecycle?.({
+        id: "credence-pi-governor",
+        description:
+          "Close the credence-pi daemon SSE stream and drain pending tool-call awaiters.",
+        cleanup: () => gov.cleanup(),
+      });
+    } catch (err) {
+      log("credence-pi: could not register lifecycle cleanup", err);
     }
   },
 };

--- a/apps/credence-pi/openclaw-plugin/src/index.ts
+++ b/apps/credence-pi/openclaw-plugin/src/index.ts
@@ -1,0 +1,253 @@
+// index.ts — credence-pi OpenClaw-plugin body.
+//
+// Governs the pi/OpenClaw agent loop by intercepting tool calls and
+// routing the decision to the credence-pi Julia daemon (the opaque
+// brain). Reuses credence-pi's async wire UNCHANGED: POST /sensor (a
+// tool-proposed sensor event) then await the correlated effector signal
+// off the SSE /signals stream; map it to OpenClaw's before_tool_call
+// result. Also logs tool outcomes and reconstructed per-turn cost so the
+// observation log accumulates the data the dollars-saved surface (Move 2)
+// needs.
+//
+// Discipline (matches the pi-extension body):
+//   - The BRAIN decides; the body only translates. ask -> requireApproval
+//     (OpenClaw enforces the user's choice natively); the body posts
+//     user-responded via onResolution so the brain learns, but does not
+//     itself decide proceed/block on the reply.
+//   - Fail-open everywhere: daemon unreachable / slow ⇒ the tool proceeds,
+//     with one warning per outage.
+
+import { randomUUID } from "node:crypto";
+
+import {
+  createDaemonClient,
+  type DaemonClient,
+  type SignalEnvelope,
+  type Logger,
+} from "./daemon-client.js";
+import { FeatureTracker } from "./features.js";
+import { buildPriceTable, computeTurnCost } from "./cost.js";
+import type {
+  PluginEntry,
+  BeforeToolCallResult,
+  RequireApprovalPayload,
+} from "./openclaw-types.js";
+
+const DEFAULT_DAEMON_URL = "http://127.0.0.1:8787";
+const DEFAULT_HOOK_TIMEOUT_MS = 3_000;
+// How long OpenClaw waits for the human on an `ask` (requireApproval).
+// Distinct from the daemon-decision timeout above.
+const DEFAULT_APPROVAL_TIMEOUT_MS = 120_000;
+
+function newEventId(): string {
+  return `evt_${randomUUID().slice(0, 12)}`;
+}
+
+export function mapSignal(
+  sig: SignalEnvelope | undefined,
+  originatingEventId: string,
+  client: DaemonClient,
+  approvalTimeoutMs: number,
+): BeforeToolCallResult | undefined {
+  if (!sig) return undefined; // timeout / fail-open ⇒ proceed
+  const p = sig.parameters ?? {};
+  switch (sig.effector) {
+    case "proceed":
+      return undefined;
+    case "block":
+      return {
+        block: true,
+        blockReason: `credence-pi: ${
+          typeof p.reason === "string"
+            ? p.reason
+            : "tool call vetoed by expected-utility calculation"
+        }`,
+      };
+    case "ask": {
+      const description =
+        typeof p.text === "string" ? p.text : "Confirm this tool call?";
+      const requireApproval: RequireApprovalPayload = {
+        title: "credence-pi governance",
+        description,
+        severity: "warning",
+        timeoutMs: approvalTimeoutMs,
+        timeoutBehavior: "deny",
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        onResolution: async (decision) => {
+          const response =
+            decision === "allow-once" || decision === "allow-always"
+              ? "yes"
+              : decision === "deny"
+                ? "no"
+                : "timeout";
+          // Fire-and-forget: the brain conditions on the reply; OpenClaw
+          // has already enforced the decision. The daemon's follow-up
+          // proceed/block signal is unneeded here and harmlessly dropped
+          // (no awaiter).
+          await client.postSensor({
+            event_type: "user-responded",
+            event_id: newEventId(),
+            in_response_to: originatingEventId,
+            timestamp: new Date().toISOString(),
+            response,
+          });
+        },
+      };
+      return { requireApproval };
+    }
+    default:
+      return undefined; // unknown effector ⇒ fail open
+  }
+}
+
+const plugin: PluginEntry = {
+  id: "credence-pi",
+  name: "credence-pi governance",
+  description:
+    "Bayesian in-loop governance for the pi/OpenClaw agent — intercepts tool calls (allow/block/ask) via the credence-pi brain and logs outcomes + per-turn cost.",
+
+  register(api) {
+    const cfg = api.pluginConfig ?? {};
+    const daemonUrl =
+      typeof cfg.daemonUrl === "string" ? cfg.daemonUrl : DEFAULT_DAEMON_URL;
+    const hookTimeoutMs =
+      typeof cfg.hookTimeoutMs === "number"
+        ? cfg.hookTimeoutMs
+        : DEFAULT_HOOK_TIMEOUT_MS;
+    const approvalTimeoutMs =
+      typeof cfg.approvalTimeoutMs === "number"
+        ? cfg.approvalTimeoutMs
+        : DEFAULT_APPROVAL_TIMEOUT_MS;
+    const silent = cfg.silent === true;
+    const priceTable = buildPriceTable(cfg.pricing);
+
+    const log: Logger = (m, e) => {
+      if (silent) return;
+      const msg = e === undefined ? m : `${m} ${String(e)}`;
+      api.logger?.warn?.(msg);
+    };
+
+    const client = createDaemonClient({
+      baseUrl: daemonUrl,
+      timeoutMs: hookTimeoutMs,
+      logger: log,
+    });
+    const tracker = new FeatureTracker();
+
+    // event_id -> resolver for the awaited effector signal. The single SSE
+    // consumer dispatches signals here by in_response_to. Unmatched
+    // signals (e.g. an ask-followup after the hook already resolved) find
+    // no resolver and are dropped.
+    const awaiters = new Map<string, (sig: SignalEnvelope | undefined) => void>();
+
+    const sse = client.connectSignalsStream((sig) => {
+      const resolve = awaiters.get(sig.in_response_to);
+      if (resolve) resolve(sig);
+    });
+    void sse; // SSE runs for the plugin's lifetime; OpenClaw owns shutdown.
+
+    let warnedDown = false;
+    let announcedUp = false;
+    let down = false;
+
+    // 1. Tool-call interception (no allowConversationAccess needed).
+    api.on(
+      "before_tool_call",
+      async (event, ctx): Promise<BeforeToolCallResult | void> => {
+        const eventId = newEventId();
+        const signalPromise = new Promise<SignalEnvelope | undefined>(
+          (resolve) => {
+            const timer = setTimeout(() => {
+              awaiters.delete(eventId);
+              resolve(undefined);
+            }, hookTimeoutMs);
+            awaiters.set(eventId, (sig) => {
+              clearTimeout(timer);
+              awaiters.delete(eventId);
+              resolve(sig);
+            });
+          },
+        );
+
+        const features = tracker.extractAndRecord(event, ctx);
+        const post = await client.postSensor({
+          event_type: "tool-proposed",
+          event_id: eventId,
+          session_id: ctx.sessionId ?? ctx.sessionKey ?? "",
+          timestamp: new Date().toISOString(),
+          features,
+          proposed_call: { tool_name: event.toolName, input: event.params },
+        });
+
+        if (!post.ok) {
+          const r = awaiters.get(eventId);
+          if (r) r(undefined); // clean up timer + awaiter
+          if (!warnedDown) {
+            log(
+              `credence-pi: daemon unreachable at ${daemonUrl}; proceeding without governance`,
+            );
+            warnedDown = true;
+          }
+          down = true;
+          announcedUp = false;
+          return undefined; // fail open
+        }
+        if (down && !announcedUp) {
+          log("credence-pi: daemon reachable again; governance resumed");
+          announcedUp = true;
+          down = false;
+        }
+
+        const sig = await signalPromise;
+        return mapSignal(sig, eventId, client, approvalTimeoutMs);
+      },
+      { priority: 100, timeoutMs: hookTimeoutMs + 1_000 },
+    );
+
+    // 2. Tool outcome (no allowConversationAccess needed). Correlate by
+    //    the stable toolCallId (tools run in parallel).
+    api.on("after_tool_call", async (event, _ctx) => {
+      await client.postSensor({
+        event_type: "tool-completed",
+        event_id: newEventId(),
+        in_response_to: event.toolCallId ?? "",
+        timestamp: new Date().toISOString(),
+        outcome: {
+          success: event.error == null,
+          duration_ms: event.durationMs ?? null,
+          result_summary: null,
+          error: event.error ?? null,
+        },
+      });
+    });
+
+    // 3. Per-turn cost (REQUIRES plugins.entries.credence-pi.hooks
+    //    .allowConversationAccess: true). Wrapped so a blocked
+    //    registration never breaks governance — cost is just absent.
+    try {
+      api.on("llm_output", async (event, ctx) => {
+        const tc = computeTurnCost(event, priceTable);
+        await client.postSensor({
+          event_type: "turn-cost",
+          event_id: newEventId(),
+          session_id: ctx.sessionId ?? event.sessionId ?? "",
+          timestamp: new Date().toISOString(),
+          usd: tc.usd,
+          total_tokens: tc.total_tokens,
+          input_tokens: tc.input_tokens,
+          output_tokens: tc.output_tokens,
+          cache_read: tc.cache_read,
+          cache_write: tc.cache_write,
+          model: tc.model,
+        });
+      });
+    } catch (err) {
+      log(
+        "credence-pi: llm_output hook unavailable (set hooks.allowConversationAccess:true for the cost signal)",
+        err,
+      );
+    }
+  },
+};
+
+export default plugin;

--- a/apps/credence-pi/openclaw-plugin/src/openclaw-types.ts
+++ b/apps/credence-pi/openclaw-plugin/src/openclaw-types.ts
@@ -108,6 +108,21 @@ export interface OpenClawPluginApi {
   // This plugin's resolved config (validated against openclaw.plugin.json).
   pluginConfig?: Record<string, unknown>;
 
+  // Cleanup hooks run on reset/delete/reload paths
+  // (OpenClaw src/plugins/host-hooks.ts PluginRuntimeLifecycleRegistration).
+  // Optional so the plugin still loads on hosts that predate it.
+  lifecycle?: {
+    registerRuntimeLifecycle: (registration: {
+      id: string;
+      description?: string;
+      cleanup?: (ctx: {
+        reason?: string;
+        sessionKey?: string;
+        runId?: string;
+      }) => void | Promise<void>;
+    }) => void;
+  };
+
   on(
     hook: "before_tool_call",
     handler: HookHandler<BeforeToolCallEvent, BeforeToolCallResult>,

--- a/apps/credence-pi/openclaw-plugin/src/openclaw-types.ts
+++ b/apps/credence-pi/openclaw-plugin/src/openclaw-types.ts
@@ -1,0 +1,143 @@
+// openclaw-types.ts — minimal local declarations of the OpenClaw plugin
+// API surface this body consumes.
+//
+// Sourced from OpenClaw (HEAD 36a596aa9f, 2026-06-02):
+//   - src/plugins/types.ts          (OpenClawPluginApi, api.on)
+//   - src/plugins/hook-types.ts     (before_tool_call / after_tool_call /
+//                                     llm_output events + results)
+//
+// We declare ONLY what we consume so the plugin builds standalone with no
+// @openclaw/openclaw dependency — mirroring the dependency-free pattern of
+// apps/openclaw-plugin/ (which used `api: any`). At runtime OpenClaw calls
+// register(api) with the real, fully-typed api; these declarations are our
+// compile-time view. If the host surface drifts, the runtime still works;
+// only this file needs occasional resync. Keep it narrow.
+
+export type PluginApprovalResolution =
+  | "allow-once"
+  | "allow-always"
+  | "deny"
+  | "timeout"
+  | "cancelled";
+
+export interface RequireApprovalPayload {
+  title: string;
+  description: string;
+  severity?: "info" | "warning" | "critical";
+  timeoutMs?: number;
+  timeoutBehavior?: "allow" | "deny";
+  allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
+  pluginId?: string;
+  onResolution?: (decision: PluginApprovalResolution) => Promise<void> | void;
+}
+
+export interface BeforeToolCallEvent {
+  toolName: string;
+  params: Record<string, unknown>;
+  toolKind?: string;
+  toolInputKind?: string;
+  runId?: string;
+  toolCallId?: string;
+  derivedPaths?: readonly string[];
+}
+
+export interface BeforeToolCallResult {
+  params?: Record<string, unknown>;
+  block?: boolean;
+  blockReason?: string;
+  requireApproval?: RequireApprovalPayload;
+}
+
+export interface AfterToolCallEvent {
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+}
+
+export interface LlmUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+}
+
+export interface LlmOutputEvent {
+  runId?: string;
+  sessionId?: string;
+  provider?: string;
+  model?: string;
+  resolvedRef?: string;
+  usage?: LlmUsage;
+}
+
+export interface ToolContext {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+  toolName?: string;
+  toolCallId?: string;
+  channelId?: string;
+  workspaceDir?: string;
+}
+
+export interface PluginLogger {
+  info?: (msg: string) => void;
+  warn?: (msg: string) => void;
+  error?: (msg: string) => void;
+}
+
+export type HookHandler<E, R = void> = (
+  event: E,
+  ctx: ToolContext,
+) => Promise<R | void> | R | void;
+
+export interface HookOpts {
+  priority?: number;
+  timeoutMs?: number;
+}
+
+export interface OpenClawPluginApi {
+  id?: string;
+  logger?: PluginLogger;
+  // This plugin's resolved config (validated against openclaw.plugin.json).
+  pluginConfig?: Record<string, unknown>;
+
+  on(
+    hook: "before_tool_call",
+    handler: HookHandler<BeforeToolCallEvent, BeforeToolCallResult>,
+    opts?: HookOpts,
+  ): void;
+  on(
+    hook: "after_tool_call",
+    handler: HookHandler<AfterToolCallEvent, void>,
+    opts?: HookOpts,
+  ): void;
+  on(
+    hook: "llm_output",
+    handler: HookHandler<LlmOutputEvent, void>,
+    opts?: HookOpts,
+  ): void;
+  // Catch-all for hooks we register opportunistically (e.g. agent_end);
+  // typed loosely on purpose.
+  on(
+    hook: string,
+    handler: (...args: unknown[]) => unknown,
+    opts?: HookOpts,
+  ): void;
+}
+
+// The default export shape OpenClaw loads. apps/openclaw-plugin/ exported a
+// bare object literal of this shape (works via compat); we do the same to
+// stay dependency-free (no `definePluginEntry` import from the host).
+export interface PluginEntry {
+  id: string;
+  name: string;
+  description?: string;
+  register: (api: OpenClawPluginApi) => void | Promise<void>;
+}

--- a/apps/credence-pi/openclaw-plugin/tests/cost.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/cost.test.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeTurnCost, buildPriceTable } from "../src/cost.js";
+import type { LlmOutputEvent } from "../src/openclaw-types.js";
+
+test("known model reconstructs USD from token counts (opus: 15 in / 75 out per Mtok)", () => {
+  const table = buildPriceTable(undefined);
+  const ev: LlmOutputEvent = {
+    model: "claude-opus-4-8",
+    usage: { input: 1_000_000, output: 1_000_000 },
+  };
+  const tc = computeTurnCost(ev, table);
+  assert.equal(tc.usd, 90); // 15 + 75
+  assert.equal(tc.total_tokens, 2_000_000);
+  assert.equal(tc.model, "claude-opus-4-8");
+});
+
+test("family substring match (sonnet) prices a versioned id", () => {
+  const table = buildPriceTable(undefined);
+  const tc = computeTurnCost(
+    { model: "claude-sonnet-4-6-20250101", usage: { input: 1_000_000, output: 0 } },
+    table,
+  );
+  assert.equal(tc.usd, 3); // sonnet input 3 / Mtok
+});
+
+test("unknown model → usd null, token counts preserved", () => {
+  const table = buildPriceTable(undefined);
+  const tc = computeTurnCost(
+    { model: "mystery-model-x", usage: { input: 100, output: 50, total: 150 } },
+    table,
+  );
+  assert.equal(tc.usd, null);
+  assert.equal(tc.total_tokens, 150);
+  assert.equal(tc.input_tokens, 100);
+});
+
+test("config override prices an otherwise-unknown model", () => {
+  const table = buildPriceTable({ "mystery-model-x": { input: 1, output: 2 } });
+  const tc = computeTurnCost(
+    { model: "mystery-model-x", usage: { input: 1_000_000, output: 1_000_000 } },
+    table,
+  );
+  assert.equal(tc.usd, 3); // 1 + 2
+});
+
+test("missing usage → zero tokens, usd 0 for a priced model", () => {
+  const table = buildPriceTable(undefined);
+  const tc = computeTurnCost({ model: "claude-haiku-4-5" }, table);
+  assert.equal(tc.total_tokens, 0);
+  assert.equal(tc.usd, 0);
+});

--- a/apps/credence-pi/openclaw-plugin/tests/features.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/features.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { FeatureTracker } from "../src/features.js";
+import type { BeforeToolCallEvent, ToolContext } from "../src/openclaw-types.js";
+
+const ctx = (over: Partial<ToolContext> = {}): ToolContext => ({
+  runId: "r1",
+  sessionId: "s1",
+  ...over,
+});
+const ev = (
+  toolName: string,
+  over: Partial<BeforeToolCallEvent> = {},
+): BeforeToolCallEvent => ({ toolName, params: {}, ...over });
+
+test("tool-name buckets known tools verbatim and unknowns to other", () => {
+  const t = new FeatureTracker();
+  assert.equal(t.extractAndRecord(ev("bash"), ctx(), 1000)["tool-name"], "bash");
+  assert.equal(t.extractAndRecord(ev("WeirdTool"), ctx(), 1000)["tool-name"], "other");
+});
+
+test("parent-tool-call-name and recent-repetition-count come from per-run history", () => {
+  const t = new FeatureTracker();
+  const c = ctx({ runId: "rep" });
+  let f = t.extractAndRecord(ev("bash"), c, 1000);
+  assert.equal(f["parent-tool-call-name"], "none");
+  assert.equal(f["recent-repetition-count"], "rep-0");
+  f = t.extractAndRecord(ev("bash"), c, 1001);
+  assert.equal(f["parent-tool-call-name"], "bash");
+  assert.equal(f["recent-repetition-count"], "rep-1");
+  f = t.extractAndRecord(ev("bash"), c, 1002);
+  assert.equal(f["recent-repetition-count"], "rep-2");
+  f = t.extractAndRecord(ev("bash"), c, 1003);
+  assert.equal(f["recent-repetition-count"], "rep-3plus");
+});
+
+test("repetition is per-run-isolated", () => {
+  const t = new FeatureTracker();
+  t.extractAndRecord(ev("bash"), ctx({ runId: "a" }), 1);
+  const f = t.extractAndRecord(ev("bash"), ctx({ runId: "b" }), 1);
+  assert.equal(f["recent-repetition-count"], "rep-0");
+  assert.equal(f["parent-tool-call-name"], "none");
+});
+
+test("time-since-last-user-message bucketing (with injected clock)", () => {
+  const t = new FeatureTracker();
+  const c = ctx({ runId: "time" });
+  assert.equal(
+    t.extractAndRecord(ev("bash"), c, 10_000)["time-since-last-user-message"],
+    "gt-10m",
+  );
+  t.markUserMessage(c, 10_000);
+  const at = (ms: number) =>
+    t.extractAndRecord(ev("bash"), c, 10_000 + ms)["time-since-last-user-message"];
+  assert.equal(at(10_000), "lt-30s");
+  assert.equal(at(60_000), "lt-2m");
+  assert.equal(at(300_000), "lt-10m");
+  assert.equal(at(1_200_000), "gt-10m");
+});
+
+test("working-directory-relative classifies against workspaceDir", () => {
+  const t = new FeatureTracker();
+  const c = ctx({ runId: "wd", workspaceDir: "/home/u/proj" });
+  assert.equal(
+    t.extractAndRecord(ev("bash"), c, 1)["working-directory-relative"],
+    "no-path",
+  );
+  assert.equal(
+    t.extractAndRecord(ev("edit", { derivedPaths: ["/home/u/proj/src/a.ts"] }), c, 2)[
+      "working-directory-relative"
+    ],
+    "subdirectory",
+  );
+  assert.equal(
+    t.extractAndRecord(ev("read", { derivedPaths: ["/etc/passwd"] }), c, 3)[
+      "working-directory-relative"
+    ],
+    "outside-project",
+  );
+  assert.equal(
+    t.extractAndRecord(ev("ls", { derivedPaths: ["/home/u/proj"] }), c, 4)[
+      "working-directory-relative"
+    ],
+    "project-root",
+  );
+});

--- a/apps/credence-pi/openclaw-plugin/tests/index.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/index.test.ts
@@ -1,0 +1,173 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { createGovernor } from "../src/index.js";
+import { buildPriceTable } from "../src/cost.js";
+import type { DaemonClient, SignalEnvelope } from "../src/daemon-client.js";
+import type { BeforeToolCallEvent, ToolContext } from "../src/openclaw-types.js";
+
+// Let queued microtasks + the post round-trip settle.
+const flush = () => new Promise((r) => setTimeout(r, 5));
+
+type Posted = Record<string, unknown>;
+
+function harness(postOk = true) {
+  const posted: Posted[] = [];
+  let onSignal: ((s: SignalEnvelope) => void) | undefined;
+  let closed = false;
+  const client: DaemonClient = {
+    postSensor: async (e) => {
+      posted.push(e as Posted);
+      return { ok: postOk };
+    },
+    connectSignalsStream: (cb) => {
+      onSignal = cb;
+      return {
+        close: () => {
+          closed = true;
+        },
+        done: Promise.resolve(),
+      };
+    },
+  };
+  const gov = createGovernor(client, {
+    hookTimeoutMs: 50,
+    approvalTimeoutMs: 5_000,
+    priceTable: buildPriceTable(undefined),
+    redactToolInputs: false,
+    log: () => {},
+  });
+  const find = (t: string) => posted.find((e) => e.event_type === t);
+  return {
+    gov,
+    posted,
+    find,
+    closed: () => closed,
+    signal: (effector: string, eventId: string, parameters: Record<string, unknown> = {}) =>
+      onSignal?.({
+        signal_type: "effector",
+        signal_id: "s",
+        in_response_to: eventId,
+        effector,
+        parameters,
+      }),
+    lastProposedId: () =>
+      [...posted].reverse().find((e) => e.event_type === "tool-proposed")
+        ?.event_id as string,
+  };
+}
+
+const ev = (
+  toolName = "bash",
+  over: Partial<BeforeToolCallEvent> = {},
+): BeforeToolCallEvent => ({ toolName, params: { command: "x" }, ...over });
+const ctx: ToolContext = { runId: "r1", sessionId: "s1" };
+
+test("before_tool_call: proceed → allow (undefined), no awaiter leak", async () => {
+  const h = harness();
+  const p = h.gov.beforeToolCall(ev(), ctx);
+  await flush();
+  assert.equal(h.gov.pendingCount(), 1);
+  h.signal("proceed", h.lastProposedId());
+  assert.equal(await p, undefined);
+  assert.equal(h.gov.pendingCount(), 0);
+  h.gov.cleanup();
+});
+
+test("before_tool_call: block → {block, blockReason}", async () => {
+  const h = harness();
+  const p = h.gov.beforeToolCall(ev(), ctx);
+  await flush();
+  h.signal("block", h.lastProposedId(), { reason: "runaway loop" });
+  const r = await p;
+  assert.equal(r?.block, true);
+  assert.match(r?.blockReason ?? "", /runaway loop/);
+  h.gov.cleanup();
+});
+
+test("before_tool_call: ask → requireApproval; onResolution posts user-responded", async () => {
+  const h = harness();
+  const p = h.gov.beforeToolCall(ev(), ctx);
+  await flush();
+  const eid = h.lastProposedId();
+  h.signal("ask", eid, { text: "Allow?" });
+  const r = await p;
+  assert.ok(r?.requireApproval);
+  await r.requireApproval.onResolution?.("deny");
+  const ur = h.find("user-responded");
+  assert.equal(ur?.response, "no");
+  assert.equal(ur?.in_response_to, eid);
+  h.gov.cleanup();
+});
+
+test("before_tool_call: daemon timeout → fail-open, awaiter cleaned up", async () => {
+  const h = harness();
+  const r = await h.gov.beforeToolCall(ev(), ctx); // no signal; times out at 50ms
+  assert.equal(r, undefined);
+  assert.equal(h.gov.pendingCount(), 0);
+  h.gov.cleanup();
+});
+
+test("before_tool_call: postSensor failure → fail-open immediately, no leak", async () => {
+  const h = harness(false);
+  const r = await h.gov.beforeToolCall(ev(), ctx);
+  assert.equal(r, undefined);
+  assert.equal(h.gov.pendingCount(), 0);
+  h.gov.cleanup();
+});
+
+test("redactToolInputs: tool input omitted from the sensor event", async () => {
+  const posted: Posted[] = [];
+  const client: DaemonClient = {
+    postSensor: async (e) => {
+      posted.push(e as Posted);
+      return { ok: true };
+    },
+    connectSignalsStream: () => ({ close: () => {}, done: Promise.resolve() }),
+  };
+  const gov = createGovernor(client, {
+    hookTimeoutMs: 20,
+    approvalTimeoutMs: 5_000,
+    priceTable: buildPriceTable(undefined),
+    redactToolInputs: true,
+    log: () => {},
+  });
+  await gov.beforeToolCall(ev("bash", { params: { command: "secret-token-123" } }), ctx);
+  const tp = posted.find((e) => e.event_type === "tool-proposed") as
+    | { proposed_call: { tool_name: string; input: unknown } }
+    | undefined;
+  assert.equal(tp?.proposed_call.input, null);
+  assert.equal(tp?.proposed_call.tool_name, "bash");
+  gov.cleanup();
+});
+
+test("after_tool_call: posts tool-completed correlated by toolCallId", async () => {
+  const h = harness();
+  await h.gov.afterToolCall({ toolName: "bash", toolCallId: "tc1", params: {}, durationMs: 12 }, ctx);
+  const tc = h.find("tool-completed") as
+    | { in_response_to: string; outcome: { success: boolean; duration_ms: number } }
+    | undefined;
+  assert.equal(tc?.in_response_to, "tc1");
+  assert.equal(tc?.outcome.success, true);
+  assert.equal(tc?.outcome.duration_ms, 12);
+  h.gov.cleanup();
+});
+
+test("llm_output: posts turn-cost with reconstructed USD", async () => {
+  const h = harness();
+  await h.gov.llmOutput(
+    { model: "claude-opus-4-8", usage: { input: 1_000_000, output: 1_000_000 } },
+    ctx,
+  );
+  const t = h.find("turn-cost") as { usd: number; total_tokens: number } | undefined;
+  assert.equal(t?.usd, 90);
+  assert.equal(t?.total_tokens, 2_000_000);
+  h.gov.cleanup();
+});
+
+test("cleanup: closes the SSE stream", () => {
+  const h = harness();
+  assert.equal(h.closed(), false);
+  h.gov.cleanup();
+  assert.equal(h.closed(), true);
+});

--- a/apps/credence-pi/openclaw-plugin/tests/mapping.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/mapping.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { mapSignal } from "../src/index.js";
+import type { DaemonClient, SignalEnvelope } from "../src/daemon-client.js";
+
+function fakeClient(posted: Record<string, unknown>[]): DaemonClient {
+  return {
+    postSensor: async (e) => {
+      posted.push(e as Record<string, unknown>);
+      return { ok: true };
+    },
+    connectSignalsStream: () => ({ close: () => {}, done: Promise.resolve() }),
+  };
+}
+
+const sig = (
+  effector: string,
+  parameters: Record<string, unknown> = {},
+): SignalEnvelope => ({
+  signal_type: "effector",
+  signal_id: "s1",
+  in_response_to: "evt_1",
+  effector,
+  parameters,
+});
+
+test("proceed signal → undefined (allow)", () => {
+  assert.equal(mapSignal(sig("proceed"), "evt_1", fakeClient([]), 1000), undefined);
+});
+
+test("no signal (daemon timeout) → undefined (fail-open)", () => {
+  assert.equal(mapSignal(undefined, "evt_1", fakeClient([]), 1000), undefined);
+});
+
+test("unknown effector → undefined (fail-open)", () => {
+  assert.equal(mapSignal(sig("substitute"), "evt_1", fakeClient([]), 1000), undefined);
+});
+
+test("block signal → {block:true, blockReason carrying the reason}", () => {
+  const r = mapSignal(sig("block", { reason: "runaway loop" }), "evt_1", fakeClient([]), 1000);
+  assert.equal(r?.block, true);
+  assert.match(r?.blockReason ?? "", /runaway loop/);
+});
+
+test("ask signal → requireApproval, and onResolution posts mapped user-responded", async () => {
+  const posted: Record<string, unknown>[] = [];
+  const r = mapSignal(sig("ask", { text: "Allow bash rm -rf?" }), "evt_1", fakeClient(posted), 5000);
+  assert.ok(r?.requireApproval, "ask must yield requireApproval");
+  assert.equal(r.requireApproval.description, "Allow bash rm -rf?");
+  assert.equal(r.requireApproval.timeoutBehavior, "deny");
+  assert.equal(r.requireApproval.timeoutMs, 5000);
+  assert.deepEqual(r.requireApproval.allowedDecisions, ["allow-once", "allow-always", "deny"]);
+
+  await r.requireApproval.onResolution?.("allow-once");
+  await r.requireApproval.onResolution?.("allow-always");
+  await r.requireApproval.onResolution?.("deny");
+  await r.requireApproval.onResolution?.("timeout");
+
+  assert.equal(posted.length, 4);
+  assert.equal(posted[0].event_type, "user-responded");
+  assert.equal(posted[0].in_response_to, "evt_1");
+  assert.deepEqual(
+    posted.map((p) => p.response),
+    ["yes", "yes", "no", "timeout"],
+  );
+});

--- a/apps/credence-pi/openclaw-plugin/tsconfig.json
+++ b/apps/credence-pi/openclaw-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/credence-pi/savings.jl
+++ b/apps/credence-pi/savings.jl
@@ -1,0 +1,191 @@
+# Role: brain (reporting — display-only, non-causal)
+"""
+    savings.jl — the dollars-saved surface for credence-pi.
+
+Reads the append-only observation log and produces a human-facing
+governance + spend report: total LLM spend, how many tool calls the
+agent proposed, how many credence-pi asked about, how many the user then
+denied (stopping that work), and an explicitly-bounded estimate of the
+spend those denials avoided.
+
+DISPLAY-ONLY / NON-CAUSAL. This module summarises what already happened;
+its arithmetic never feeds a decision or a belief update, so it sits
+outside Invariant 1's scope (the constitution's "display formatting,
+diagnostic telemetry … out of scope" carve-out). It calls neither
+`condition` nor `expect`; it is reporting/IO over already-logged values.
+
+Honesty notes baked into the report:
+  - Cost is per-TURN, not per-tool-call (pi exposes no per-tool usage), so
+    "prevented spend" is an ESTIMATE: denied-calls x average-turn-cost. It
+    is labelled as such, never presented as a guaranteed figure.
+  - The log records inbound sensor events, not the brain's effector
+    signals, so the unambiguous governance signal is "asked -> user
+    responded yes/no". proceed/block without an ask are not distinguished
+    here (a Phase-2 enhancement would log decisions).
+"""
+module Savings
+
+include(joinpath(@__DIR__, "daemon", "observation_log.jl"))
+using .ObservationLog: read_log
+
+export savings_report, format_report
+
+"""
+    savings_report(path) -> NamedTuple
+
+Compute the governance + spend tallies from the observation log at
+`path`. Pure over the file contents; returns a NamedTuple of counts and
+(clearly-labelled) estimates. Empty/missing log yields an all-zero report.
+"""
+function savings_report(path::AbstractString)
+    records = read_log(path)
+
+    sessions = Set{String}()
+    n_by_type = Dict{String, Int}()
+    first_at = ""
+    last_at = ""
+
+    # spend
+    total_usd = 0.0
+    priced_turns = 0
+    total_tokens = 0
+    n_turns = 0
+
+    # governance correlation
+    proposed_tool = Dict{String, String}()   # tool-proposed event_id -> tool name
+    responses = Dict{String, String}()        # in_response_to -> response
+    decisions = Dict{String, Int}()           # brain decision action -> count
+    n_completed = 0
+
+    for r in records
+        ev = r.event
+        et = string(get(ev, "event_type", ""))
+        n_by_type[et] = get(n_by_type, et, 0) + 1
+        sid = get(ev, "session_id", nothing)
+        sid === nothing || push!(sessions, string(sid))
+        ra = r.received_at
+        if !isempty(ra)
+            isempty(first_at) && (first_at = ra)
+            last_at = ra
+        end
+
+        if et == "turn-cost"
+            n_turns += 1
+            usd = get(ev, "usd", nothing)
+            if usd isa Number
+                total_usd += float(usd)
+                priced_turns += 1
+            end
+            tok = get(ev, "total_tokens", nothing)
+            tok isa Number && (total_tokens += Int(round(tok)))
+        elseif et == "tool-proposed"
+            eid = string(get(ev, "event_id", ""))
+            pc = get(ev, "proposed_call", nothing)
+            tool = pc === nothing ? "(unknown)" : string(get(pc, "tool_name", "(unknown)"))
+            proposed_tool[eid] = tool
+        elseif et == "user-responded"
+            irt = string(get(ev, "in_response_to", ""))
+            responses[irt] = string(get(ev, "response", ""))
+        elseif et == "tool-completed"
+            n_completed += 1
+        elseif et == "decision"
+            act = string(get(ev, "action", ""))
+            decisions[act] = get(decisions, act, 0) + 1
+        end
+    end
+
+    n_proposed = length(proposed_tool)
+    asked_ids = [eid for eid in keys(proposed_tool) if haskey(responses, eid)]
+    n_asked = length(asked_ids)
+    n_approved = count(eid -> responses[eid] == "yes", asked_ids)
+    n_denied = count(eid -> responses[eid] == "no", asked_ids)
+    n_timeout = count(eid -> responses[eid] == "timeout", asked_ids)
+    denied_tools = sort([proposed_tool[eid] for eid in asked_ids if responses[eid] == "no"])
+
+    avg_usd_per_turn = priced_turns == 0 ? 0.0 : total_usd / priced_turns
+
+    # Brain decisions (one "decision" record per emitted effector signal).
+    # These count the silent auto-blocks / auto-proceeds the user-response
+    # view misses — every `block` prevented a tool call from running.
+    n_block = get(decisions, "block", 0)
+    n_proceed = get(decisions, "proceed", 0)
+    n_ask = get(decisions, "ask", 0)
+    prevented_calls = n_block
+
+    # ESTIMATE only — see module docstring. Per-turn cost (pi exposes no
+    # per-tool cost), so avoided spend ~ prevented calls x average turn cost.
+    estimated_prevented_usd = prevented_calls * avg_usd_per_turn
+
+    return (
+        total_events = length(records),
+        sessions = length(sessions),
+        first_at = first_at,
+        last_at = last_at,
+        events_by_type = n_by_type,
+        total_usd = total_usd,
+        priced_turns = priced_turns,
+        turns = n_turns,
+        total_tokens = total_tokens,
+        avg_usd_per_turn = avg_usd_per_turn,
+        tool_calls_proposed = n_proposed,
+        decided_block = n_block,
+        decided_proceed = n_proceed,
+        decided_ask = n_ask,
+        prevented_calls = prevented_calls,
+        asked = n_asked,
+        approved = n_approved,
+        denied = n_denied,
+        timed_out = n_timeout,
+        completed = n_completed,
+        denied_tools = denied_tools,
+        estimated_prevented_usd = estimated_prevented_usd,
+    )
+end
+
+_usd(x) = string("\$", string(round(x; digits=4)))
+
+"""
+    format_report(io, report)
+
+Pretty-print a `savings_report` NamedTuple. Human-facing; the estimate is
+labelled as an estimate.
+"""
+function format_report(io::IO, r)
+    println(io, "=" ^ 60)
+    println(io, "credence-pi — governance & spend report")
+    println(io, "=" ^ 60)
+    if r.total_events == 0
+        println(io, "No observations yet. Deploy the plugin and run some sessions.")
+        return
+    end
+    println(io, "Window:        $(r.first_at)  ->  $(r.last_at)")
+    println(io, "Sessions:      $(r.sessions)")
+    println(io, "Events:        $(r.total_events)  $(r.events_by_type)")
+    println(io)
+    println(io, "Spend observed (per-turn LLM cost):")
+    println(io, "  turns priced:  $(r.priced_turns) / $(r.turns)")
+    println(io, "  total:         $(_usd(r.total_usd))   ($(r.total_tokens) tokens)")
+    println(io, "  avg / turn:    $(_usd(r.avg_usd_per_turn))")
+    println(io)
+    println(io, "Governance (brain decisions):")
+    println(io, "  tool calls proposed: $(r.tool_calls_proposed)")
+    println(io, "  proceed:             $(r.decided_proceed)")
+    println(io, "  blocked:             $(r.decided_block)")
+    println(io, "  asked:               $(r.decided_ask)   (user approved $(r.approved), denied $(r.denied), timed-out $(r.timed_out))")
+    println(io, "  completed (ran):     $(r.completed)")
+    if !isempty(r.denied_tools)
+        println(io, "  user-denied tools:   ", join(r.denied_tools, ", "))
+    end
+    println(io)
+    println(io, "Estimated prevented spend (blocked calls x avg turn cost):")
+    println(io, "  ~ $(_usd(r.estimated_prevented_usd))   [ESTIMATE — cost is per-turn, not per-tool; see savings.jl]")
+    println(io, "=" ^ 60)
+end
+
+# CLI: julia apps/credence-pi/savings.jl [log-path]
+if abspath(PROGRAM_FILE) == @__FILE__
+    path = length(ARGS) >= 1 ? ARGS[1] : joinpath(homedir(), ".credence-pi", "observations.jsonl")
+    format_report(stdout, savings_report(path))
+end
+
+end # module Savings

--- a/apps/credence-pi/tests/julia/test_savings.jl
+++ b/apps/credence-pi/tests/julia/test_savings.jl
@@ -1,0 +1,91 @@
+#!/usr/bin/env julia
+# Role: tests
+"""
+    test_savings.jl — the dollars-saved surface (display-only reporting).
+
+Builds a synthetic observation log and asserts savings_report's tallies:
+spend (per-turn cost), governance (asked / approved / denied), and the
+explicitly-bounded prevented-spend estimate. Also checks the empty-log
+case and that the rendered report carries the ESTIMATE caveat.
+"""
+
+include(joinpath(@__DIR__, "..", "..", "savings.jl"))
+using .Savings: savings_report, format_report
+
+const PASSED = String[]
+ok(name) = (push!(PASSED, name); println("PASSED: ", name))
+
+let path = tempname() * ".jsonl"
+    A = Savings.ObservationLog.append_event!
+    # Two priced turns: $0.10 (1000 tok) + $0.30 (3000 tok); avg $0.20.
+    A(path, Dict("event_type" => "turn-cost", "session_id" => "s1", "usd" => 0.10, "total_tokens" => 1000))
+    A(path, Dict("event_type" => "turn-cost", "session_id" => "s1", "usd" => 0.30, "total_tokens" => 3000))
+    # Three proposed tool calls, with the "decision" records the daemon
+    # emits alongside each effector signal:
+    #   e1: ask -> user denies -> followup block   (a prevented call)
+    #   e2: ask -> user approves -> followup proceed -> completed
+    #   e3: auto-block, no ask                       (a prevented call)
+    A(path, Dict("event_type" => "tool-proposed", "event_id" => "e1", "session_id" => "s1",
+                 "proposed_call" => Dict("tool_name" => "bash")))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "e1", "action" => "ask"))
+    A(path, Dict("event_type" => "user-responded", "in_response_to" => "e1", "response" => "no"))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "e1", "action" => "block"))
+
+    A(path, Dict("event_type" => "tool-proposed", "event_id" => "e2", "session_id" => "s1",
+                 "proposed_call" => Dict("tool_name" => "bash")))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "e2", "action" => "ask"))
+    A(path, Dict("event_type" => "user-responded", "in_response_to" => "e2", "response" => "yes"))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "e2", "action" => "proceed"))
+    A(path, Dict("event_type" => "tool-completed", "event_id" => "c1", "in_response_to" => "e2"))
+
+    A(path, Dict("event_type" => "tool-proposed", "event_id" => "e3", "session_id" => "s1",
+                 "proposed_call" => Dict("tool_name" => "read")))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "e3", "action" => "block"))
+
+    r = savings_report(path)
+    @assert r.total_events == 13
+    @assert r.sessions == 1
+    @assert r.priced_turns == 2
+    @assert isapprox(r.total_usd, 0.40; atol = 1e-12)
+    @assert r.total_tokens == 4000
+    @assert isapprox(r.avg_usd_per_turn, 0.20; atol = 1e-12)
+    @assert r.tool_calls_proposed == 3
+    @assert r.decided_ask == 2
+    @assert r.decided_block == 2      # e1 followup block + e3 auto-block
+    @assert r.decided_proceed == 1
+    @assert r.prevented_calls == 2
+    @assert r.asked == 2
+    @assert r.approved == 1
+    @assert r.denied == 1
+    @assert r.completed == 1
+    @assert r.denied_tools == ["bash"]
+    # 2 blocked calls * $0.20 avg turn = $0.40 estimated prevented.
+    @assert isapprox(r.estimated_prevented_usd, 0.40; atol = 1e-12)
+    ok("savings_report tallies spend, brain decisions (incl. silent auto-blocks), and the prevented estimate")
+
+    io = IOBuffer()
+    format_report(io, r)
+    s = String(take!(io))
+    @assert occursin("ESTIMATE", s)
+    @assert occursin("credence-pi", s)
+    ok("format_report renders the report with the estimate caveat")
+
+    rm(path)
+end
+
+let path = tempname() * ".jsonl"  # never created
+    r = savings_report(path)
+    @assert r.total_events == 0
+    @assert r.total_usd == 0.0
+    @assert r.denied == 0
+    io = IOBuffer()
+    format_report(io, r)
+    @assert occursin("No observations yet", String(take!(io)))
+    ok("savings_report on a missing/empty log yields an all-zero report")
+    isfile(path) && rm(path)
+end
+
+println()
+println("=" ^ 60)
+println("ALL ", length(PASSED), " ASSERTIONS PASSED")
+println("=" ^ 60)

--- a/apps/credence-pi/tests/julia/test_server.jl
+++ b/apps/credence-pi/tests/julia/test_server.jl
@@ -231,6 +231,42 @@ let path = tempname() * ".jsonl"
     rm(path)
 end
 
+# ── 4b. handle_sensor_event: turn-cost is log-only ─────────────────────
+#
+# Move 1 (Pass 2): the OpenClaw-plugin body emits per-turn token/USD
+# cost via its llm_output hook. The daemon logs it (for the dollars-
+# saved surface and the cost-denominated utility, both Move 2) but does
+# NOT condition the posterior and emits NO signal — exactly like
+# tool-completed.
+
+let path = tempname() * ".jsonl"
+    state = fresh_state(; tmp_log=path)
+    before = expect(state.posterior[], Identity())
+
+    turn_cost = Dict{String, Any}(
+        "event_type"   => "turn-cost",
+        "event_id"     => "evt_tc1",
+        "session_id"   => "test",
+        "usd"          => 0.0123,
+        "total_tokens" => 1500,
+        "model"        => "claude-opus-4-8",
+    )
+    ack = handle_sensor_event(state, turn_cost)
+    @assert ack["ack"] == true && ack["event_id"] == "evt_tc1"
+    @assert isempty(snapshot(state.signal_queue))
+    @assert isapprox(expect(state.posterior[], Identity()), before; atol=TOL)
+    ok("turn-cost: log-only, no signal emitted, posterior unchanged")
+
+    records = Server.ObservationLog.read_log(path)
+    @assert length(records) == 1
+    @assert records[1].event["event_type"] == "turn-cost"
+    @assert records[1].event["usd"] == 0.0123
+    @assert records[1].event["total_tokens"] == 1500
+    ok("turn-cost: logged with cost fields intact for the Move-2 dollars-saved surface")
+
+    rm(path)
+end
+
 # ── 5. End-to-end: HTTP /sensor + SSE /signals ─────────────────────────
 #
 # Spin up a real HTTP server on an ephemeral port, open an SSE

--- a/apps/credence-pi/tests/julia/test_server.jl
+++ b/apps/credence-pi/tests/julia/test_server.jl
@@ -222,11 +222,15 @@ let path = tempname() * ".jsonl"
     @assert isapprox(expect(state.posterior[], Identity()), 3.0 / 5.0; atol=TOL)
     ok("tool-completed: log-only, no signal emitted, posterior unchanged")
 
-    # Verify log accumulated all three events.
+    # Verify log accumulated all events in order — including the "decision"
+    # records emit_signal! writes alongside each effector signal (for the
+    # dollars-saved surface; replay ignores them).
     records = Server.ObservationLog.read_log(path)
     @assert [r.event["event_type"] for r in records] ==
-            ["tool-proposed", "user-responded", "tool-completed"]
-    ok("handle_sensor_event flow appends log entries in order")
+            ["tool-proposed", "decision", "user-responded", "decision", "tool-completed"]
+    @assert records[2].event["action"] == "ask"
+    @assert records[4].event["action"] == "proceed"
+    ok("handle_sensor_event flow appends sensor + decision log entries in order")
 
     rm(path)
 end

--- a/docs/credence-pi-pass-2/move-1-design.md
+++ b/docs/credence-pi-pass-2/move-1-design.md
@@ -1,0 +1,136 @@
+# credence-pi Pass 2 — Move 1 design: OpenClaw-plugin body (MVP-0, deploy-first)
+
+> Per `docs/posture-3/DESIGN-DOC-TEMPLATE.md`. This is the FORCED deploy-first move (the
+> observation dataset is empty). It ships the installable product that begins accumulating data
+> **and** the cost signal. Brain (daemon + BDSL) is reused; the new code is a body + a small
+> daemon cost-ingestion branch.
+
+## Purpose
+
+Make credence-pi a real, installable **OpenClaw plugin** that governs tool calls on the user's own
+OpenClaw sessions, talking to the existing credence-pi Julia daemon, and deploy it to accumulate
+(a) governance observations and (b) the per-turn dollar-cost signal. The MVP brain stays the Pass-1
+single-Beta `ask`/`proceed`/`block` (`voi`-gated) — deliberately simple to ship fast; the
+cost-denominated halting utility is Move 2.
+
+## OQ1 — RESOLVED (binding reality)
+
+OpenClaw forked pi's coding-agent in-tree and runs its gateway agent with `noExtensions: true`; a pi
+`ExtensionFactory` is inert inside OpenClaw. The supported interception point is an **OpenClaw plugin
+`before_tool_call` hook** (`~/git/openclaw/src/plugins/hook-types.ts:516-564`). So MVP-0's body is an
+OpenClaw plugin (this move); the existing pi-shaped `apps/credence-pi/extension/` stays as the
+**secondary pi-direct body** (untouched here). Two bodies, one brain.
+
+## Architecture — reuse the async wire, don't change it
+
+credence-pi's daemon wire is **POST `/sensor` (ack-only) + GET `/signals` (SSE, correlated by
+`event_id`)** — unchanged. `before_tool_call` is async, so the plugin:
+
+1. on `before_tool_call`: build a `tool-proposed` sensor event (features + `toolCallId`), POST to
+   `/sensor`, and **await** the correlated effector signal off the SSE stream (with a bounded
+   timeout = the hook's `timeoutMs`); map the signal to the hook result.
+2. on `after_tool_call`: POST `tool-completed` (`result`/`error`/`durationMs` — all provided by
+   OpenClaw here).
+3. on `llm_output`: compute per-turn USD via `calculateCost(model, usage)` (from
+   `openclaw/plugin-sdk/llm`) and POST a new `turn-cost` sensor event.
+4. `ask` → `requireApproval`: the plugin returns `{requireApproval:{…, onResolution}}`; OpenClaw's
+   native UI **enforces** the decision; `onResolution(decision)` POSTs `user-responded` so the brain
+   **conditions** (learns). The daemon's `followup-after-response` proceed/block signal is redundant
+   for OpenClaw (OpenClaw already enforced) and is harmlessly dropped (no awaiter) — see OQ-c.
+
+This reuses `extension/src/client.ts` (SSE+POST, fail-open, reconnect) **verbatim** and the awaiter /
+event_id correlation pattern from `extension/src/index.ts` (adapted off the pi hooks onto the
+OpenClaw hooks).
+
+### Decision mapping (daemon effector signal → `before_tool_call` result)
+
+| daemon signal `effector` | `before_tool_call` result |
+|---|---|
+| `proceed` | `undefined` (allow) |
+| `block` | `{ block: true, blockReason: <reason> }` |
+| `ask` | `{ requireApproval: { title, description, severity:"warning", timeoutMs, timeoutBehavior:"deny", allowedDecisions:["allow-once","allow-always","deny"], onResolution } }` |
+| (timeout / daemon unreachable) | `undefined` (fail-open) |
+
+`onResolution(decision)` maps `allow-once`/`allow-always`→`yes`, `deny`→`no`,
+`timeout`/`cancelled`→`timeout`, and POSTs `user-responded`.
+
+### Cost reconstruction (the money signal)
+
+Per-turn USD is not handed to plugins. From `llm_output` `{model, usage:{input,output,cacheRead,
+cacheWrite,total}}`, the plugin calls `calculateCost(model, usage)` (SDK-exported;
+`Model.cost` is $/M tokens) to get USD, and POSTs `turn-cost`. **Requires
+`plugins.entries.<id>.hooks.allowConversationAccess: true`** for `llm_output` — documented in the
+install steps. If `model` can't be resolved or cost is 0 (custom/OAuth providers), emit token counts
+with `usd: null` (Move 2's surface handles the token×price fallback).
+
+### Feature extraction (the 5 declared features, OpenClaw-shaped)
+
+`before_tool_call` event/ctx + a plugin-maintained buffer keyed by `runId`/`sessionKey`
+(`api.runContext` or an in-memory ring):
+
+| feature | source |
+|---|---|
+| `tool-name` | `event.toolName` (bucketed to the declared finite set) |
+| `working-directory-relative` | `workspaceDir` captured from an agent-context hook (`before_agent_start`/`llm_output`) or `api.config`, vs the tool's path args |
+| `parent-tool-call-name` | last tool in the per-run history buffer |
+| `recent-repetition-count` | count of same-tool entries in the recent buffer (the prior-art `recentHistory` pattern) |
+| `time-since-last-user-message` | `Date.now()` minus a timestamp stamped on `message_received`/`session_start` |
+
+Correlation key for `tool-completed` is the stable **`toolCallId`** (OpenClaw runs tools in
+parallel) — not toolName.
+
+## Files
+
+New body `apps/credence-pi/openclaw-plugin/` (distinct from the legacy sidecar `apps/openclaw-plugin/`):
+- `package.json` — `@openclaw/plugin-sdk` dep, `"openclaw"` block (`runtimeExtensions: ["./dist/index.js"]`, `compat`), build emit (tsc → dist).
+- `openclaw.plugin.json` — manifest (`id: "credence-pi"`, `activation.onStartup:true`, strict `configSchema`: `daemonUrl`, `hookTimeoutMs`).
+- `tsconfig.json`.
+- `src/index.ts` — `definePluginEntry({ id, name, register })`; wires the four hooks; awaiter/correlation core (adapted from the pi extension); decision mapping.
+- `src/daemon-client.ts` — re-export/adapt `extension/src/client.ts` (SSE+POST). Prefer importing the shared client; if cross-package import is awkward, vendor a copy with a shared-source note.
+- `src/features.ts` — buffer-based extractors producing the declared kebab-case values.
+- `src/cost.ts` — `llm_output` → `calculateCost` → `turn-cost` payload.
+- `README.md` — install/run (`openclaw plugins install -l`, `allowConversationAccess:true`, gateway restart, daemon start).
+- `tests/` — mapping + features + cost reconstruction + fail-open (Node test runner, mirroring the pi extension's tests).
+
+Brain (small):
+- `apps/credence-pi/daemon/server.jl` — add `elseif event_type == "turn-cost"` (log-only for Move 1; `append_event!` already logs-first, so this just makes intent explicit and suppresses the unknown-type `@warn`). No signal, no posterior change.
+- `apps/credence-pi/tests/julia/test_server.jl` (or test_observation_log.jl) — assert `turn-cost` is logged and emits **no** signal.
+- `apps/credence-pi/SPEC.md` — document the `turn-cost` sensor event in the wire schema.
+
+## Behaviour preserved
+
+Daemon wire unchanged; Pass-1 brain (`decide-action`/`observe-response`/`followup-after-response`)
+unchanged; fail-open everywhere (daemon down ⇒ tool proceeds, one warning); **zero production-side
+lint pragmas**; the pi extension body untouched.
+
+## Worked end-to-end example
+
+OpenClaw agent proposes `bash rm -rf build/` → `before_tool_call` fires → plugin extracts features,
+POSTs `tool-proposed` (event_id=evt_x, toolCallId=tc_1) → daemon logs it, runs `decide-action` on
+the Beta(2,2) posterior; `voi(ask) > EU(proceed)=EU(block)=0` at cold-start → emits `ask` signal
+(in_response_to=evt_x) → plugin's SSE awaiter resolves → returns `{requireApproval{…, onResolution}}`
+→ OpenClaw shows the approval dialog → user picks `deny` → OpenClaw blocks the tool; `onResolution`
+POSTs `user-responded`(no) → daemon conditions posterior toward refuse. Tool didn't run; brain
+learned. (Daemon down at step 2 ⇒ plugin fails open, tool proceeds, one warning.)
+
+## Open design questions
+
+- **OQ-a (turn-cost schema):** fields = `{event_type:"turn-cost", event_id, session_id, timestamp, usd:number|null, total_tokens, input_tokens, output_tokens, cache_read, cache_write, model}`. Confirm this is what Move 2's surface needs; keep it generic.
+- **OQ-b (shared client):** import `extension/src/client.ts` across the two body packages vs vendor a copy. Lean: shared import if the workspace allows; else vendored copy with a `// shared-source:` note and a test that both stay in sync.
+- **OQ-c (redundant followup):** the daemon emits a proceed/block followup on `user-responded` that OpenClaw doesn't need (it enforced via requireApproval). Harmless drop in Move 1; a body-type flag could suppress it later. Acceptable now.
+- **OQ-d (cwd reliability):** `workspaceDir` isn't on the tool ctx; capture from an agent-context hook or `api.config`. Confirm the most reliable source at implementation.
+
+## Risk + mitigation
+
+- **Scope/version:** the plugin imports `@openclaw/plugin-sdk` types only (NOT pi packages), so the `@mariozechner`↔`@earendil-works` split doesn't bite here. Pin `compat.minGatewayVersion` to current.
+- **`allowConversationAccess`:** without it, `llm_output` is blocked for non-bundled plugins ⇒ no cost signal. Documented as a required config step; degrade gracefully (governance still works; cost just absent) if unset.
+- **Hook latency:** the daemon round-trip is in the agent's critical path. Set the hook `timeoutMs` (e.g. 2–5s) so a slow/dead daemon fails open fast.
+- **Parallel tools:** correlate by `toolCallId`, never toolName.
+- **Prior-art drift:** `after_tool_call.userApproval` no longer exists — use `requireApproval.onResolution`. Replace `api:any` with typed SDK + `definePluginEntry`.
+
+## Verification
+
+- `cd apps/credence-pi/openclaw-plugin && npm install && npm run build && npm test` (TS body).
+- `julia apps/credence-pi/tests/julia/test_server.jl` (turn-cost logged, no signal).
+- `python3 tools/credence-lint/credence_lint.py --repo-root . check apps/credence-pi/` → zero violations.
+- **Manual deploy gate:** `openclaw plugins install -l apps/credence-pi/openclaw-plugin`, set `allowConversationAccess:true`, start the daemon, restart the gateway, run a real session, confirm `~/.credence-pi/observations.jsonl` accumulates `tool-proposed`/`tool-completed`/`turn-cost` and that an `ask` surfaces an approval dialog.

--- a/docs/credence-pi-pass-2/move-2-design.md
+++ b/docs/credence-pi-pass-2/move-2-design.md
@@ -1,0 +1,66 @@
+# credence-pi Pass 2 — Move 2 design: the dollars-saved surface + demo
+
+> Per `docs/posture-3/DESIGN-DOC-TEMPLATE.md`. Completes the MVP (Moves 0–2 + demo) — the
+> user/VC-facing "return you can see." Product-first; the cost-denominated *decision* utility and
+> feature-conditioned learning are Phase 2 (data-gated — see §"Deferred").
+
+## Purpose
+
+Turn the data Move 1 accumulates into a human-facing **governance + spend report** ("$ saved"), and
+ship a **reproducible demo** that shows the product mechanic end-to-end on the real brain — without
+needing a live OpenClaw or real data.
+
+## What this lands
+
+1. **Decision logging (daemon).** `emit_signal!` now writes a `decision` record
+   (`{event_type:"decision", in_response_to, action}`) to the observation log alongside every
+   effector signal. **Why:** the log previously held only inbound sensor events, so *silent
+   auto-blocks/auto-proceeds* (no `user-responded`) were invisible — the savings surface undercounted
+   prevented spend ~10× (the demo proved it: 1 counted vs 10 actual). Decision records are **derived**
+   (replay reconstructs them from the posterior), so `replay_user_responses` ignores them and replay
+   correctness is unaffected. Documented in SPEC.md.
+2. **The dollars-saved surface** (`apps/credence-pi/savings.jl`). Reads the observation log and
+   reports: total per-turn spend + tokens, brain decisions (proceed/block/ask), user
+   approvals/denials, and an **explicitly-bounded** prevented-spend estimate
+   (`blocked_calls × avg_turn_cost`). **Display-only / non-causal** — its arithmetic never feeds a
+   decision or belief, so it is outside Invariant 1's scope (the "diagnostic telemetry" carve-out);
+   it calls neither `condition` nor `expect`. Lint-clean.
+3. **Reproducible demo** (`apps/credence-pi/demo/governance_demo.jl`). Drives the real daemon
+   dispatcher on a synthetic session: the agent repeats a wasteful `bash` call → the brain asks → the
+   user denies → the global approval posterior concentrates → the brain **auto-blocks by EU
+   maximisation** (no hard-coded rule) → the savings report shows the caught spend (~$1.20 across 10
+   turns). Output is the user/VC artifact.
+
+## Honesty (baked into the report + demo framing)
+
+- **Cost is per-turn, not per-tool** (pi exposes no per-tool usage) → prevented spend is an
+  ESTIMATE (`blocked × avg-turn-cost`), labelled as such, never a guaranteed figure.
+- **Pass-1 brain is a single GLOBAL approval posterior.** The demo learns this user's tool-approval
+  rate; it does **not** detect loops per-context. The honest claim is "governs, learns from you,
+  auto-blocks when confident, reports caught spend" — not "loop detection" (that is Phase 2).
+- The demo prints these caveats inline.
+
+## Files
+
+`apps/credence-pi/daemon/server.jl` (decision logging in `emit_signal!`); `apps/credence-pi/savings.jl`
+(new, display-only); `apps/credence-pi/demo/governance_demo.jl` (new); `apps/credence-pi/tests/julia/test_savings.jl`
+(new); `apps/credence-pi/tests/julia/test_server.jl` (decision-logging assertion);
+`apps/credence-pi/SPEC.md` (`decision` record + earlier `turn-cost`).
+
+## Verification
+
+`julia apps/credence-pi/tests/julia/test_server.jl` (22/22, incl. decision logging);
+`test_savings.jl` (3/3, incl. silent auto-block counting); `governance_demo.jl` (shows ask→auto-block,
+~$1.20 caught); credence-lint clean (9 files, 0 violations).
+
+## Deferred to Phase 2 (data-gated — NOT forced on hypothetical data)
+
+- **Cost-denominated *decision* utility** (replace decide.bdsl's symmetric ±1 with a dollar utility).
+  Genuine cost-aware halting needs a per-call cost estimate at decision time + a value model; the cost
+  signal is per-turn and arrives after the call, so this wants accumulated data to estimate per-context
+  cost. The demo already shows EU-optimal blocking from learned approval; dollar-denomination refines
+  *when* it blocks.
+- **Feature-conditioned learning / CEG** (loop-*detection*), outcome conditioning, calibration eval —
+  all need the real n=1 observation log the deployed plugin produces. Per the brief, designing these
+  on hypothetical data is the trap to avoid. **The unlock is the user deploying Move 1** (runbook in
+  the plugin README) and accumulating sessions.


### PR DESCRIPTION
The credence-pi **product MVP**: an installable OpenClaw plugin that lets the credence-pi Bayesian brain govern a real pi/OpenClaw agent loop, learn from the user, auto-block wasteful calls, and report the **dollars caught** — built product-first per the agreed priority (users/VCs first; the academic/calibration track is non-gating Phase 2).

## What's in it (Moves 0–2 + demo)
- **Move 0** — Pass-2 master plan (already merged, #109).
- **Move 1 — installable OpenClaw-plugin body** (`apps/credence-pi/openclaw-plugin/`): `before_tool_call` → daemon → allow / `{block}` / `requireApproval` (OpenClaw enforces the ask; `onResolution` posts the reply so the brain learns); `after_tool_call` → outcome; `llm_output` → per-turn cost (reconstructed from token counts × a config price table). Reuses credence-pi's async daemon wire unchanged; dependency-free; fail-open. Brain/BDSL untouched (opaque-brain payoff: new body, same brain). + daemon `turn-cost` ingestion + CI.
- **Move 2 — the "dollars saved" surface** (`savings.jl`, display-only) over the observation log, plus **decision logging** in the daemon so silent auto-blocks are counted honestly, plus a **reproducible demo** (`demo/governance_demo.jl`).

## Demo (real brain, synthetic session, no live OpenClaw needed)
The agent repeats a wasteful call → brain asks → user denies → posterior concentrates → brain **auto-blocks by EU maximisation** → report shows **~$1.20 caught across 10 turns**. `julia --project=. apps/credence-pi/demo/governance_demo.jl`.

## Verification
- Plugin: tsc build clean; **15/15** TS unit tests (mapping, features, cost).
- Daemon: **22/22** Julia assertions (incl. decision logging). Savings: **3/3** (incl. silent auto-block counting).
- credence-lint clean (zero production pragmas).

## Honesty / scope
- Cost is **per-turn** (pi exposes no per-tool cost) → prevented spend is a clearly-labelled ESTIMATE.
- The Pass-1 brain learns a **global** approval rate — honest "governs/learns/auto-blocks/reports," not loop-*detection*.
- **User-gated (the deploy-first end state):** deploying to a live OpenClaw + accumulating real n=1 data is the operator step (runbook in the plugin README). **Phase 2** (cost-denominated decision utility, feature-conditioned/CEG learning, calibration) is deliberately *not* built on hypothetical data — it unlocks once real sessions accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)