### PR TITLE
qa_benchmark: deploy posterior-weighted credit (post), close #111

### DIFF
--- a/apps/julia/qa_benchmark/README.md
+++ b/apps/julia/qa_benchmark/README.md
@@ -330,7 +330,33 @@ julia apps/julia/qa_benchmark/host.jl --seeds 2
 
 # Ablation (Bayesian variants only)
 julia apps/julia/qa_benchmark/host.jl --seeds 20 --ablation
+
+# Inferred-category credit rule (issue #111). Default is :post
+# (posterior-weighted). Use :soft to reproduce the paper's committed B2c numbers.
+julia apps/julia/qa_benchmark/host.jl --seeds 20 --credit soft
 ```
+
+### Inferred-category credit rule (`--credit`, issue #111)
+
+Under *inferred* categories the classifier gives a soft posterior `π` over a
+question's category, and after a tool answers, its per-category reliability
+`θ_{t,c}` must be credited across the uncertain categories. Two rules
+(`apps/julia/qa_benchmark/category_update.jl`):
+
+| `--credit` | rule | credit weight |
+|-----------|------|---------------|
+| `post` (default) | posterior-weighted (deployed) | `ρ_c ∝ π_c · ℓ_{t,c}(outcome)` — the exact one-step category posterior |
+| `soft` | soft-credit (B2c) | `π_c` — the classifier prior; the outcome likelihood is ignored |
+
+`post` credits the category where the tool is *reliable*, not the misclassified
+one; it strictly dominates `soft`. Both route every belief change through
+`condition` (the category posterior `ρ` is itself a `condition` on the
+categorical prior — no host-side Bayes). **Both are mean-field projections of
+the intractable exact joint** (the latent category is shared across tools and
+the decision, so the exact posterior is a mixture over ~`K^#questions` global
+assignments); `post` is the better tractable projection, not the exact update —
+see the `category_update.jl` file docstring. **Paper 1's committed numbers use
+`soft`**; reproduce them with `--credit soft`.
 
 ---
 

--- a/apps/julia/qa_benchmark/category_update.jl
+++ b/apps/julia/qa_benchmark/category_update.jl
@@ -10,16 +10,37 @@ marginalise over π:
 - `marginal_reliability(row, π)` — the category-marginalised reliability
   belief for the decision side: a `MixturePrevision` over the per-category
   Betas weighted by π, fed to the existing `eu`/`voi`/`expect`.
-- `update_reliability(row, π, outcome)` — the resource-rational update:
-  credit *every* category by its posterior weight via the
-  `WeightedBernoulli` conjugate `condition`
-  (`α_{t,c} += π_c·correct, β_{t,c} += π_c·wrong`). Uses the whole
-  posterior (not MAP); reduces *exactly* to the unit-count update when π
+- `update_reliability(row, π, outcome)` — *soft-credit* (B2c): credit every
+  category by the classifier weight `π_c` via the `WeightedBernoulli`
+  conjugate `condition` (`α_{t,c} += π_c·correct, β_{t,c} += π_c·wrong`).
+  `π` is the *prior* for the credit step — it ignores the outcome's
+  likelihood. Reduces *exactly* to the unit-count update when π is one-hot.
+- `post_update(row, π, outcome)` — *posterior-weighted credit* (issue #111,
+  the deployed default): credit by the one-step category posterior
+  `ρ_c ∝ π_c·ℓ_{t,c}(outcome)` instead of the prior `π_c`, so a correct
+  answer credits the category where the tool is reliable, not the
+  misclassified one. Both the category posterior `ρ`
+  (`posterior_credit_weights`) and the per-category Beta updates go through
+  `condition` — no host arithmetic. Strictly dominates soft (which discards
+  the likelihood); reduces to soft, hence to the unit-count update, when π
   is one-hot.
 
+DECLARED APPROXIMATION (no-silent-approximation rule). The exact joint
+latent-category update does NOT factorise over tools: each question's
+category is a latent shared across every tool queried on it and the
+decision, so the exact posterior over `{θ_{t,c}}` is a mixture over global
+category assignments (~K^#questions) — intractable. `soft` and `post` are
+both mean-field / assumed-density projections; they differ only in the
+credit weight. `post`'s category posterior `ρ` is *exact one-step*, but the
+per-category reliability collapse (the fractional pseudo-count update)
+projects the exact 2-component mixture
+`ρ_c·Beta(α+o,β+1-o) + (1-ρ_c)·Beta(α,β)` back onto a single Beta. The
+principled extension — retain k mixture components and choose k by EU-max
+over accuracy-vs-compute (metareasoned fidelity) — is out of scope here.
+
 `row` is a tool's reliability row `[θ_{t,c} for c]::Vector{BetaPrevision}`;
-`π` is the category posterior (same length). Pure functions — no embedding
-dependency; the host supplies π from the classifier (wired in B3/B4).
+`π` is the classifier's category posterior (same length). Pure functions —
+no embedding dependency; the host supplies π from the classifier.
 """
 
 using Credence
@@ -39,10 +60,12 @@ const WEIGHTED_RELIABILITY_KERNEL = Kernel(
 """
     update_reliability(row, π, outcome) -> Vector{BetaPrevision}
 
-Full-posterior-weighted reliability update. `outcome ∈ {0,1}` (1 = tool
-correct). Each category's Beta is conditioned on the same outcome with
-weight `π_c`, via `WeightedBernoulli`. One-hot π reduces exactly to the
-unit-count update.
+Soft-credit reliability update (B2c). `outcome ∈ {0,1}` (1 = tool correct).
+Each category's Beta is conditioned on the same outcome with weight `π_c`
+(the classifier prior — the outcome likelihood is NOT used), via
+`WeightedBernoulli`. One-hot π reduces exactly to the unit-count update.
+`post_update` is the deployed default (issue #111); pass these weights as a
+posterior `ρ` and this becomes the posterior-weighted update.
 """
 function update_reliability(row::Vector{BetaPrevision}, π::Vector{Float64}, outcome)
     length(row) == length(π) ||
@@ -51,6 +74,61 @@ function update_reliability(row::Vector{BetaPrevision}, π::Vector{Float64}, out
     BetaPrevision[
         condition(row[c], WEIGHTED_RELIABILITY_KERNEL, (o, π[c])) for c in eachindex(row)
     ]
+end
+
+# Category-belief kernel for the posterior credit step. Source = category
+# index space (0-based, aligned to `CATEGORIES`); target = the binary
+# correctness outcome. For category `c` the per-outcome log-likelihood uses
+# the queried tool's predictive correctness `m_c = E[θ_{t,c}]` (`o=1`) or
+# `1 - m_c` (`o=0`). Conditioning the classifier prior π on the observed
+# outcome through this kernel is the exact one-step category posterior —
+# the Bayes step lives in `condition`, not in host arithmetic.
+# `rel_means[Int(c)+1]` maps the 0-based space value to the 1-based vector.
+function category_belief_kernel(rel_means::Vector{Float64})
+    Kernel(
+        Finite(collect(0:length(rel_means) - 1)),
+        Finite([0, 1]),
+        c -> error("category_belief_kernel.generate not exercised (categorical condition path)"),
+        (c, o) -> (Float64(o) == 1.0 ? log(rel_means[Int(c) + 1]) :
+                                       log(1.0 - rel_means[Int(c) + 1]));
+        likelihood_family = Flat(),
+    )
+end
+
+"""
+    posterior_credit_weights(row, π, outcome) -> Vector{Float64}
+
+The exact one-step category posterior `ρ` given the observed `outcome ∈
+{0,1}` from a tool whose per-category reliability beliefs are `row`:
+`ρ_c ∝ π_c · ℓ_{t,c}(outcome)`, computed by conditioning the categorical
+prior π (via `condition`) — never by host-side Bayes. The predictive
+likelihood `ℓ_{t,c}` reads `mean(row[c])` (the sanctioned accessor); for
+Beta–Bernoulli the predictive correctness probability IS the mean, so this
+likelihood is exact. One-hot π returns one-hot ρ.
+"""
+function posterior_credit_weights(row::Vector{BetaPrevision}, π::Vector{Float64}, outcome)
+    length(row) == length(π) ||
+        error("posterior_credit_weights: row length $(length(row)) ≠ π length $(length(π))")
+    means = Float64[mean(row[c]) for c in eachindex(row)]
+    prior = CategoricalMeasure(Finite(collect(0:length(π) - 1)), log.(π))
+    post = condition(prior, category_belief_kernel(means), Float64(outcome))
+    weights(post)
+end
+
+"""
+    post_update(row, π, outcome) -> Vector{BetaPrevision}
+
+Posterior-weighted reliability update (issue #111, the deployed default).
+Credits each category by the one-step category posterior
+`ρ_c ∝ π_c·ℓ_{t,c}(outcome)` instead of the classifier prior `π_c` — see the
+file-level docstring for the declared-approximation statement (both soft and
+post are mean-field projections of the intractable joint; post is the better
+projection). Reduces to `update_reliability` (hence to the unit-count update)
+when π is one-hot.
+"""
+function post_update(row::Vector{BetaPrevision}, π::Vector{Float64}, outcome)
+    ρ = posterior_credit_weights(row, π, outcome)
+    update_reliability(row, ρ, outcome)
 end
 
 """

--- a/apps/julia/qa_benchmark/host.jl
+++ b/apps/julia/qa_benchmark/host.jl
@@ -81,15 +81,20 @@ function run_bayesian_seed(tools::Vector{SimulatedTool},
                            use_voi::Bool=true, learn::Bool=true,
                            allow_abstain::Bool=true, greedy::Bool=false,
                            category_posteriors::Union{Nothing,Dict{String,Vector{Float64}}}=nothing,
+                           credit::Symbol=:post,
                            init_reliability::Union{Nothing,AbstractMatrix}=nothing)
     n_tools = length(tools)
     n_cats = length(CATEGORIES)
+    credit in (:post, :soft) ||
+        error("run_bayesian_seed: credit must be :post or :soft, got :$credit")
 
     # When `category_posteriors` is supplied (id → soft posterior over
     # CATEGORIES), the agent runs under *inferred* categories (Paper 1 fair
     # conditions): decisions marginalise reliability over the posterior and
-    # learning is the full-posterior-weighted update (B2c). Otherwise it
-    # uses the given category (one-hot) — the v1 path, bit-for-bit.
+    # learning is the posterior-weighted update (`credit=:post`, the deployed
+    # default; issue #111) or the soft-credit B2c update (`credit=:soft`, the
+    # paper's committed numbers). Otherwise it uses the given category
+    # (one-hot) — the v1 path, bit-for-bit, unaffected by `credit`.
     inferred = category_posteriors !== nothing
 
     # init_reliability seeds the per-(tool,category) reliability beliefs. With
@@ -234,9 +239,12 @@ function run_bayesian_seed(tools::Vector{SimulatedTool},
         # Reliability learning (skip if learn=false)
         if learn
             if inferred
-                # Full-posterior-weighted update across all categories (B2c).
+                # Posterior-weighted (`:post`, issue #111) or soft-credit
+                # (`:soft`, B2c) update across all categories. Both route every
+                # belief change through `condition` (no host-side Bayes).
+                credit_update = credit === :soft ? update_reliability : post_update
                 for (t, resp) in tool_responses
-                    rel_betas[t, :] = update_reliability(
+                    rel_betas[t, :] = credit_update(
                         rel_betas[t, :], π, resp == q.correct_index ? 1 : 0)
                 end
             else
@@ -410,6 +418,7 @@ function parse_args()
     llm_only = false
     ablation = false
     models = String[]
+    credit = :post   # inferred-category credit rule (issue #111); :soft repro's the paper
     for (i, arg) in enumerate(ARGS)
         if arg == "--include-llm"
             include_llm = true
@@ -426,10 +435,16 @@ function parse_args()
             push!(models, split(arg, "=")[2])
         elseif arg == "--ablation"
             ablation = true
+        elseif arg == "--credit" && i < length(ARGS)
+            credit = Symbol(ARGS[i + 1])
+        elseif startswith(arg, "--credit=")
+            credit = Symbol(split(arg, "=")[2])
         end
     end
+    credit in (:post, :soft) ||
+        error("--credit must be 'post' (default) or 'soft' (paper repro), got '$credit'")
     if isempty(models); models = ["llama3.1"]; end
-    (; n_seeds, include_llm, llm_only, ablation, models)
+    (; n_seeds, include_llm, llm_only, ablation, models, credit)
 end
 
 # --- Main ---
@@ -453,6 +468,10 @@ function main()
     cat_post = isfile(joinpath(FIXTURE_DIR, "question_embeddings.json")) ?
         category_posteriors_from_fixture() : nothing
     cat_post === nothing && println(stderr, "  (no embedding fixture — skipping bayesian_inferred)")
+    cat_post !== nothing && println(stderr,
+        "  inferred-category credit rule: :$(args.credit)" *
+        (args.credit === :soft ? " (B2c — reproduces the paper's committed numbers)" :
+                                 " (posterior-weighted, issue #111 default; --credit soft for paper repro)"))
     for seed in 0:args.n_seeds-1
         rng = MersenneTwister(seed)
         questions = get_questions(; seed)
@@ -475,13 +494,13 @@ function main()
             # Pareto. The LLM agents (raw question text, no category) are reused
             # from the saved DB — see docs/paper1 B4.
             push!(agents, ("bayesian_inferred",
-                () -> run_bayesian_seed(tools, questions, response_table; category_posteriors=cat_post)))
+                () -> run_bayesian_seed(tools, questions, response_table; category_posteriors=cat_post, credit=args.credit)))
             push!(agents, ("greedy_inferred",
-                () -> run_bayesian_seed(tools, questions, response_table; greedy=true, category_posteriors=cat_post)))
+                () -> run_bayesian_seed(tools, questions, response_table; greedy=true, category_posteriors=cat_post, credit=args.credit)))
             push!(agents, ("no_voi_inferred",
-                () -> run_bayesian_seed(tools, questions, response_table; use_voi=false, category_posteriors=cat_post)))
+                () -> run_bayesian_seed(tools, questions, response_table; use_voi=false, category_posteriors=cat_post, credit=args.credit)))
             push!(agents, ("no_learning_inferred",
-                () -> run_bayesian_seed(tools, questions, response_table; learn=false, category_posteriors=cat_post)))
+                () -> run_bayesian_seed(tools, questions, response_table; learn=false, category_posteriors=cat_post, credit=args.credit)))
         end
         for (name, runner) in agents
             result = runner()

--- a/test/test_qa_benchmark_inferred_host.jl
+++ b/test/test_qa_benchmark_inferred_host.jl
@@ -53,6 +53,30 @@ check("inferred path: deterministic (==)", i1.total_score == i2.total_score,
       "$(i1.total_score) vs $(i2.total_score)")
 check("inferred path: finite score", isfinite(i1.total_score))
 
+# Issue #111 — credit rule wiring. The inferred default is :post
+# (posterior-weighted); :soft reproduces the paper's committed B2c numbers.
+# Both route every belief change through `condition`. (We do NOT assert
+# post ≠ soft per-seed: the credit rule changes the learning trajectory but
+# can land on the same submit decisions on a given seed — the strict
+# post-beats-soft guarantee is the unit test's closer-to-exact-mixture check.)
+ipost = run_bayesian_seed(tools, questions, rt; category_posteriors=cp, credit=:post)
+isoft = run_bayesian_seed(tools, questions, rt; category_posteriors=cp, credit=:soft)
+check("inferred default credit is :post (== explicit :post)",
+      i1.total_score == ipost.total_score, "$(i1.total_score) vs $(ipost.total_score)")
+check(":soft path: 50 records, finite score",
+      length(isoft.records) == 50 && isfinite(isoft.total_score))
+check(":soft deterministic (==)", isoft.total_score ==
+      run_bayesian_seed(tools, questions, rt; category_posteriors=cp, credit=:soft).total_score)
+check("invalid credit rule rejected",
+      try
+          run_bayesian_seed(tools, questions, rt; category_posteriors=cp, credit=:bogus)
+          false
+      catch
+          true
+      end)
+
 println("="^60)
-println("HOST WIRING OK — given=$(round(g1.total_score, digits=1)) inferred=$(round(i1.total_score, digits=1))")
+println("HOST WIRING OK — given=$(round(g1.total_score, digits=1)) " *
+        "inferred[post]=$(round(ipost.total_score, digits=1)) " *
+        "inferred[soft]=$(round(isoft.total_score, digits=1))")
 println("="^60)

--- a/test/test_qa_benchmark_post_credit.jl
+++ b/test/test_qa_benchmark_post_credit.jl
@@ -1,0 +1,140 @@
+# test_qa_benchmark_post_credit.jl — issue #111.
+#
+# Tests the posterior-weighted reliability update (the deployed default)
+# in `apps/julia/qa_benchmark/category_update.jl`: `post_update` and its
+# `posterior_credit_weights` (the exact one-step category posterior ρ).
+#
+# `post` credits each category by ρ_c ∝ π_c·ℓ_{t,c}(outcome) instead of the
+# classifier prior π_c (`soft`/B2c). Both ρ and the per-category Beta
+# updates go through `condition` — no host-side Bayes.
+#
+# Key guards: (1) ρ via `condition` equals the closed-form π·ℓ/normaliser;
+# (2) one-hot π reduces `post` EXACTLY (`==`) to the soft / unit-count
+# update; (3) `post` lands STRICTLY closer to the exact 2-component mixture
+# than `soft` (the better-projection claim — the whole point of #111);
+# (4) the fractional (α,β) are exact; (5) determinism; (6) a zero-prior
+# category (−Inf log-weight) is handled and stays zero.
+#
+# Run from the repo root:
+#     julia test/test_qa_benchmark_post_credit.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: BetaPrevision
+
+include(joinpath(@__DIR__, "..", "apps", "julia", "qa_benchmark", "category_update.jl"))
+
+const _PASS = Ref(0)
+function check(name, cond, detail="")
+    if cond
+        _PASS[] += 1
+        println("PASSED: $name")
+    else
+        println("FAILED: $name — $detail")
+        error("post_credit assertion failed: $name")
+    end
+end
+
+# Clean Beta mean via the BetaMeasure view (no raw field read).
+betamean(p::BetaPrevision) = mean(wrap_in_measure(p))
+
+println("="^60)
+println("Issue #111 — posterior-weighted credit (post_update)")
+println("="^60)
+
+# Shared oracle case (matches test_qa_benchmark_category_update.jl Test 3):
+# row = [Beta(2,3), Beta(1,1)], π = [0.7, 0.3], observe CORRECT (o=1).
+# Predictive likelihoods ℓ_c(1) = mean(row[c]) = [0.4, 0.5].
+# ρ ∝ π·ℓ = [0.7·0.4, 0.3·0.5] = [0.28, 0.15]  →  ρ = [0.28,0.15]/0.43.
+const ROW = [BetaPrevision(2.0, 3.0), BetaPrevision(1.0, 1.0)]
+const Π   = [0.7, 0.3]
+const ΡEXACT = [0.28, 0.15] ./ 0.43
+
+# ── Test 1: ρ via `condition` equals the closed-form category posterior ──
+let
+    ρ = posterior_credit_weights(ROW, Π, 1)
+    check("ρ (correct) == π·ℓ/normaliser, ℓ=mean (rtol 1e-12)",
+          isapprox(ρ, ΡEXACT; rtol=1e-12), "got $ρ vs $ΡEXACT")
+    check("ρ sums to 1 (rtol 1e-12)", isapprox(sum(ρ), 1.0; rtol=1e-12), "got $(sum(ρ))")
+
+    # Wrong outcome: ℓ_c(0) = 1 - mean = [0.6, 0.5]; ρ ∝ [0.42, 0.15].
+    ρw = posterior_credit_weights(ROW, Π, 0)
+    check("ρ (wrong) == π·(1-mean)/normaliser (rtol 1e-12)",
+          isapprox(ρw, [0.42, 0.15] ./ 0.57; rtol=1e-12), "got $ρw")
+end
+
+# ── Test 2: one-hot π reduces post EXACTLY to soft / unit-count update ──
+let
+    for (oh, o) in (([1.0, 0.0], 1), ([1.0, 0.0], 0), ([0.0, 1.0], 1))
+        p = post_update(ROW, oh, o)
+        s = update_reliability(ROW, oh, o)
+        check("one-hot $oh o=$o: post == soft (==)",
+              all(i -> p[i].alpha == s[i].alpha && p[i].beta == s[i].beta, eachindex(p)),
+              "post=$(p) soft=$(s)")
+    end
+    # And that one-hot is the literal unit-count update on the certain category.
+    p = post_update(ROW, [1.0, 0.0], 1)
+    check("one-hot correct: cat1 Beta(2,3)→Beta(3,3), cat2 untouched (==)",
+          p[1].alpha == 3.0 && p[1].beta == 3.0 &&
+          p[2].alpha == 1.0 && p[2].beta == 1.0, "got $p")
+end
+
+# ── Test 3: post is STRICTLY closer to the exact mixture than soft ──
+# Exact posterior marginal mean of θ₁ after the correct observation (the
+# 2-component mixture ρ collapses): component c=1 (weight ρ₁) → Beta(3,3),
+# mean 0.5; component c=2 (weight ρ₂) → Beta(2,3), mean 0.4.
+let
+    exact = ΡEXACT[1] * 0.5 + ΡEXACT[2] * 0.4            # 0.46512 closed-form
+    post = post_update(ROW, Π, 1)
+    soft = update_reliability(ROW, Π, 1)
+    dpost = abs(betamean(post[1]) - exact)
+    dsoft = abs(betamean(soft[1]) - exact)
+    check("post mean θ₁ closer to exact mixture than soft (strict)",
+          dpost < dsoft, "dpost=$dpost dsoft=$dsoft exact=$exact")
+end
+
+# ── Test 4: exact fractional (α,β) — post credits with ρ, not π ──
+let
+    post = post_update(ROW, Π, 1)                        # correct → α gets ρ
+    check("post correct: cat1 α 2→2+ρ₁, cat2 α 1→1+ρ₂ (rtol 1e-12)",
+          isapprox(post[1].alpha, 2.0 + ΡEXACT[1]; rtol=1e-12) && post[1].beta == 3.0 &&
+          isapprox(post[2].alpha, 1.0 + ΡEXACT[2]; rtol=1e-12) && post[2].beta == 1.0,
+          "got ($(post[1].alpha),$(post[1].beta)),($(post[2].alpha),$(post[2].beta))")
+
+    ρw = [0.42, 0.15] ./ 0.57
+    postw = post_update(ROW, Π, 0)                       # wrong → β gets ρ
+    check("post wrong: cat1 β 3→3+ρ₁, cat2 β 1→1+ρ₂ (rtol 1e-12)",
+          postw[1].alpha == 2.0 && isapprox(postw[1].beta, 3.0 + ρw[1]; rtol=1e-12) &&
+          postw[2].alpha == 1.0 && isapprox(postw[2].beta, 1.0 + ρw[2]; rtol=1e-12),
+          "got ($(postw[1].alpha),$(postw[1].beta)),($(postw[2].alpha),$(postw[2].beta))")
+
+    # Definitional consistency: post == update_reliability(row, ρ, o).
+    ρ = posterior_credit_weights(ROW, Π, 1)
+    viaρ = update_reliability(ROW, ρ, 1)
+    check("post_update ≡ update_reliability(row, ρ, o) (==)",
+          all(i -> post[i].alpha == viaρ[i].alpha && post[i].beta == viaρ[i].beta, eachindex(post)))
+end
+
+# ── Test 5: determinism ──
+let
+    a = post_update(ROW, [0.6, 0.4], 1)
+    b = post_update(ROW, [0.6, 0.4], 1)
+    check("determinism: identical (α,β) across calls (==)",
+          all(i -> a[i].alpha == b[i].alpha && a[i].beta == b[i].beta, eachindex(a)))
+end
+
+# ── Test 6: a zero-prior category (−Inf log-weight) stays zero ──
+let
+    row3 = [BetaPrevision(2.0, 3.0), BetaPrevision(1.0, 1.0), BetaPrevision(4.0, 1.0)]
+    ρ = posterior_credit_weights(row3, [0.7, 0.0, 0.3], 1)
+    check("zero-prior category gets ρ=0 (==)", ρ[2] == 0.0, "got ρ=$ρ")
+    check("ρ still normalised over the surviving categories (rtol 1e-12)",
+          isapprox(sum(ρ), 1.0; rtol=1e-12), "got $(sum(ρ))")
+    p = post_update(row3, [0.7, 0.0, 0.3], 1)
+    check("zero-prior category Beta untouched (==)",
+          p[2].alpha == 1.0 && p[2].beta == 1.0, "got $(p[2])")
+end
+
+println("="^60)
+println("ALL $(_PASS[]) CHECKS PASSED (post-credit / issue #111)")
+println("="^60)


### PR DESCRIPTION
Closes #111.

## What

Replaces the deployed inferred-category reliability update (B2c soft-credit, which credits every category by the classifier **prior** `π_c` and ignores the outcome likelihood) with **posterior-weighted credit** as the default:

```
ρ_c ∝ π_c · ℓ_{t,c}(outcome)     (ℓ = predictive mean E[θ_{t,c}], exact for Beta–Bernoulli)
```

A correct answer now credits the category where the tool is reliable, not the misclassified one.

## How (constitution-clean — two `condition` calls, no host-side Bayes)

1. **Category posterior `ρ`** — `condition` the categorical prior `π` on the observed outcome through a new `category_belief_kernel` (per-category success prob = the sanctioned `mean(row[c])`). The Bayes step lives in `condition`, not in host arithmetic.
2. **Reliability update** — the existing `WeightedBernoulli` `update_reliability`, with `ρ` instead of `π`.

So **issue point 3 resolves to: no new conjugate path** — `post` reuses `WeightedBernoulli` with a posterior weight; the only new machinery is the categorical-condition step.

## Honest framing (issue point 1 — the disclosure)

The issue called `post` "the proper/exact update." It isn't, and the code now says so. The exact joint latent-category update **does not factorise over tools** (each question's category is a latent shared across every queried tool and the decision), so the exact posterior is a mixture over ~`K^#questions` global assignments — intractable. `soft` and `post` are **both mean-field projections**; `post`'s category posterior is exact one-step, but the per-category reliability collapse (fractional pseudo-count) is still an assumed-density projection. `post` is the **better tractable projection**, not the exact update. Disclosed in the `category_update.jl` file docstring + README. The metareasoned fidelity-knob extension (retain *k* mixture components, choose *k* by EU-max over accuracy-vs-compute) is named as out-of-scope future work.

## Reproducibility — Paper 1 untouched

`run_bayesian_seed` gains `credit=:post` (default); `--credit soft` reproduces the paper's committed numbers **bit-for-bit**:

| agent | `--credit soft` | committed | `--credit post` |
|-------|----------------|-----------|-----------------|
| greedy_inferred | **149.6** | 149.6 | 151.0 |
| bayesian_inferred | **110.4** | 110.4 | 112.4 |

Paper 1 stays pinned to the committed B2c (soft) numbers. The host's `post` 151.0 vs the research script's 151.4 is the decision-side difference (host marginalises through the proper `MixturePrevision`; the script hand-rolls a direct sum) — the `post` *update* is bit-identical (unit test pins ρ to 1e-12).

## Tests

- **New `test/test_qa_benchmark_post_credit.jl`** (15 checks): ρ via `condition` == closed-form category posterior (1e-12); one-hot π → `post` == `soft` == unit update (bit-exact); **`post` lands STRICTLY closer to the exact 2-component mixture than `soft`** (the better-projection claim); exact fractional α,β; determinism; zero-prior (−Inf log-weight) category handled.
- **`test_qa_benchmark_inferred_host.jl`** extended: default is `:post`, `:soft` reproducible + deterministic, invalid rule rejected. (No per-seed `post ≠ soft` assertion — the rule changes the trajectory but can coincide on a seed; the strict guarantee is the unit test.)
- B2c test unchanged (9/9). `WeightedBernoulli` conjugate + real-embeddings tests pass. Lint clean (`check apps/` + corpus self-test, 0 violations).

Julia tests are not CI-gated; all run locally and pass. CI covers the Python/lint path (this is a Julia-only change to `apps/julia/qa_benchmark`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)