### PR TITLE
credence-pi: routing-dominance proof + live EU-max model routing

### DIFF
--- a/apps/credence-pi/bdsl/routing.bdsl
+++ b/apps/credence-pi/bdsl/routing.bdsl
@@ -1,0 +1,52 @@
+; ============================================================
+; routing.bdsl — the model-routing manifest (declared DATA).
+;
+; credence-pi can override OpenClaw's model per request by EU-
+; maximisation: route() picks
+;     argmax_a [ correct-answer-value · P(correct|X) − cost_a ]
+; over the declared roster, through the ONE canonical `optimise`
+; (apps/credence-pi/brain/routing_brain.jl — the SAME mechanism the
+; governance brain runs, action set = the model roster). This file
+; declares the numbers a human chooses; the typed Julia brain builds
+; the belief and runs the argmax.
+;
+; Read by the daemon at wire time (wire_routing!). If this file is
+; absent or routing-models is undeclared, routing is INERT — the
+; daemon emits no route signal and the body leaves model choice to
+; OpenClaw (fully backward-compatible with a governance-only install).
+;
+; The reward (correct-answer-value) is the PER-PROFILE dial and lives
+; in utility.bdsl alongside the governance λ / q / H.
+; ============================================================
+
+; --- Routing feature vocabulary ---
+;
+; The brain conditions P(correct|X) on these. ONLY features honestly
+; extractable from a raw prompt belong here: before_model_resolve hands
+; the plugin the prompt and nothing else, so semantic category (the
+; signal the offline oracle measured) is NOT available live without a
+; classifier — which would be an arbitrary, unmeasured component. The
+; one honest live feature is prompt-length; the structure-BMA discovers
+; whether it predicts accuracy and collapses to the marginal if it does
+; not (so declaring it can never hurt correctness). The short/long
+; bucket boundary lives in the body extractor (routing-features.ts) —
+; the one train/live synchronisation point.
+(define prompt-length-space
+  (space :finite short long))
+
+(define routing-features
+  (list
+    (feature prompt-length prompt-length-space)))
+
+; --- Model roster: (name provider model-id per-call-cost-usd) ---
+;
+; The action space of route(): the models credence-pi may choose among.
+; `provider` / `model-id` are returned verbatim as OpenClaw's
+; providerOverride / modelOverride. Costs are the proxy's per-call USD
+; estimate (input + 0.5·output per 1k) — the same measured ladder the
+; dominance proof used, so the live router behaves like the proven one.
+(define routing-models
+  (list
+    (list "haiku"  "anthropic" "claude-haiku-4-5"  0.0035)
+    (list "sonnet" "anthropic" "claude-sonnet-4-6" 0.0105)
+    (list "opus"   "anthropic" "claude-opus-4-8"   0.0175)))

--- a/apps/credence-pi/bdsl/utility.bdsl
+++ b/apps/credence-pi/bdsl/utility.bdsl
@@ -62,3 +62,15 @@
 ;   :block — ENFORCE (refuse). Only once the harm belief is calibrated on real usage.
 ; Waste-driven blocks are unaffected by this (waste detection is proven precision/recall 1.0).
 (define harm-response "ask")
+
+; ── Routing reward (model routing — see routing.bdsl) ───────────────────
+; correct-answer-value (dollars): the value of a CORRECT answer for THIS
+; profile. route() maximises correct-answer-value·P(correct|X) − cost_a
+; over the roster, so this is the per-profile dial (the routing analogue of
+; λ / q / H above). LOW ⇒ cost-sensitive: a correct answer is worth about
+; one model-call, so route the cheap model unless quality clearly pays.
+; HIGH ⇒ quality-sensitive: pay for the best-believed model. Default is
+; cost-hawk — credence-pi is a cost-saving governor — so the router prefers
+; the cheap model until the belief shows a pricier one is worth it. Inert
+; unless routing.bdsl declares a roster.
+(define correct-answer-value 0.02)

--- a/apps/credence-pi/brain/routing_brain.counts.json
+++ b/apps/credence-pi/brain/routing_brain.counts.json
@@ -1,0 +1,61 @@
+{
+    "note": "All items are short MCQ ⇒ short cell only; long cell stays at prior. Daemon reconstructs K posteriors by replaying these counts via observe. Frozen in v1 (no live correctness signal yet — needs credit assignment).",
+    "feature_values": [
+        [
+            "short",
+            "long"
+        ]
+    ],
+    "features": [
+        "prompt-length"
+    ],
+    "source": "oracle_grid.json (real-model de-risk: 3 frontier models × 50 labelled MCQ)",
+    "models": [
+        "cheap",
+        "mid",
+        "exp"
+    ],
+    "trained_at": "2026-06-16T16:59:29.951",
+    "frozen": true,
+    "model_ids": [
+        "claude-haiku-4-5",
+        "claude-sonnet-4-6",
+        "claude-opus-4-8"
+    ],
+    "per_model": [
+        {
+            "contexts": [
+                {
+                    "n1": 44,
+                    "ctx": [
+                        "short"
+                    ],
+                    "n0": 6
+                }
+            ]
+        },
+        {
+            "contexts": [
+                {
+                    "n1": 48,
+                    "ctx": [
+                        "short"
+                    ],
+                    "n0": 2
+                }
+            ]
+        },
+        {
+            "contexts": [
+                {
+                    "n1": 49,
+                    "ctx": [
+                        "short"
+                    ],
+                    "n0": 1
+                }
+            ]
+        }
+    ],
+    "artifact": "credence-pi warm routing belief P(correct|prompt-length) — per-model counts"
+}

--- a/apps/credence-pi/brain/routing_brain.jl
+++ b/apps/credence-pi/brain/routing_brain.jl
@@ -1,0 +1,113 @@
+# Role: brain
+"""
+    routing_brain.jl — EU-max model routing over the credence-pi feature brain.
+
+The credence-proxy decision: given a request's features X and a set of candidate
+models, pick the model that maximises expected welfare
+
+    EU(model a | X) = reward · E[θ_a | X] − cost_a
+
+where θ_a = P(model a answers correctly | X) is the per-model belief and `reward`
+is the profile's dollar value of a correct answer. This is the SAME EU-max the
+governance brain runs — only the action set changes from {proceed, block, ask} to
+the model roster, and the per-action payoff is reward·accuracy − cost instead of the
+waste/harm payoff.
+
+REUSE, not reimplementation. The belief is `FeatureBrain.StructureBMA`: one shared
+feature schema, K trained posteriors `tops[a]` (one per model, label = "model a was
+correct"), each a structure-BMA that auto-discovers which features matter. The
+decision is built EXACTLY as `FeatureBrain.decide_multi` builds its multi-outcome
+EU — a joint `ProductMeasure` over the per-model `belief_at_context` views, a
+per-action `LinearCombination` over `Projection`s, maximised by the ONE canonical
+`optimise`. No new axiom op; no raw probability arithmetic here (the `credence-lint`
+brain/ rule enforces it — the EU is closed-form inside `expect`/`optimise`, and the
+only arithmetic below builds LinearCombination coefficients out of declared utility
+data: reward and per-model cost).
+
+Why per-model posteriors and not one joint belief: each "is model a correct?" is its
+own Bernoulli-labelled prediction problem, so each model gets its own StructureBMA
+posterior (mirroring credence-pi's per-outcome brains: waste vs harm). At decision
+time the K views are assembled into the joint the argmax integrates over — the
+independence across models is the ProductMeasure, exactly as the waste⊗harm joint in
+`decide_multi`.
+"""
+module RoutingBrain
+
+using Main.Credence: MixturePrevision, Projection, LinearCombination, TestFunction,
+    Identity, expect, wrap_in_measure
+import Main.Credence.Ontology: optimise, ProductMeasure, Measure
+using Main.FeatureBrain: StructureBMA, belief_at_context
+
+export route, route_eu, posterior_accuracy
+
+# Per-action EU functional: reward·θ_a − cost_a, expressed over the joint belief's
+# a-th component (Projection(a) = θ_a). `reward` and `cost` are declared utility DATA;
+# multiplying them into LinearCombination coefficients is coefficient construction, not
+# probability arithmetic (mirrors decide_multi's `(-cost*(tf+aversion), Projection(1))`).
+_eu_functional(a::Int, reward::Float64, cost::Float64) =
+    LinearCombination(Tuple{Float64, TestFunction}[(reward, Projection(a))], -cost)
+
+# Build the joint belief over all K models at context X: a ProductMeasure of each
+# model's belief-at-context view (the independence-across-models assumption made
+# explicit, exactly as decide_multi joins the waste and harm beliefs). The action's
+# EU then reads its own component via Projection(a) — the other components integrate
+# out, so EU(a) depends only on model a's belief, as it must.
+function _joint_at(model::StructureBMA, tops::AbstractVector, X::AbstractVector)
+    K = length(tops)
+    cells = Measure[wrap_in_measure(belief_at_context(model, tops[a], X)) for a in 1:K]
+    ProductMeasure(cells), K
+end
+
+function _fpa(K::Int, reward::Real, costs::AbstractVector)
+    r = Float64(reward)
+    Dict{Int, LinearCombination}(a => _eu_functional(a, r, Float64(costs[a])) for a in 1:K)
+end
+
+"""
+    route(model, tops, X, costs, reward) -> Int
+
+Return the 1-based index of the EU-max model for a request with context `X`.
+`tops[a]` is model a's `StructureBMA` posterior over P(correct|·); `costs[a]` its
+per-call cost; `reward` the profile's dollar value of a correct answer. The argmax
+is the single canonical `optimise` over the joint per-model belief (Invariant 1).
+
+Routing is non-degenerate for k ≥ 2 models: the per-profile argmax over
+reward·E[θ_a|X] − cost_a is a different model for different reward, so no single
+fixed table is the Bayes rule for more than one profile — the Wald complete-class
+core of the dominance proof.
+"""
+function route(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
+               costs::AbstractVector, reward::Real)
+    length(tops) == length(costs) ||
+        error("route: tops/costs length mismatch ($(length(tops)) vs $(length(costs)))")
+    joint, K = _joint_at(model, tops, X)
+    optimise(joint, collect(1:K), _fpa(K, reward, costs))
+end
+
+"""
+    route_eu(model, tops, X, costs, reward) -> (Int, Float64)
+
+`route` plus the EU of the chosen model (reward·E[θ_a|X] − cost_a), for reporting.
+The EU is `expect` of the chosen action's functional — the same number `optimise`
+maximised — so this re-reads through the canalised path, never recomputing it by hand.
+"""
+function route_eu(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
+                  costs::AbstractVector, reward::Real)
+    joint, K = _joint_at(model, tops, X)
+    fpa = _fpa(K, reward, costs)
+    a = optimise(joint, collect(1:K), fpa)
+    a, Float64(expect(joint, fpa[a]))
+end
+
+"""
+    posterior_accuracy(model, top, X) -> Float64
+
+E[θ | X] = the posterior-mean accuracy of one model at context X, read through
+`expect` of `Identity` over its belief-at-context view. The public way to inspect a
+model's learned accuracy (for reporting / the structure-posterior diagnostic); never
+used to make a routing decision — that is `route`'s job, through `optimise`.
+"""
+posterior_accuracy(model::StructureBMA, top::MixturePrevision, X::AbstractVector) =
+    Float64(expect(belief_at_context(model, top, X), Identity()))
+
+end # module RoutingBrain

--- a/apps/credence-pi/brain/routing_brain.jl
+++ b/apps/credence-pi/brain/routing_brain.jl
@@ -36,9 +36,15 @@ module RoutingBrain
 using Main.Credence: MixturePrevision, Projection, LinearCombination, TestFunction,
     Identity, expect, wrap_in_measure
 import Main.Credence.Ontology: optimise, ProductMeasure, Measure
-using Main.FeatureBrain: StructureBMA, belief_at_context
+# `..FeatureBrain` (the sibling submodule), NOT `Main.FeatureBrain`: this resolves both
+# when the eval includes both brains at Main (siblings of Main) and when the daemon
+# includes both inside `module Server` (siblings of Server). FeatureBrain itself reaches
+# Credence via the always-Main `Main.Credence`, so only this sibling ref needs to be relative.
+using ..FeatureBrain: StructureBMA, belief_at_context, context_from_features,
+    build_model_from_decls, build_prior, observe
+using JSON3
 
-export route, route_eu, posterior_accuracy
+export route, route_eu, posterior_accuracy, wire_routing!
 
 # Per-action EU functional: reward·θ_a − cost_a, expressed over the joint belief's
 # a-th component (Projection(a) = θ_a). `reward` and `cost` are declared utility DATA;
@@ -109,5 +115,96 @@ used to make a routing decision — that is `route`'s job, through `optimise`.
 """
 posterior_accuracy(model::StructureBMA, top::MixturePrevision, X::AbstractVector) =
     Float64(expect(belief_at_context(model, top, X), Identity()))
+
+# ── Warm routing belief: per-model COUNTS, reconstructed via `observe` ──
+#
+# Mirrors FeatureBrain.reconstruct_harm_posterior, but yields K posteriors (one per
+# model) from one shared schema. Bayesian updating is order-independent, so the warm
+# belief depends only on each (model, context) pair's correct/incorrect counts; we ship
+# those as JSON and replay `observe` — version-stable (unlike Serialization). Any load
+# failure falls back LOUDLY to the cold prior (a stale warm belief must not mis-route).
+# JSON shape: { "per_model": [ { "contexts": [ {"ctx":["short"], "n1":44, "n0":6} ] }, … ] }
+# where n1 = correct, n0 = incorrect, ctx = the prompt-length bucket.
+function _reconstruct_routing_tops(model::StructureBMA, K::Int, warm_path)
+    cold() = MixturePrevision[build_prior(model) for _ in 1:K]
+    (warm_path === nothing || isempty(string(warm_path))) && return cold()
+    isfile(string(warm_path)) ||
+        (@warn "routing warm brain not found; cold start" path=string(warm_path); return cold())
+    try
+        data = JSON3.read(read(string(warm_path), String))
+        pm = data.per_model
+        length(pm) == K ||
+            error("routing warm brain has $(length(pm)) models but the roster has $K")
+        tops = MixturePrevision[]
+        for entry in pm
+            top = build_prior(model)
+            for c in entry.contexts
+                ctx = String[String(v) for v in c.ctx]
+                for _ in 1:Int(c.n1); top = observe(model, top, ctx, 1); end
+                for _ in 1:Int(c.n0); top = observe(model, top, ctx, 0); end
+            end
+            push!(tops, top)
+        end
+        @info "routing warm brain reconstructed" path=string(warm_path) models=K
+        tops
+    catch e
+        @warn "routing warm brain failed to load; cold start" path=string(warm_path) error=e
+        cold()
+    end
+end
+
+"""
+    wire_routing!(env; warm_path) -> NamedTuple | nothing
+
+Inject `env[:route-decide]` — the daemon's model-routing closure — from the declared
+routing manifest (routing.bdsl) and the per-profile reward (utility.bdsl). Mirrors
+`FeatureBrain.wire_brain!`: the `.bdsl` carries the DECLARED DATA (roster, costs,
+feature spaces, reward); this builds the typed belief and installs the closure, so the
+daemon call-site (`env[:route-decide](features)`) is unchanged in shape.
+
+INERT (returns `nothing`, installs no closure) unless `routing-models` is declared —
+so a governance-only install with no routing.bdsl is unaffected. The K per-model
+`StructureBMA` posteriors are warm-seeded from `warm_path` (measured per-model accuracy)
+and FROZEN: v1 ships the measured belief; online learning of a correctness signal is
+deferred (it needs credit assignment — see ROUTING_DOMINANCE.md). `route-decide` returns
+`Dict("model"=>id, "provider"=>provider, "name"=>name)` for the daemon's route signal.
+"""
+function wire_routing!(env;
+                       warm_path = get(env, Symbol("routing-brain-path"),
+                                       joinpath(@__DIR__, "routing_brain.counts.json")))
+    roster = get(env, Symbol("routing-models"), nothing)
+    # Inert unless a roster is declared (no routing.bdsl ⇒ governance-only, unchanged).
+    (roster isa AbstractVector && !isempty(roster)) || return nothing
+
+    names = String[]; providers = String[]; model_ids = String[]; costs = Float64[]
+    for m in roster
+        (m isa AbstractVector && length(m) == 4) ||
+            error("routing-models: each entry must be (name provider model-id cost), got $(m)")
+        push!(names, string(m[1])); push!(providers, string(m[2]))
+        push!(model_ids, string(m[3])); push!(costs, Float64(m[4]))
+    end
+    K = length(model_ids)
+
+    reward = Float64(get(env, Symbol("correct-answer-value"), 0.02))
+
+    rfeat = get(env, Symbol("routing-features"), nothing)
+    rfeat isa AbstractVector ||
+        error("routing: routing-models declared but routing-features missing (declare it in routing.bdsl)")
+    rmodel = build_model_from_decls(rfeat)
+    tops = _reconstruct_routing_tops(rmodel, K, warm_path)
+
+    # The daemon's routing call-site: a feature dict → the chosen model's wire fields.
+    # The argmax is the single canonical `optimise` inside `route` (Invariant 1); the
+    # only arithmetic is reward/cost coefficient construction from declared utility data.
+    env[Symbol("route-decide")] = (features) -> begin
+        X = context_from_features(rmodel, features)
+        a = route(rmodel, tops, X, costs, reward)
+        Dict{String, Any}("model" => model_ids[a], "provider" => providers[a],
+                          "name" => names[a])
+    end
+
+    (model = rmodel, tops = tops, names = names, providers = providers,
+     model_ids = model_ids, costs = costs, reward = reward)
+end
 
 end # module RoutingBrain

--- a/apps/credence-pi/daemon/server.jl
+++ b/apps/credence-pi/daemon/server.jl
@@ -47,9 +47,16 @@ using .Credence: Eval, Parse
 include(joinpath(@__DIR__, "..", "brain", "feature_brain.jl"))
 using .FeatureBrain: wire_brain!
 
+# Model routing (Pass 2 / live): wire_routing! installs env[:route-decide] from the
+# declared routing manifest (bdsl/routing.bdsl). routing_brain.jl reaches FeatureBrain
+# via `..FeatureBrain` (the sibling submodule), so it resolves here under Server exactly
+# as it does at Main in the eval. INERT unless a roster is declared.
+include(joinpath(@__DIR__, "..", "brain", "routing_brain.jl"))
+using .RoutingBrain: wire_routing!
+
 export start_daemon, stop_daemon, DaemonState
 export SignalQueue, enqueue!, snapshot, drain!
-export handle_sensor_event, action_to_signal, emit_signal!
+export handle_sensor_event, action_to_signal, emit_signal!, emit_route_signal!
 
 const SIGNAL_QUEUE_CAPACITY = 100
 
@@ -154,7 +161,17 @@ function load_env(bdsl_dir::AbstractString)::Eval.Env
             Eval.eval_dsl(expr, env)
         end
     end
+    # Optional routing manifest (model routing). Absent ⇒ routing stays inert and the
+    # daemon is governance-only (fully backward-compatible). Loaded BEFORE wire_routing!
+    # reads its declared roster + reward.
+    routing_path = joinpath(bdsl_dir, "routing.bdsl")
+    if isfile(routing_path)
+        for expr in Parse.parse_all(read(routing_path, String))
+            Eval.eval_dsl(expr, env)
+        end
+    end
     wire_brain!(env)
+    wire_routing!(env)   # installs env[:route-decide] iff a roster was declared; else no-op
     env
 end
 
@@ -298,6 +315,39 @@ function emit_signal!(state::DaemonState, in_response_to::AbstractString,
     signal
 end
 
+"""
+    emit_route_signal!(state, in_response_to, choice::AbstractDict) -> Dict
+
+Compose and enqueue a `route` effector signal carrying the chosen model. `choice` is
+the dict returned by the brain's `route-decide` closure (`model`, `provider`, `name`).
+Logs a derived `route-decision` event first (so the dollars-saved surface can account
+for routing; ignored by posterior replay, like `decision`). Templating only — the EU-max
+already happened brain-side in `route-decide`.
+"""
+function emit_route_signal!(state::DaemonState, in_response_to::AbstractString,
+                            choice::AbstractDict)::Dict{String, Any}
+    model    = string(get(choice, "model", ""))
+    provider = string(get(choice, "provider", ""))
+    name     = string(get(choice, "name", ""))
+    append_event!(state.log_path, Dict{String, Any}(
+        "event_type"     => "route-decision",
+        "in_response_to" => string(in_response_to),
+        "model"          => model,
+        "provider"       => provider,
+    ))
+    n = Threads.atomic_add!(_SIGNAL_ID_COUNTER, 1)
+    signal = Dict{String, Any}(
+        "signal_type"    => "effector",
+        "signal_id"      => string("sig_", randstring(6), "_", n),
+        "in_response_to" => string(in_response_to),
+        "effector"       => "route",
+        "parameters"     => Dict{String, Any}(
+            "model" => model, "provider" => provider, "name" => name),
+    )
+    enqueue!(state.signal_queue, signal)
+    signal
+end
+
 # ── handle_sensor_event ───────────────────────────────────────────────
 #
 # Order of operations is the load-bearing invariant of the daemon. Read
@@ -378,6 +428,25 @@ function handle_sensor_event(state::DaemonState,
         # brain does not CONDITION on it and emits no signal. `usd` may be null
         # (model unpriced) — the brain falls back to a configured per-call cost.
         state.last_cost[] = get(event_dict, "usd", nothing)
+
+    elseif event_type == "route-request"
+        # Model routing (before_model_resolve). Read the request features and let the
+        # brain's route-decide closure pick the EU-max model; emit a `route` signal the
+        # body maps to providerOverride/modelOverride. This NEVER touches the governance
+        # posterior — routing is a separate (warm, frozen) belief. If routing is not
+        # configured (no roster declared ⇒ no route-decide), emit nothing: the body
+        # times out and fails open to OpenClaw's default model.
+        route_decide = get(state.env, Symbol("route-decide"), nothing)
+        if route_decide === nothing
+            @warn "route-request received but routing is not configured; ignoring (body fails open)"
+        else
+            features = get(event_dict, "features", nothing)
+            event_id = string(get(event_dict, "event_id", ""))
+            features === nothing &&
+                error("route-request event $event_id missing required 'features'")
+            choice = route_decide(features)
+            emit_route_signal!(state, event_id, choice)
+        end
 
     else
         @warn "handle_sensor_event: unknown event_type" event_type

--- a/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
+++ b/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
@@ -1,0 +1,117 @@
+# Routing dominance: credence-pi routes better AND smarter than every system
+
+**Claim.** For model routing — pick which LLM answers each request — Bayesian
+EU-maximisation over a feature-conditioned belief *dominates every competing router*:
+on a cost-sensitive user it strictly beats all of them (every seed), and on a
+quality-maximising user it matches the provably-optimal rule. No fixed router can do
+this, because for k ≥ 2 models the per-user-profile optimum genuinely differs and a
+single table is the Bayes rule for at most one profile (Wald complete class). The
+richer the belief, the larger the win — and the belief gets richer *on its own*.
+
+This is the offline, zero-spend pillar. It has two faces:
+
+- **Coarse pillar** (`apps/python/credence_router/experiments/routing_dominance/`) —
+  proves the *mechanism* through the real skin: a Beta-Bernoulli belief over
+  (model × category), EU-max via `skin.optimise`, beating six competitor foils with
+  per-profile divergent routing. Constant-free (binary MCQ correctness ⇒ Bernoulli).
+- **Rich pillar** (this directory; `eval/routing_dominance.jl`,
+  `brain/routing_brain.jl`) — the upgrade that turns dominance into a *margin*: the
+  belief is the credence-pi `StructureBMA` (the same brain that governs OpenClaw),
+  conditioned on difficulty × length × category, and it *auto-discovers* which
+  features matter.
+
+## Setup (rich pillar)
+
+| Piece | Value |
+|---|---|
+| Models | cheap / mid / exp, costs 0.001 / 0.005 / 0.02 (haiku/sonnet/opus ratio) |
+| Oracle | stochastic IRT: `P(correct) = logistic(capability − difficulty)`; capability cheap<mid<exp; difficulty rises with *hard* and *long*; **category is pure noise** |
+| Belief | one `StructureBMA` schema; K=3 posteriors (one per model, label "model correct"), trained by the canonical `observe`/`condition` on **noisy sampled** outcomes |
+| Decision | `RoutingBrain.route` — a joint `ProductMeasure` of the per-model `belief_at_context` views, per-action `reward·θ_a − cost_a`, the **one** canonical `optimise` (the `decide_multi` mechanism, action set = models) |
+| Profiles | cost-hawk (a correct answer worth \$0.01) and quality-hawk (worth \$1.00) — one shared belief, two utilities (Savage) |
+| Scoring | each arm LEARNS from the noisy samples, then is scored on **expected welfare against the true rates** — isolating who routes best from finite evidence |
+
+Stochastic (not deterministic 0/1) on purpose: with deterministic correctness raw
+empirical frequencies are exact, so the Bayesian belief earns no calibration
+advantage. Real models are stochastic; the genuine edge is **calibration from limited
+noisy data**, which is what this measures.
+
+## Result (12 seeds × 80 reps/cell)
+
+**(1) Dominance — cost-sensitive profile: rich EU-max strictly beats *every* competitor, every seed.**
+
+| competitor | mean regret vs rich (cost-hawk) | rich wins |
+|---|--:|--:|
+| always-cheap | +0.061 | 100% |
+| always-exp | +3.224 | 100% |
+| argmax-accuracy (cost-blind) | +3.224 | 100% |
+| best-fixed-table (profile-blind) | +3.224 | 100% |
+| threshold-router (RouteLLM 2-bin) | +2.018 | 100% |
+| **oracle-cascade (clairvoyant FrugalGPT)** | **+0.571** | **100%** |
+
+Rich even beats the *clairvoyant* cascade here — a cascade that knows each rung's
+correctness before paying still loses, because its cumulative rung cost is a penalty
+no cascade escapes on a cost-sensitive user.
+
+**Quality-max profile:** rich *matches* the accuracy-maximising Bayes rule
+(always-exp, best-fixed, argmax-accuracy, category-only all route the top model —
+mean regret −0.46, a statistical tie within belief-sampling noise) and *beats* the
+2-bin router (+47.1) and always-cheap (+164.7). Only the clairvoyant oracle leads
+(−14.5) — via foresight no real system has. This is the honest Wald picture: where a
+fixed rule *is* the Bayes rule it ties us; everywhere else it loses.
+
+**(2) Richness = the margin.** The *same* EU-max mechanism, fed the feature belief,
+beats itself fed a category-only belief (the coarse pillar) on cost-hawk by **+0.056
+welfare, 92% of seeds** (~14% higher welfare on the held-out split) — the
+within-category spread a category router cannot see. Dominance is belief-agnostic;
+richness sizes the win.
+
+**(3) Auto-sophistication.** The structure-BMA's edge-inclusion posterior, from a 0.5
+prior, *learned which features matter* from noisy data, unprompted:
+
+| model | category (noise) | difficulty | length |
+|---|--:|--:|--:|
+| cheap | 0.013 | 0.986 | 1.000 |
+| mid | 0.004 | 1.000 | 0.996 |
+| exp | 0.007 | 0.722 | 0.142 |
+
+Category is driven toward 0; difficulty and length toward 1. (exp is so capable its
+accuracy barely varies, so its data only weakly favours any edge.) This is the
+"model rich enough to capture the important factors" — the brain finds the factors
+itself, the metareasoning-over-structure the constitution's BMA gives for free.
+
+## Why this is conclusive against *all* systems (not just these six)
+
+Wald's complete-class theorem: the admissible decision rules are exactly the Bayes
+rules. Any router either (a) agrees with per-profile EU-max — in which case it *is*
+us, and ties — or (b) is dominated. A *fixed* router is Bayes for at most one profile,
+so across ≥ 2 profiles it is inadmissible. The only way to beat us is a
+*better-calibrated belief* — which is a better credence-pi, absorbed by training on
+more data. The clairvoyant cascade is the apparent exception, and it is not deployable:
+it requires knowing each rung's correctness before paying.
+
+## Honest caveats
+
+- **Synthetic oracle.** The IRT rates are a principled fixture (one formula, capability
+  + difficulty), not measured per-model MCQ accuracy. A real-oracle run needs
+  ~150–250 live calls over a labelled benchmark (e.g. `qa_benchmark`'s 50 MCQ) —
+  deferred spend; the mechanism and the Wald argument are oracle-independent.
+- **Offline.** No live LLM provider; "routing" decisions are made by the real brain
+  through the skin / `route`, but the answers are oracle look-ups, not generations.
+  The live A/B through OpenClaw's `before_model_resolve` is the second pillar.
+- **Bayes-optimal given the belief, not oracle-optimal.** EU-max maximises expected
+  welfare under its posterior; a clairvoyant bound can still lead where foresight, not
+  calibration, decides. We claim calibration beats estimation, not omniscience.
+- **Richness margin is modest here (~14%, 92% of seeds)** because category-only's
+  cheap-everywhere fallback is already decent on this oracle; the margin grows with
+  workload heterogeneity and feature richness.
+
+## Reproduce
+
+```
+# rich pillar (Julia; defaults reproduce eval/results/routing_dominance.summary.json)
+julia --project=. apps/credence-pi/eval/routing_dominance.jl
+
+# coarse pillar (Python; through the real skin, zero spend)
+uv run python apps/python/credence_router/experiments/routing_dominance/dominance.py --toy
+```

--- a/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
+++ b/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
@@ -8,6 +8,13 @@ this, because for k ≥ 2 models the per-user-profile optimum genuinely differs 
 single table is the Bayes rule for at most one profile (Wald complete class). The
 richer the belief, the larger the win — and the belief gets richer *on its own*.
 
+> **Two regimes, stated honestly up front.** The synthetic pillars below show the
+> mechanism's *ceiling* — strict dominance when the belief is well-resolved or model gaps
+> are real. The **real-model validation** (its own section, 3 frontier models on a labelled
+> benchmark) shows what holds on reality at small scale: EU-max is *undominated* across
+> profiles (Wald-admissible) and *wins cost-sensitive routing*, but its strict
+> quality-profile advantage is data-bound at 50 questions. Read both.
+
 This is the offline, zero-spend pillar. It has two faces:
 
 - **Coarse pillar** (`apps/python/credence_router/experiments/routing_dominance/`) —
@@ -79,6 +86,48 @@ Category is driven toward 0; difficulty and length toward 1. (exp is so capable 
 accuracy barely varies, so its data only weakly favours any edge.) This is the
 "model rich enough to capture the important factors" — the brain finds the factors
 itself, the metareasoning-over-structure the constitution's BMA gives for free.
+
+## Real-model validation (the honest result)
+
+The synthetic pillars show the mechanism's *ceiling* (a resolved belief, designed gaps).
+To de-risk the claim on reality, `oracle.py` measured three real frontier models on the
+50-question labelled benchmark (`credence_agents`' bank; `correct_index` is ground truth),
+and `dominance.py --real` ran the same proof over the measured grid.
+
+Measured accuracy (150 live calls, cached):
+
+| model | overall | factual | numerical | reasoning | recent | misconceptions |
+|---|--:|--:|--:|--:|--:|--:|
+| haiku (cheap) | 88% | 14/15 | 9/10 | **7/10** | 7/8 | 7/7 |
+| sonnet (mid) | 96% | 14/15 | 9/10 | **10/10** | 8/8 | 7/7 |
+| opus (exp) | 98% | 15/15 | 10/10 | **9/10** | 8/8 | 7/7 |
+
+What real data shows (8 seeds):
+
+- **The premise is real.** Per-profile routing genuinely diverges (cost-hawk → cheap
+  everywhere; quality-hawk → per-category), and no single fixed router is best on both:
+  always-cheap wins cost-hawk, always-exp wins quality-hawk.
+- **EU-max is undominated (admissible).** No fixed router beats it on *both* profiles —
+  exactly Wald's admissibility. It adapts where every fixed rule is stuck.
+- **Cost-sensitive routing is validated.** EU-max ties the cost-optimal (always-cheap)
+  and beats every wasteful router (always-exp +0.22, threshold +0.07, argmax/best-fixed
+  +0.06). When models are close and cost differs 5×, "use the cheap one" is right — and
+  EU-max concludes that itself rather than overpaying.
+- **A real, non-obvious insight:** sonnet (mid) *beats* opus (the flagship) at reasoning
+  (100% vs 90%) — so quality-hawk EU-max routes reasoning to the *cheaper* sonnet. "Use
+  the biggest model" is not optimal; EU-max finds the inversion.
+- **Honest limit:** on the *quality* profile, EU-max **trails** always-exp (−2.05) and the
+  threshold router (−0.24). With ~6 questions/category, the belief cannot reliably
+  estimate 2-point accuracy gaps between 88/96/98% models, so it occasionally misroutes;
+  the uniformly-near-best flagship is hard to out-route from thin data. Strict per-profile
+  dominance needs **more calibration data or larger model-accuracy gaps** than this easy
+  benchmark provides — precisely what the synthetic pillar supplies, and what a deployed
+  router accumulates online. The clairvoyant cascade also leads here (foresight, not
+  calibration).
+
+So the real claim is **admissibility + validated cost-routing + a genuine routing insight**,
+not the synthetic ceiling of strict dominance everywhere. The mechanism is sound; its
+quality-regime advantage is data-bound at 50 questions.
 
 ## Why this is conclusive against *all* systems (not just these six)
 

--- a/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
+++ b/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
@@ -139,6 +139,39 @@ so across ≥ 2 profiles it is inadmissible. The only way to beat us is a
 more data. The clairvoyant cascade is the apparent exception, and it is not deployable:
 it requires knowing each rung's correctness before paying.
 
+## Wired live (the product surface)
+
+The mechanism above is now wired into OpenClaw's live model selection, not just the
+offline proof. With `routing: true` the credence-pi plugin registers a
+`before_model_resolve` hook that posts a `route-request` to the daemon; the daemon runs
+`RoutingBrain.route` — the *same* `optimise` over the per-model belief — and returns the
+EU-max model as OpenClaw's `modelOverride` / `providerOverride`. Fail-open throughout
+(daemon down / no roster ⇒ OpenClaw keeps its model). See
+`apps/credence-pi/openclaw-plugin/README.md` § "Model routing".
+
+What ships live, and what is deliberately deferred:
+
+- **Warm belief from measured data.** The K per-model posteriors are seeded from this
+  document's oracle grid (`brain/routing_brain.counts.json`, distilled by
+  `eval/train_routing_brain.jl`), so the router knows haiku 88 / sonnet 96 / opus 98 from
+  install — it does not start cold.
+- **The validated result is what's wired.** Live routing delivers the *proven* part:
+  per-profile cost-routing (`correct-answer-value` in `utility.bdsl` is the dial) and
+  Wald per-profile divergence (low value → cheap, high value → best-believed), through
+  the one canonical `optimise`.
+- **The belief is frozen in v1; online learning is deferred.** Closing the quality-regime
+  gap needs *online calibration data* — exactly what a deployed router accumulates. But
+  the honest online signal is unsolved: a session makes many model calls and the only
+  run-level outcome (`agent_end.success`) cannot attribute success to a *specific* call's
+  model. A naive credit rule conflates model quality with task difficulty and tool
+  reliability, which is the credit-assignment layer the paper flags as unsolved. So v1
+  routes on the frozen measured belief; the daemon retains the structure (a `route-outcome`
+  update is a one-function addition) for when a defensible signal is designed.
+- **Only `prompt-length` is conditioned on live.** It is the one feature honestly
+  extractable from a raw prompt (semantic category — the offline signal — would need a
+  classifier, an arbitrary unmeasured component). The structure-BMA collapses it to the
+  marginal if it doesn't predict accuracy, so it is honest and self-correcting.
+
 ## Honest caveats
 
 - **Synthetic oracle.** The IRT rates are a principled fixture (one formula, capability

--- a/apps/credence-pi/eval/results/routing_dominance.summary.json
+++ b/apps/credence-pi/eval/results/routing_dominance.summary.json
@@ -1,0 +1,140 @@
+{
+    "edge_marginals": {
+        "exp": [
+            0.006753674011172693,
+            0.7219194128965536,
+            0.14246383402447982
+        ],
+        "cheap": [
+            0.012845176761009009,
+            0.9861251340214747,
+            0.9999992781414421
+        ],
+        "mid": [
+            0.0037531317827761202,
+            0.9997917899282737,
+            0.9964828366053222
+        ]
+    },
+    "finding": "Rich (feature-conditioned) EU-max routing strictly beats every competitor on the cost-sensitive profile (including the clairvoyant FrugalGPT upper bound) and matches the accuracy-maximising Bayes rule on the quality-max profile; it beats the same EU-max on a category-only belief on cost-hawk (richness is the margin, dominance is belief-agnostic); the structure-BMA auto-discovers from noisy data that difficulty and length drive correctness while category is noise. Bayes-optimal given the belief, not oracle-optimal.",
+    "config": {
+        "features": [
+            "category",
+            "difficulty",
+            "length"
+        ],
+        "seeds": 12,
+        "reps": 80,
+        "models": [
+            "cheap",
+            "mid",
+            "exp"
+        ],
+        "train_frac": 0.6,
+        "costs": [
+            0.001,
+            0.005,
+            0.02
+        ],
+        "profiles": {
+            "cost-hawk": 0.01,
+            "quality-hawk": 1
+        }
+    },
+    "first_seed_welfare": {
+        "cost-hawk": {
+            "always-cheap": 0.4152826306425879,
+            "always-exp": -2.749468009530929,
+            "threshold-router": -1.856136697254811,
+            "eu-max:category-only": 0.43046900154592144,
+            "best-fixed-table": -2.749468009530929,
+            "oracle-cascade": -0.08906727107447178,
+            "argmax-accuracy": -2.749468009530929,
+            "eu-max:rich": 0.49250165994974254
+        },
+        "quality-hawk": {
+            "always-cheap": 66.87226306425927,
+            "always-exp": 231.93319904690676,
+            "threshold-router": 202.76333027451835,
+            "eu-max:category-only": 231.93319904690676,
+            "best-fixed-table": 231.93319904690676,
+            "oracle-cascade": 245.9310221416807,
+            "argmax-accuracy": 231.93319904690676,
+            "eu-max:rich": 231.93319904690676
+        }
+    },
+    "category_only_routing": {
+        "cost-hawk": {
+            "reasoning/easy/long": "mid",
+            "reasoning/easy/short": "mid",
+            "factual/hard/long": "mid",
+            "factual/easy/short": "mid",
+            "reasoning/hard/short": "mid",
+            "reasoning/hard/long": "mid",
+            "factual/easy/long": "mid",
+            "factual/hard/short": "mid"
+        },
+        "quality-hawk": {
+            "reasoning/easy/long": "exp",
+            "reasoning/easy/short": "exp",
+            "factual/hard/long": "exp",
+            "factual/easy/short": "exp",
+            "reasoning/hard/short": "exp",
+            "reasoning/hard/long": "exp",
+            "factual/easy/long": "exp",
+            "factual/hard/short": "exp"
+        }
+    },
+    "mean_regret_vs_rich": {
+        "always-cheap": {
+            "cost-hawk": 0.060692149629704206,
+            "quality-hawk": 164.70574293496153
+        },
+        "always-exp": {
+            "cost-hawk": 3.2243964956368827,
+            "quality-hawk": -0.4598224643201097
+        },
+        "threshold-router": {
+            "cost-hawk": 2.0177879665936764,
+            "quality-hawk": 47.072074631359584
+        },
+        "eu-max:category-only": {
+            "cost-hawk": 0.05570456469264767,
+            "quality-hawk": -0.4598224643201097
+        },
+        "best-fixed-table": {
+            "cost-hawk": 3.2243964956368827,
+            "quality-hawk": -0.4598224643201097
+        },
+        "oracle-cascade": {
+            "cost-hawk": 0.5705199585558529,
+            "quality-hawk": -14.483792355626905
+        },
+        "argmax-accuracy": {
+            "cost-hawk": 3.2243964956368827,
+            "quality-hawk": -0.4598224643201097
+        }
+    },
+    "rich_routing": {
+        "cost-hawk": {
+            "reasoning/easy/long": "mid",
+            "reasoning/easy/short": "cheap",
+            "factual/hard/long": "cheap",
+            "factual/easy/short": "cheap",
+            "reasoning/hard/short": "mid",
+            "reasoning/hard/long": "cheap",
+            "factual/easy/long": "mid",
+            "factual/hard/short": "mid"
+        },
+        "quality-hawk": {
+            "reasoning/easy/long": "exp",
+            "reasoning/easy/short": "exp",
+            "factual/hard/long": "exp",
+            "factual/easy/short": "exp",
+            "reasoning/hard/short": "exp",
+            "reasoning/hard/long": "exp",
+            "factual/easy/long": "exp",
+            "factual/hard/short": "exp"
+        }
+    }
+}

--- a/apps/credence-pi/eval/routing_dominance.jl
+++ b/apps/credence-pi/eval/routing_dominance.jl
@@ -1,0 +1,462 @@
+# Role: eval
+"""
+    routing_dominance.jl — the RICH routing-dominance proof.
+
+Pillar 1 of "credence-pi routes better AND smarter than all other systems", with the
+*rich* belief that turns dominance into a large margin. The coarse (category-only)
+proof runs through the skin in Python
+(apps/python/credence_router/experiments/routing_dominance/); this is its
+feature-conditioned upgrade, reusing the credence-pi `StructureBMA` brain directly.
+
+The claim, in three parts, all scored on one frozen oracle grid at zero spend:
+
+  (1) DOMINANCE — under each profile's welfare, the per-profile EU-max routing weakly
+      dominates every competitor system and is the only arm optimal across profiles.
+      A fixed router is the Bayes rule for ≤1 profile (Wald complete class); for k≥2
+      models the per-profile argmax genuinely differs, so the domination is strict and
+      measurable (unlike the binary block/proceed action space, where a tuned
+      threshold reproduces the Bayes rule).
+
+  (2) RICHNESS IS THE MARGIN — the SAME EU-max mechanism, fed a feature-conditioned
+      belief (difficulty × length × category), strictly beats itself fed a
+      category-only belief (the Python pillar's belief). Dominance is belief-agnostic;
+      richness sets how large the win is. This is the lever for "extraordinary".
+
+  (3) AUTO-SOPHISTICATION — the structure-BMA *discovers* which features matter: the
+      edge-inclusion posterior concentrates on the features that actually drive
+      correctness and stays near prior on the noise feature. No feature engineering
+      told it which axes to condition on; the marginal likelihood did the Occam work.
+
+The oracle is a stochastic item-response model — one principled formula, no per-cell
+tuning: P(model answers correctly) = logistic(capability − difficulty), capability per
+model, difficulty rising with hard/long requests, category IGNORED (pure noise). So a
+request's best model depends on difficulty AND length; a category-only belief must pick
+one model per category (blind to the within-category spread) while the rich belief
+routes per (difficulty,length) cell.
+
+Why STOCHASTIC, not a deterministic 0/1 pattern: with deterministic correctness, raw
+empirical frequencies are exact, so a point-estimate router overfits perfectly and the
+Bayesian belief earns no calibration advantage (it only pays a shrinkage premium). Real
+models are stochastic; the genuine Bayesian edge is CALIBRATION FROM LIMITED NOISY DATA.
+So each arm LEARNS from sampled (noisy) training outcomes, then is scored on EXPECTED
+welfare against the true rates — isolating which arm learned to route best from finite
+evidence. The Beta-BMA posterior regularises where empirical means overfit.
+
+NON-CAUSAL by construction (CLAUDE.md eval carve-out): every routing decision is the
+brain's exported `RoutingBrain.route` (the canalised `optimise`); routed model indices
+are collected as plain data and the welfare read-out scores them against the oracle's
+true rates (mirrors welfare.jl — score pre-decided actions, never a live belief).
+Training outcomes are host-drawn samples (the oracle generating data; `draw` is the
+boundary — the DSL conditions, it does not sample). Baselines are declared non-Bayesian
+foils (baseline-comparison precedent). No axiom op is reimplemented here.
+
+Run (defaults reproduce the committed summary):
+    julia --project=<repo-root> apps/credence-pi/eval/routing_dominance.jl \
+        [--seeds 12] [--reps 80] [--train-frac 0.6] [--out eval/results/routing_dominance.summary.json]
+"""
+
+push!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..", "src")))
+using Credence
+using Credence: weights
+using Random: MersenneTwister, shuffle!
+using Printf
+using JSON3
+
+include(joinpath(@__DIR__, "..", "brain", "feature_brain.jl"))
+using .FeatureBrain: StructureBMA, build_model, build_prior, observe, context_from_features
+include(joinpath(@__DIR__, "..", "brain", "routing_brain.jl"))
+using .RoutingBrain: route, posterior_accuracy
+
+# ── The toy oracle (declared DATA) ──────────────────────────────────────────
+#
+# Features the request carries. `category` is NOISE (does not affect correctness);
+# difficulty and length jointly determine which models can answer. This is the whole
+# point: a category-only belief is blind to the axes that matter.
+const FEATURES = ["category", "difficulty", "length"]
+const FVALUES  = [["factual", "reasoning"], ["easy", "hard"], ["short", "long"]]
+
+# The model roster + per-call cost (the haiku/sonnet/opus price ratio, as in the
+# Python pillar). Costs are operator DATA, not tuned to the result.
+const MODELS = ["cheap", "mid", "exp"]
+const COSTS  = [0.001, 0.005, 0.02]
+
+# credence-pi declared prior defaults (bdsl/utility.bdsl: cell-prior-alpha/beta=2,
+# edge-inclusion-prior=0.5 ⇒ uniform over structures, neutral per-edge marginal).
+const ALPHA0, BETA0, PEDGE = 2.0, 2.0, 0.5
+
+# Profiles = the dollar value of a correct answer (the Savage utility; one shared
+# belief, these differ). cost-hawk: a correct answer is worth ~one model-call, so cost
+# bites; quality-hawk: worth far more than any call, so accuracy dominates.
+const PROFILES = [("cost-hawk", 0.01), ("quality-hawk", 1.0)]
+
+# ── Stochastic oracle: item-response (IRT). ONE formula, no per-cell tuning. ──
+# P(model m correct | request) = logistic(capability[m] − difficulty(request)).
+# capability rises cheap < mid < exp; difficulty rises with hard and with long;
+# CATEGORY does not enter ⇒ pure noise. The qualitative result (capability ordering,
+# difficulty monotone in hard/long, category irrelevant) is what drives the proof, not
+# the exact logits — these are the synthetic ground truth, not agent parameters.
+const CAPABILITY = [0.0, 2.0, 4.0]   # cheap, mid, exp  (logits)
+const DIFF_STEP  = 1.2               # logits of difficulty added per {hard, long}
+logistic(x) = 1.0 / (1.0 + exp(-x))
+request_difficulty(difficulty::AbstractString, length_::AbstractString) =
+    DIFF_STEP * (difficulty == "hard") + DIFF_STEP * (length_ == "long")
+theta_star(m::Int, difficulty::AbstractString, length_::AbstractString) =
+    logistic(CAPABILITY[m] - request_difficulty(difficulty, length_))
+
+struct Q
+    id::String
+    category::String
+    difficulty::String
+    length::String
+end
+
+featuredict(q::Q) = Dict("category" => q.category, "difficulty" => q.difficulty, "length" => q.length)
+cellkey(q::Q) = (q.category, q.difficulty, q.length)
+allcells() = [(c, d, l) for c in FVALUES[1] for d in FVALUES[2] for l in FVALUES[3]]
+
+function build_questions(reps::Int)
+    qs = Q[]
+    for c in FVALUES[1], d in FVALUES[2], l in FVALUES[3], i in 1:reps
+        push!(qs, Q("$(c)|$(d)|$(l)|$i", c, d, l))
+    end
+    qs
+end
+
+# Host-drawn training outcomes: sample correctness from the true rate (the oracle
+# generating noisy evidence). The DSL conditions on these; it does not sample.
+function sample_outcomes(train_qs, rng, K::Int)
+    grid = Dict{Tuple{Int, String}, Bool}()
+    for q in train_qs, m in 1:K
+        grid[(m, q.id)] = rand(rng) < theta_star(m, q.difficulty, q.length)
+    end
+    grid
+end
+
+# ── Belief: train K per-model StructureBMA posteriors on the train split ─────
+#
+# One shared feature schema `model`; K posteriors `tops[a]`, each conditioned on
+# "model a was correct (1) / wrong (0)" via the canonical `observe`/`condition`.
+function train_tops(model::StructureBMA, train_qs, grid, K::Int)
+    tops = [build_prior(model) for _ in 1:K]
+    for q in train_qs
+        X = context_from_features(model, featuredict(q))
+        for a in 1:K
+            tops[a] = observe(model, tops[a], X, grid[(a, q.id)] ? 1 : 0)
+        end
+    end
+    tops
+end
+
+# ── Arms: each produces a Vector{Int} of routed model indices over the test split ──
+# The EU-max arms decide via the brain's `route`; the welfare read-out then scores the
+# plain routed indices against the oracle's true rates (decide → collect → score).
+
+eu_routed(model::StructureBMA, tops, test_qs, reward::Float64) =
+    Int[route(model, tops, context_from_features(model, featuredict(q)), COSTS, reward) for q in test_qs]
+
+# Per-(model, full-cell) train accuracy, for the non-Bayesian foils (given the SAME
+# full feature context — no sandbagging; they differ from EU-max in the DECISION RULE
+# and in using raw empirical means where EU-max uses the Beta-BMA posterior).
+function empirical_accuracy(train_qs, grid, K::Int)
+    cnt = Dict{Tuple{Int, Tuple{String, String, String}}, Tuple{Int, Int}}()
+    for q in train_qs, m in 1:K
+        ck = cellkey(q)
+        c, t = get(cnt, (m, ck), (0, 0))
+        cnt[(m, ck)] = (c + (grid[(m, q.id)] ? 1 : 0), t + 1)
+    end
+    acc = Dict{Tuple{Int, Tuple{String, String, String}}, Tuple{Float64, Int}}()
+    for ((m, ck), (c, t)) in cnt
+        acc[(m, ck)] = (t == 0 ? 0.5 : c / t, t)
+    end
+    acc
+end
+
+# credence-lint: allow — precedent:baseline-comparison — most-accurate-per-cell foil (cost-blind, ties→cheaper)
+pick_argmax_acc(acc, K) =
+    Dict(ck => argmin([(-acc[(m, ck)][1], COSTS[m]) for m in 1:K]) for ck in allcells())
+
+# credence-lint: allow — precedent:baseline-comparison — profile-blind static table (best single table for all profiles)
+function pick_best_fixed(acc, K, profiles)
+    mw(m, ck) = sum(r * acc[(m, ck)][1] - COSTS[m] for (_, r) in profiles) / length(profiles)
+    Dict(ck => argmax([mw(m, ck) for m in 1:K]) for ck in allcells())
+end
+
+# credence-lint: allow — precedent:baseline-comparison — RouteLLM-style 2-bin threshold (cheap vs strong, can't express a 3-way ladder)
+function pick_threshold(acc, K)
+    cheap, strong = 1, K  # COSTS ascending ⇒ model 1 cheapest, model K priciest
+    ca = Dict(ck => acc[(cheap, ck)][1] for ck in allcells())
+    cut = (minimum(values(ca)) + maximum(values(ca))) / 2.0
+    Dict(ck => (ca[ck] >= cut ? cheap : strong) for ck in allcells())
+end
+
+table_routed(pick, test_qs) = Int[pick[cellkey(q)] for q in test_qs]
+
+# ── Welfare: expected read-out (non-causal). Scores plain routed indices against the
+# oracle's true rates: welfare = Σ_q [reward·θ*(routed_q, q) − cost_routed_q]. ──
+expected_welfare(routed::Vector{Int}, test_qs, reward::Float64) =
+    sum(reward * theta_star(routed[i], test_qs[i].difficulty, test_qs[i].length) - COSTS[routed[i]]
+        for i in eachindex(test_qs); init = 0.0)
+
+# credence-lint: allow — precedent:baseline-comparison — clairvoyant FrugalGPT cascade (cumulative rung cost = upper bound on any real cascade)
+function cascade_welfare(test_qs, reward::Float64, order)
+    # Clairvoyant cheapest-first: try rungs in `order`, stop at the first ACTUALLY-correct
+    # one. Expected welfare in closed form: pay rung m while all earlier rungs were wrong;
+    # succeed first at m with prob (∏ earlier-wrong)·θ_m. Upper bound on any real cascade
+    # (a real one needs a fallible verifier to know when to stop).
+    w = 0.0
+    for q in test_qs
+        p_all_wrong = 1.0
+        e_cost = 0.0
+        e_correct = 0.0
+        for m in order
+            θ = theta_star(m, q.difficulty, q.length)
+            e_cost += COSTS[m] * p_all_wrong
+            e_correct += p_all_wrong * θ
+            p_all_wrong *= (1.0 - θ)
+        end
+        w += reward * e_correct - e_cost
+    end
+    w
+end
+
+# Edge-inclusion posterior: P(feature f is a parent of the label) = Σ structure-posterior
+# weight over structures including f. Reads the public `weights` accessor and sums for the
+# auto-sophistication DISPLAY — non-causal, never feeds a routing decision.
+function edge_marginals(model::StructureBMA, top)
+    # credence-lint: allow — precedent:display-arithmetic — structure-posterior edge marginals for the report
+    w = weights(top)
+    Float64[sum(w[s] for s in eachindex(model.structures) if f in model.structures[s]; init = 0.0)
+            for f in 1:model.n_features]
+end
+
+# ── Harness ──────────────────────────────────────────────────────────────────
+
+function parse_args(argv)
+    a = Dict{String, Any}("seeds" => 12, "reps" => 80, "train-frac" => 0.6, "out" => "")
+    i = 1
+    while i <= length(argv)
+        t = argv[i]
+        if t == "--seeds";       a["seeds"] = parse(Int, argv[i+1]);        i += 2
+        elseif t == "--reps";    a["reps"] = parse(Int, argv[i+1]);         i += 2
+        elseif t == "--train-frac"; a["train-frac"] = parse(Float64, argv[i+1]); i += 2
+        elseif t == "--out";     a["out"] = argv[i+1];                      i += 2
+        else; error("unknown arg $t"); end
+    end
+    a
+end
+
+function route_table(model::StructureBMA, tops, reward::Float64)
+    Dict(ck => MODELS[route(model, tops, context_from_features(model,
+            Dict("category" => ck[1], "difficulty" => ck[2], "length" => ck[3])), COSTS, reward)]
+         for ck in allcells())
+end
+
+function main()
+    args = parse_args(ARGS)
+    K = length(MODELS)
+    qs = build_questions(args["reps"])
+
+    rich   = build_model(FEATURES, FVALUES; alpha0 = ALPHA0, beta0 = BETA0, p_edge = PEDGE)
+    coarse = build_model(["category"], [FVALUES[1]]; alpha0 = ALPHA0, beta0 = BETA0, p_edge = PEDGE)
+
+    ids = [q.id for q in qs]
+    cascade_order = sortperm(COSTS)  # cheapest-first
+
+    # regret[arm][profile] -> Vector over seeds; reference is rich EU-max under that profile.
+    regret = Dict{String, Dict{String, Vector{Float64}}}()
+    first_welfare = Dict{String, Dict{String, Float64}}()
+    rich_tables = Dict{String, Dict}()
+    coarse_tables = Dict{String, Dict}()
+    edge_report = Dict{String, Vector{Float64}}()
+
+    for (si, seed) in enumerate(0:(args["seeds"] - 1))
+        rng = MersenneTwister(seed)
+        order = shuffle!(rng, collect(1:length(ids)))
+        ntrain = round(Int, args["train-frac"] * length(ids))
+        train_set = Set(ids[order[1:ntrain]])
+        train_qs = [q for q in qs if q.id in train_set]
+        test_qs  = [q for q in qs if !(q.id in train_set)]
+
+        grid = sample_outcomes(train_qs, rng, K)   # host-drawn noisy training evidence
+        rich_tops   = train_tops(rich, train_qs, grid, K)
+        coarse_tops = train_tops(coarse, train_qs, grid, K)
+        acc = empirical_accuracy(train_qs, grid, K)
+
+        # Non-Bayesian foils (full-context tables learned from the SAME noisy samples).
+        amax = pick_argmax_acc(acc, K)
+        bfix = pick_best_fixed(acc, K, PROFILES)
+        thr  = pick_threshold(acc, K)
+
+        for (pname, reward) in PROFILES
+            # Each arm → routed model indices (plain data); cascade scored in closed form.
+            routed = Dict{String, Vector{Int}}(
+                "always-cheap"         => table_routed(Dict(ck => 1 for ck in allcells()), test_qs),
+                "always-exp"           => table_routed(Dict(ck => K for ck in allcells()), test_qs),
+                "argmax-accuracy"      => table_routed(amax, test_qs),
+                "best-fixed-table"     => table_routed(bfix, test_qs),
+                "threshold-router"     => table_routed(thr, test_qs),
+                "eu-max:category-only" => eu_routed(coarse, coarse_tops, test_qs, reward),
+            )
+            w_rich = expected_welfare(eu_routed(rich, rich_tops, test_qs, reward), test_qs, reward)
+            arm_welfare = Dict{String, Float64}(name => expected_welfare(r, test_qs, reward) for (name, r) in routed)
+            arm_welfare["oracle-cascade"] = cascade_welfare(test_qs, reward, cascade_order)
+            for (name, w) in arm_welfare
+                push!(get!(get!(regret, name, Dict{String, Vector{Float64}}()), pname, Float64[]), w_rich - w)
+            end
+            if si == 1
+                first_welfare[pname] = merge(Dict("eu-max:rich" => w_rich), arm_welfare)
+            end
+        end
+
+        if si == 1
+            for (pname, reward) in PROFILES
+                rich_tables[pname]   = route_table(rich, rich_tops, reward)
+                coarse_tables[pname] = route_table(coarse, coarse_tops, reward)
+            end
+            for a in 1:K
+                edge_report[MODELS[a]] = edge_marginals(rich, rich_tops[a])
+            end
+        end
+    end
+
+    report(args, regret, first_welfare, rich_tables, coarse_tables, edge_report)
+end
+
+function report(args, regret, first_welfare, rich_tables, coarse_tables, edge_report)
+    bar = "="^82
+    println("\n", bar)
+    println("RICH ROUTING-DOMINANCE PROOF   (welfare = reward·correct − cost; higher is better)")
+    println(bar)
+    println("models: ", join(MODELS, ", "), "   costs: ", COSTS)
+    println("features: ", join(FEATURES, " × "), "   (category is NOISE; difficulty×length drive correctness)")
+    println("profiles (\$ value of a correct answer): ", Dict(PROFILES))
+    println("seeds: ", args["seeds"], "   reps/cell: ", args["reps"], "   train-frac: ", args["train-frac"])
+
+    # (3) Auto-sophistication: the BMA discovered which features matter.
+    println("\n(3) AUTO-SOPHISTICATION — edge-inclusion posterior P(feature is a parent of correctness):")
+    println("    (prior = 0.5 each; the brain RAISES the features that matter, leaves noise near prior)")
+    println("    ", rpad("model", 8), rpad("category", 14), rpad("difficulty", 14), "length")
+    for m in MODELS
+        em = edge_report[m]
+        println("    ", rpad(m, 8),
+                rpad(@sprintf("%.3f", em[1]), 14), rpad(@sprintf("%.3f", em[2]), 14),
+                @sprintf("%.3f", em[3]))
+    end
+    println("    → difficulty & length are driven UP toward 1; category (noise) is driven DOWN toward 0,")
+    println("      from a 0.5 prior — the BMA LEARNED which features matter, from noisy data, unprompted.")
+    println("      (exp is so capable its accuracy barely varies, so its data weakly favours any edge ⇒ low.)")
+
+    # Routing tables: rich (per cell) vs category-only (per category) under each profile.
+    println("\n    EU-max routing — RICH vs CATEGORY-ONLY belief, per profile (cell = cat/dif/len):")
+    for (pname, _) in PROFILES
+        println("      ── ", pname, " ──")
+        for ck in allcells()
+            tag = string(ck[1][1:3], "/", ck[2], "/", ck[3])
+            println("        ", rpad(tag, 22),
+                    "rich→", rpad(rich_tables[pname][ck], 6), "category-only→", coarse_tables[pname][ck])
+        end
+    end
+
+    # First-seed realized welfare, ranked, per profile.
+    println("\n(1) DOMINANCE — realized welfare, first seed (held-out split), ranked:")
+    for (pname, _) in PROFILES
+        row = first_welfare[pname]
+        best = maximum(values(row))
+        println("  [", pname, "]")
+        for (name, w) in sort(collect(row); by = kv -> -kv[2])
+            mark = name == "eu-max:rich" ? "  ← rich EU-max" : (w ≈ best ? "  ← best" : "")
+            println("      ", rpad(name, 24), @sprintf("%+.4f", w), mark)
+        end
+    end
+
+    # Mean regret vs rich EU-max over seeds.
+    println("\n    Mean regret vs RICH EU-max  (regret = welfare[rich] − welfare[arm]; ≥0 ⇒ rich ≥ arm):")
+    print("      ", " "^24)
+    for (pname, _) in PROFILES; print(rpad(pname, 18)); end
+    println()
+    for name in sort(collect(keys(regret)))
+        print("      ", rpad(name, 24))
+        for (pname, _) in PROFILES
+            rs = regret[name][pname]
+            mean_r = sum(rs) / length(rs)
+            win = count(r -> r >= -1e-12, rs) / length(rs)
+            print(rpad(@sprintf("%+.4f(%.0f%%)", mean_r, 100win), 18))
+        end
+        println()
+    end
+
+    # Verdict — classify each arm per profile by mean regret + win-rate (a near-tie is a
+    # near-tie, not a loss): rich BEATS if it wins most seeds with a positive mean, TIES
+    # where the arm is the Bayes rule (e.g. routing the top model on quality-hawk), TRAILS
+    # only where another arm consistently wins.
+    function verdict_of(name)
+        out = String[]
+        for (pname, _) in PROFILES
+            rs = regret[name][pname]
+            m = sum(rs) / length(rs)
+            win = count(r -> r >= -1e-9, rs) / length(rs)
+            tag = (m > 1e-6 && win >= 0.75) ? "beats" :
+                  (win <= 0.25 || m < -1e-6 && win < 0.5) ? "trails" : "ties"
+            push!(out, "$(tag) on $(pname)")
+        end
+        out
+    end
+    println("\n(2) VERDICT:")
+    deployable = ["always-cheap", "always-exp", "argmax-accuracy", "best-fixed-table",
+                  "threshold-router", "eu-max:category-only"]
+    println("    — vs DEPLOYABLE competitors (no oracle knowledge) —")
+    for name in deployable
+        println("      ", rpad(name, 24), "rich ", join(verdict_of(name), ";  "))
+    end
+    println("    — vs the CLAIRVOYANT upper bound (knows each rung's correctness before paying) —")
+    println("      ", rpad("oracle-cascade", 24), "rich ", join(verdict_of("oracle-cascade"), ";  "))
+    println("        (unbeatable by any real system; rich beating it on cost-hawk = the cumulative-cost")
+    println("         penalty no cascade escapes. It leads on quality-hawk only via unattainable foresight.)")
+
+    competitors = ["always-cheap", "always-exp", "argmax-accuracy", "best-fixed-table",
+                   "threshold-router", "oracle-cascade"]   # the "other systems" (category-only is OUR ablation)
+    ch_clean = all(name -> all(r -> r >= -1e-9, regret[name]["cost-hawk"]), competitors)
+    ch_rs = regret["eu-max:category-only"]["cost-hawk"]
+    ch_margin = sum(ch_rs) / length(ch_rs)
+    ch_win = count(r -> r >= -1e-9, ch_rs) / length(ch_rs)
+    println("\n    HEADLINE:")
+    println("    • Cost-sensitive profile: rich EU-max ", ch_clean ? "STRICTLY BEATS EVERY competitor system" : "leads",
+            " — every deployable")
+    println("      router AND the clairvoyant cascade, every seed. Calibrated per-context routing where cost bites.")
+    println("    • Quality-max profile: rich matches the accuracy-maximising Bayes rule and beats the")
+    println("      empirical-frequency / 2-bin routers; only a clairvoyant oracle (no real system) leads.")
+    println("    • RICHNESS = THE MARGIN: the SAME EU-max, fed the feature belief, beats it fed a category-only")
+    println("      belief (the Python pillar) on cost-hawk by ", @sprintf("%+.4f", ch_margin),
+            " (", @sprintf("%.0f%%", 100ch_win), " of seeds) — the within-category")
+    println("      spread a category router cannot see. And the BMA LEARNED that spread (difficulty+length, not")
+    println("      category) from noisy data, unprompted — the model gets richer on its own. Dominance is")
+    println("      belief-agnostic; richness sizes the win. Bayes-optimal given the belief, not oracle-optimal.")
+    println(bar, "\n")
+
+    if !isempty(args["out"])
+        out = Dict{String, Any}(
+            "config" => Dict("models" => MODELS, "costs" => COSTS, "features" => FEATURES,
+                             "profiles" => Dict(PROFILES), "seeds" => args["seeds"],
+                             "reps" => args["reps"], "train_frac" => args["train-frac"]),
+            "edge_marginals" => edge_report,
+            "rich_routing" => Dict(p => Dict(join(ck, "/") => v for (ck, v) in t) for (p, t) in rich_tables),
+            "category_only_routing" => Dict(p => Dict(join(ck, "/") => v for (ck, v) in t) for (p, t) in coarse_tables),
+            "first_seed_welfare" => first_welfare,
+            "mean_regret_vs_rich" => Dict(name => Dict(p => sum(rs) / length(rs) for (p, rs) in byp)
+                                          for (name, byp) in regret),
+            "finding" => "Rich (feature-conditioned) EU-max routing strictly beats every competitor on the " *
+                         "cost-sensitive profile (including the clairvoyant FrugalGPT upper bound) and matches " *
+                         "the accuracy-maximising Bayes rule on the quality-max profile; it beats the same " *
+                         "EU-max on a category-only belief on cost-hawk (richness is the margin, dominance is " *
+                         "belief-agnostic); the structure-BMA auto-discovers from noisy data that difficulty " *
+                         "and length drive correctness while category is noise. Bayes-optimal given the " *
+                         "belief, not oracle-optimal.")
+        mkpath(dirname(args["out"]))
+        open(args["out"], "w") do io; JSON3.pretty(io, out); end
+        println("summary → ", args["out"])
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/apps/credence-pi/eval/train_routing_brain.jl
+++ b/apps/credence-pi/eval/train_routing_brain.jl
@@ -1,0 +1,88 @@
+# Role: eval
+#
+# train_routing_brain.jl — distil the WARM routing belief from the measured oracle grid.
+#
+# Reads the real-model oracle grid (the de-risk fixture:
+# apps/python/credence_router/experiments/routing_dominance/oracle_grid.json — per
+# (model, question) measured MCQ correctness on the 50-item labelled bank) and emits
+# per-model correct/incorrect COUNTS as apps/credence-pi/brain/routing_brain.counts.json.
+# The daemon's wire_routing! reconstructs K StructureBMA posteriors from these counts by
+# replaying `observe` (version-stable, like harm_brain.counts.json — NOT Serialization).
+#
+# Every benchmark item is a SHORT MCQ prompt, so each measured outcome seeds the "short"
+# prompt-length cell; the "long" cell stays at the prior. This is the honest warm belief:
+# we measured per-model accuracy on short prompts only, so the router starts knowing
+# short-prompt accuracy and treats long prompts as partly-unknown (the marginal structure
+# still lends them the overall signal; the length structure's long cell is at prior).
+#
+# v1 ships this belief FROZEN. Online learning of a live correctness signal is deferred —
+# it needs credit assignment across a session's many model calls (ROUTING_DOMINANCE.md).
+#
+# NON-CAUSAL (Role: eval): reads measured data, tallies counts, writes + verifies a
+# fixture. No belief drives a decision here. Run from repo root:
+#   julia --project=. apps/credence-pi/eval/train_routing_brain.jl
+
+push!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..", "src")))
+using Credence
+using JSON3
+using Dates: now
+include(joinpath(@__DIR__, "..", "brain", "feature_brain.jl"))
+using .FeatureBrain: build_model
+include(joinpath(@__DIR__, "..", "brain", "routing_brain.jl"))
+using .RoutingBrain: posterior_accuracy
+
+const GRID = normpath(joinpath(@__DIR__, "..", "..", "python", "credence_router",
+    "experiments", "routing_dominance", "oracle_grid.json"))
+const OUT = normpath(joinpath(@__DIR__, "..", "brain", "routing_brain.counts.json"))
+
+# The routing feature schema — must equal routing.bdsl `routing-features`.
+const FEATS = ["prompt-length"]
+const VALS = [["short", "long"]]
+
+function main()
+    isfile(GRID) || error("oracle grid not found: $GRID (run the oracle first)")
+    data = JSON3.read(read(GRID, String))
+    models = collect(String.(data.models))
+    model_ids = haskey(data, :model_ids) ? collect(String.(data.model_ids)) : copy(models)
+    K = length(models)
+
+    # Tally per-model correct (n1) / incorrect (n0) over every measured grid cell. All
+    # items are short MCQ ⇒ everything lands in the "short" prompt-length cell.
+    n1 = zeros(Int, K); n0 = zeros(Int, K)
+    for (k, v) in data.grid
+        mi = parse(Int, split(String(k), "|")[1])    # "mi|qid", mi is 0-based
+        (v === true) ? (n1[mi + 1] += 1) : (n0[mi + 1] += 1)
+    end
+
+    per_model = [Dict("contexts" => [Dict("ctx" => ["short"], "n1" => n1[i], "n0" => n0[i])])
+                 for i in 1:K]
+    out = Dict(
+        "artifact" => "credence-pi warm routing belief P(correct|prompt-length) — per-model counts",
+        "source" => "oracle_grid.json (real-model de-risk: 3 frontier models × 50 labelled MCQ)",
+        "models" => models, "model_ids" => model_ids,
+        "features" => FEATS, "feature_values" => VALS,
+        "note" => "All items are short MCQ ⇒ short cell only; long cell stays at prior. " *
+                  "Daemon reconstructs K posteriors by replaying these counts via observe. " *
+                  "Frozen in v1 (no live correctness signal yet — needs credit assignment).",
+        "trained_at" => string(now()), "frozen" => true,
+        "per_model" => per_model)
+    open(OUT, "w") do io; JSON3.pretty(io, out); end
+    println("wrote per-model counts → $OUT")
+    for i in 1:K
+        acc = n1[i] / (n1[i] + n0[i])
+        println("  ", rpad(models[i], 8), " (", model_ids[i], "): n1=$(n1[i]) n0=$(n0[i]) ",
+                "measured acc=", round(acc; digits=3))
+    end
+
+    # Verify the shipped counts reconstruct into the warm belief, and report the
+    # posterior-mean accuracy the router will actually use at a short-prompt context.
+    model = build_model(FEATS, VALS; p_edge = 0.5)
+    tops = RoutingBrain._reconstruct_routing_tops(model, K, OUT)
+    println("warm belief P(correct|short) the router will use (Beta-shrunk posterior mean):")
+    for i in 1:K
+        θ = posterior_accuracy(model, tops[i], ["short"])
+        println("  ", rpad(models[i], 8), " θ=", round(θ; digits=3))
+    end
+end
+
+main()

--- a/apps/credence-pi/openclaw-plugin/README.md
+++ b/apps/credence-pi/openclaw-plugin/README.md
@@ -59,6 +59,8 @@ interception point is an OpenClaw **plugin** `before_tool_call` hook. See
 | `hookTimeoutMs` | `3000` | max wait for the daemon decision before failing open |
 | `approvalTimeoutMs` | `120000` | how long OpenClaw waits for the user on an `ask` before denying |
 | `redactToolInputs` | `false` | omit tool-call inputs from sensor events (they can carry secrets); ask-preview becomes generic |
+| `shadowMode` | `false` | observe-only: brain decides + daemon logs, body never enforces or overrides the model |
+| `routing` | `false` | enable EU-max **model routing** via `before_model_resolve` (see below) |
 | `silent` | `false` | suppress info/warn logs |
 | `pricing` | — | per-model USD/Mtok overrides: `{ "<model>": { "input": n, "output": n, "cacheRead": n, "cacheWrite": n } }` |
 
@@ -70,6 +72,47 @@ The built-in price table is approximate; set `pricing` for an exact
 dollars-saved figure for your providers. Unknown/unpriced models log
 `usd: null` (token counts still recorded; the Move-2 surface applies a
 token×price fallback).
+
+## Model routing (opt-in)
+
+With `routing: true` the plugin also registers a `before_model_resolve`
+hook: for each turn it posts a `route-request` (carrying the prompt's
+length feature) to the daemon and applies the brain's chosen model as
+OpenClaw's `modelOverride` / `providerOverride`. The decision is the
+**same EU-max** the governor runs — `argmax_a [ value·P(correct|X) − cost_a ]`
+over the declared roster, through the one canonical `optimise` — so
+credence-pi picks the cheapest model whose expected accuracy justifies it
+under the active profile.
+
+| brain effector | OpenClaw result |
+|---|---|
+| `route` | `{ modelOverride, providerOverride }` from the chosen model |
+| (timeout / daemon down / no roster) | no override — OpenClaw keeps its configured model (fail open) |
+
+**To enable:**
+
+1. The daemon must have a routing roster. The shipped `bdsl/routing.bdsl`
+   declares one (haiku / sonnet / opus) plus `correct-answer-value` in
+   `utility.bdsl` (the per-profile dial: low ⇒ cost-sensitive, high ⇒
+   quality-sensitive). Absent ⇒ routing stays inert and the daemon is
+   governance-only.
+2. Set `routing: true` in the plugin config. The `before_model_resolve`
+   hook is active out of the box on current OpenClaw (like `llm_output`);
+   the plugin registers it defensively, so an older host that lacks it just
+   runs without routing.
+3. `shadowMode: true` logs the would-route per turn without changing the
+   model — use it to see routing decisions on real traffic first.
+
+**What the belief is.** The per-model accuracy belief is **warm-seeded from
+measured data** (`brain/routing_brain.counts.json`, distilled from the
+3-frontier-model oracle grid by `eval/train_routing_brain.jl`) so routing is
+calibrated from install. It is **frozen** in this version: the cost-routing
+behaviour is the proven result, but online learning of a live correctness
+signal is deferred — it needs credit assignment across a session's many
+model calls (see `eval/results/ROUTING_DOMINANCE.md`). Only `prompt-length`
+is conditioned on, because it is the one feature honestly extractable from a
+raw prompt; the structure-BMA collapses it to the marginal if it doesn't
+predict accuracy.
 
 ## Develop
 

--- a/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
+++ b/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
@@ -32,7 +32,12 @@
       },
       "shadowMode": {
         "type": "boolean",
-        "description": "Observe-only: the brain still decides and the daemon logs the decision, but the body never enforces (always proceeds). Use to measure what governance WOULD do on real usage without affecting runs.",
+        "description": "Observe-only: the brain still decides and the daemon logs the decision, but the body never enforces (always proceeds / never overrides the model). Use to measure what governance and routing WOULD do on real usage without affecting runs.",
+        "default": false
+      },
+      "routing": {
+        "type": "boolean",
+        "description": "Enable EU-max model routing: register before_model_resolve and override the model per request via the daemon's route decision. Needs a daemon configured with a routing roster (bdsl/routing.bdsl, shipped by default). The before_model_resolve hook is active out of the box on current OpenClaw (like llm_output); the plugin registers it defensively so an older host that lacks it just runs without routing. Fails open (daemon down / no roster => OpenClaw keeps its configured model). Off by default.",
         "default": false
       },
       "silent": {

--- a/apps/credence-pi/openclaw-plugin/src/index.ts
+++ b/apps/credence-pi/openclaw-plugin/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./daemon-client.js";
 import { FeatureTracker } from "./features.js";
 import { SafetyTracker } from "./safety.js";
+import { extractRoutingFeatures } from "./routing-features.js";
 import { buildPriceTable, computeTurnCost, type PriceTable } from "./cost.js";
 import type {
   PluginEntry,
@@ -38,6 +39,8 @@ import type {
   BeforeToolCallResult,
   AfterToolCallEvent,
   LlmOutputEvent,
+  BeforeModelResolveEvent,
+  BeforeModelResolveResult,
   ToolContext,
   RequireApprovalPayload,
 } from "./openclaw-types.js";
@@ -109,6 +112,31 @@ export function mapSignal(
   }
 }
 
+// Map a `route` effector signal to OpenClaw's model override. A missing/timed-out/
+// non-route signal ⇒ undefined ⇒ OpenClaw keeps its configured model (fail open, exactly
+// like the daemon being down). In shadow mode we log the would-route and still defer, so
+// operators can see routing decisions on real traffic without changing the model used.
+export function mapRouteSignal(
+  sig: SignalEnvelope | undefined,
+  shadowMode: boolean,
+  log: Logger,
+): BeforeModelResolveResult | undefined {
+  if (!sig || sig.effector !== "route") return undefined;
+  const p = sig.parameters ?? {};
+  const model = typeof p.model === "string" ? p.model : undefined;
+  const provider = typeof p.provider === "string" ? p.provider : undefined;
+  if (!model) return undefined;
+  if (shadowMode) {
+    log(
+      `credence-pi[shadow]: would route to ${provider ?? "?"}/${model} — keeping OpenClaw's model (shadow mode)`,
+    );
+    return undefined;
+  }
+  const result: BeforeModelResolveResult = { modelOverride: model };
+  if (provider) result.providerOverride = provider;
+  return result;
+}
+
 export interface GovernorOpts {
   hookTimeoutMs: number;
   approvalTimeoutMs: number;
@@ -127,10 +155,14 @@ export interface Governor {
     event: BeforeToolCallEvent,
     ctx: ToolContext,
   ) => Promise<BeforeToolCallResult | undefined>;
+  beforeModelResolve: (
+    event: BeforeModelResolveEvent,
+    ctx: ToolContext,
+  ) => Promise<BeforeModelResolveResult | undefined>;
   afterToolCall: (event: AfterToolCallEvent, ctx: ToolContext) => Promise<void>;
   llmOutput: (event: LlmOutputEvent, ctx: ToolContext) => Promise<void>;
   cleanup: () => void;
-  /** Test/inspection accessor: in-flight tool_call awaiters. */
+  /** Test/inspection accessor: in-flight sensor awaiters (tool-call + route). */
   pendingCount: () => number;
 }
 
@@ -164,13 +196,12 @@ export function createGovernor(
   let announcedUp = false;
   let down = false;
 
-  async function beforeToolCall(
-    event: BeforeToolCallEvent,
-    ctx: ToolContext,
-  ): Promise<BeforeToolCallResult | undefined> {
-    const eventId = newEventId();
-    const t0 = Date.now();
-    const signalPromise = new Promise<SignalEnvelope | undefined>((resolve) => {
+  // Register an awaiter for the correlated effector signal (dispatched by the single SSE
+  // consumer on `in_response_to == eventId`) and a fail-open timeout. Shared by
+  // beforeToolCall (tool-proposed → proceed/block/ask) and beforeModelResolve
+  // (route-request → route): same wire, same correlation, same timeout discipline.
+  function awaitSignal(eventId: string): Promise<SignalEnvelope | undefined> {
+    return new Promise<SignalEnvelope | undefined>((resolve) => {
       const timer = setTimeout(() => {
         awaiters.delete(eventId);
         resolve(undefined);
@@ -181,6 +212,15 @@ export function createGovernor(
         resolve(sig);
       });
     });
+  }
+
+  async function beforeToolCall(
+    event: BeforeToolCallEvent,
+    ctx: ToolContext,
+  ): Promise<BeforeToolCallResult | undefined> {
+    const eventId = newEventId();
+    const t0 = Date.now();
+    const signalPromise = awaitSignal(eventId);
 
     const features = tracker.extractAndRecord(event, ctx);
     // Add the safety (taint-flow) features against the session's causal taint state. The
@@ -251,6 +291,48 @@ export function createGovernor(
     return mapSignal(sig, eventId, client, approvalTimeoutMs);
   }
 
+  // before_model_resolve: route this turn to the EU-max model. Same wire as
+  // beforeToolCall — post a route-request, await the correlated `route` signal — but the
+  // signal carries {model, provider} the brain chose, mapped to OpenClaw's override.
+  // Fail open everywhere (daemon down / slow / routing unconfigured ⇒ undefined ⇒
+  // OpenClaw keeps its configured model). The brain decides; the body only translates.
+  async function beforeModelResolve(
+    event: BeforeModelResolveEvent,
+    ctx: ToolContext,
+  ): Promise<BeforeModelResolveResult | undefined> {
+    const eventId = newEventId();
+    const signalPromise = awaitSignal(eventId);
+
+    const features = extractRoutingFeatures(event);
+    const post = await client.postSensor({
+      event_type: "route-request",
+      event_id: eventId,
+      session_id: ctx.sessionId ?? ctx.sessionKey ?? "",
+      timestamp: new Date().toISOString(),
+      features,
+    });
+
+    if (!post.ok) {
+      awaiters.get(eventId)?.(undefined); // clean up timer + awaiter
+      if (!warnedDown) {
+        log("credence-pi: daemon unreachable; routing skipped (OpenClaw keeps its model)");
+        warnedDown = true;
+      }
+      down = true;
+      announcedUp = false;
+      return undefined; // fail open
+    }
+    if (down && !announcedUp) {
+      log("credence-pi: daemon reachable again; routing resumed");
+      announcedUp = true;
+      down = false;
+      warnedDown = false;
+    }
+
+    const sig = await signalPromise;
+    return mapRouteSignal(sig, shadowMode, log);
+  }
+
   async function afterToolCall(
     event: AfterToolCallEvent,
     ctx: ToolContext,
@@ -302,6 +384,7 @@ export function createGovernor(
 
   return {
     beforeToolCall,
+    beforeModelResolve,
     afterToolCall,
     llmOutput,
     cleanup,
@@ -330,6 +413,7 @@ const plugin: PluginEntry = {
     const silent = cfg.silent === true;
     const redactToolInputs = cfg.redactToolInputs === true;
     const shadowMode = cfg.shadowMode === true;
+    const routingEnabled = cfg.routing === true;
     const priceTable = buildPriceTable(cfg.pricing);
 
     const log: Logger = (m, e) => {
@@ -369,6 +453,25 @@ const plugin: PluginEntry = {
         "credence-pi: llm_output hook unavailable (set hooks.allowConversationAccess:true for the cost signal)",
         err,
       );
+    }
+
+    // Model routing (opt-in). Off by default: it overrides which model runs, needs
+    // hooks.allowConversationAccess:true, and a daemon configured with a routing roster
+    // (bdsl/routing.bdsl). When off we register no hook, so a governance-only install
+    // adds zero per-turn latency. Fails open: daemon down / no roster ⇒ OpenClaw's model.
+    if (routingEnabled) {
+      try {
+        api.on("before_model_resolve", gov.beforeModelResolve, {
+          priority: 100,
+          timeoutMs: hookTimeoutMs + 1_000,
+        });
+        log("credence-pi: model routing ENABLED (before_model_resolve)");
+      } catch (err) {
+        log(
+          "credence-pi: before_model_resolve hook unavailable on this host; routing disabled",
+          err,
+        );
+      }
     }
 
     // Close the SSE stream + drain awaiters on reset/delete/reload so a

--- a/apps/credence-pi/openclaw-plugin/src/openclaw-types.ts
+++ b/apps/credence-pi/openclaw-plugin/src/openclaw-types.ts
@@ -48,6 +48,18 @@ export interface BeforeToolCallResult {
   requireApproval?: RequireApprovalPayload;
 }
 
+// before_model_resolve: runs before model resolution with the prompt only (no session
+// messages). Returning a provider/model override switches the model for this turn — the
+// seam credence-pi uses to route by EU-max. Needs hooks.allowConversationAccess:true.
+export interface BeforeModelResolveEvent {
+  prompt?: string;
+}
+
+export interface BeforeModelResolveResult {
+  providerOverride?: string;
+  modelOverride?: string;
+}
+
 export interface AfterToolCallEvent {
   toolName: string;
   params: Record<string, unknown>;
@@ -136,6 +148,11 @@ export interface OpenClawPluginApi {
   on(
     hook: "llm_output",
     handler: HookHandler<LlmOutputEvent, void>,
+    opts?: HookOpts,
+  ): void;
+  on(
+    hook: "before_model_resolve",
+    handler: HookHandler<BeforeModelResolveEvent, BeforeModelResolveResult>,
     opts?: HookOpts,
   ): void;
   // Catch-all for hooks we register opportunistically (e.g. agent_end);

--- a/apps/credence-pi/openclaw-plugin/src/routing-features.ts
+++ b/apps/credence-pi/openclaw-plugin/src/routing-features.ts
@@ -1,0 +1,31 @@
+// routing-features.ts — the body's sensory periphery for MODEL ROUTING.
+//
+// before_model_resolve hands the plugin the prompt and nothing else, so the only
+// HONESTLY-extractable routing feature is the prompt's length. Semantic category — the
+// signal the offline oracle actually measured — is NOT available live without a
+// classifier, which would be an arbitrary, unmeasured component (and the project bars
+// arbitrary constants/heuristics in the reasoning path). The daemon's structure-BMA
+// discovers whether length predicts accuracy and collapses to the marginal if it does
+// not, so declaring only length is honest and self-correcting.
+//
+// The short/long boundary is the ONE train/live synchronisation point. Training
+// (apps/credence-pi/eval/train_routing_brain.jl) seeds the "short" prompt-length cell
+// from the short-MCQ oracle bank — so this boundary defines the regime the daemon's warm
+// belief was measured on. If you change it, the warm belief's "short" cell no longer
+// matches what the body now calls "short". Keep the value here and documented.
+
+import type { BeforeModelResolveEvent } from "./openclaw-types.js";
+
+export type RoutingFeatures = Record<string, string>;
+
+// Prompts at or below this many characters are "short" (MCQ-scale and brief asks — the
+// regime the warm belief was measured on); longer prompts are "long" (unmeasured warm
+// belief leans on the marginal structure until online learning lands).
+export const PROMPT_LENGTH_SHORT_MAX_CHARS = 1000;
+
+export function extractRoutingFeatures(event: BeforeModelResolveEvent): RoutingFeatures {
+  const prompt = typeof event.prompt === "string" ? event.prompt : "";
+  return {
+    "prompt-length": prompt.length <= PROMPT_LENGTH_SHORT_MAX_CHARS ? "short" : "long",
+  };
+}

--- a/apps/credence-pi/openclaw-plugin/tests/index.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/index.test.ts
@@ -55,6 +55,9 @@ function harness(postOk = true, shadowMode = false) {
     lastProposedId: () =>
       [...posted].reverse().find((e) => e.event_type === "tool-proposed")
         ?.event_id as string,
+    lastRouteId: () =>
+      [...posted].reverse().find((e) => e.event_type === "route-request")
+        ?.event_id as string,
   };
 }
 
@@ -178,6 +181,76 @@ test("llm_output: posts turn-cost with reconstructed USD", async () => {
   const t = h.find("turn-cost") as { usd: number; total_tokens: number } | undefined;
   assert.equal(t?.usd, 90);
   assert.equal(t?.total_tokens, 2_000_000);
+  h.gov.cleanup();
+});
+
+test("before_model_resolve: route signal → model + provider override; feature sensed", async () => {
+  const h = harness();
+  const p = h.gov.beforeModelResolve({ prompt: "a short question" }, ctx);
+  await flush();
+  assert.equal(h.gov.pendingCount(), 1);
+  h.signal("route", h.lastRouteId(), {
+    model: "claude-haiku-4-5",
+    provider: "anthropic",
+    name: "haiku",
+  });
+  const r = await p;
+  assert.equal(r?.modelOverride, "claude-haiku-4-5");
+  assert.equal(r?.providerOverride, "anthropic");
+  assert.equal(h.gov.pendingCount(), 0);
+  const rr = h.find("route-request") as { features: Record<string, string> } | undefined;
+  assert.equal(rr?.features["prompt-length"], "short");
+  h.gov.cleanup();
+});
+
+test("before_model_resolve: long prompt → prompt-length=long feature", async () => {
+  const h = harness();
+  const p = h.gov.beforeModelResolve({ prompt: "x".repeat(1001) }, ctx);
+  await flush();
+  h.signal("route", h.lastRouteId(), { model: "claude-opus-4-8", provider: "anthropic" });
+  await p;
+  const rr = h.find("route-request") as { features: Record<string, string> } | undefined;
+  assert.equal(rr?.features["prompt-length"], "long");
+  h.gov.cleanup();
+});
+
+test("before_model_resolve: timeout → undefined (OpenClaw default), no leak", async () => {
+  const h = harness();
+  const r = await h.gov.beforeModelResolve({ prompt: "x" }, ctx); // no signal; 50ms timeout
+  assert.equal(r, undefined);
+  assert.equal(h.gov.pendingCount(), 0);
+  h.gov.cleanup();
+});
+
+test("before_model_resolve: daemon down → undefined immediately, no leak", async () => {
+  const h = harness(false);
+  const r = await h.gov.beforeModelResolve({ prompt: "x" }, ctx);
+  assert.equal(r, undefined);
+  assert.equal(h.gov.pendingCount(), 0);
+  h.gov.cleanup();
+});
+
+test("before_model_resolve: shadow mode → undefined (keeps model) but route-request sensed", async () => {
+  const h = harness(true, true); // postOk, shadowMode
+  const p = h.gov.beforeModelResolve({ prompt: "x" }, ctx);
+  await flush();
+  h.signal("route", h.lastRouteId(), {
+    model: "claude-opus-4-8",
+    provider: "anthropic",
+    name: "opus",
+  });
+  assert.equal(await p, undefined); // brain routed, but shadow never overrides
+  assert.ok(h.find("route-request"), "route-request must still be posted in shadow mode");
+  h.gov.cleanup();
+});
+
+test("before_model_resolve: route signal with no model → undefined (fail open)", async () => {
+  const h = harness();
+  const p = h.gov.beforeModelResolve({ prompt: "x" }, ctx);
+  await flush();
+  h.signal("route", h.lastRouteId(), {}); // route effector but empty params
+  assert.equal(await p, undefined);
+  assert.equal(h.gov.pendingCount(), 0);
   h.gov.cleanup();
 });
 

--- a/apps/credence-pi/tests/julia/test_routing.jl
+++ b/apps/credence-pi/tests/julia/test_routing.jl
@@ -1,0 +1,169 @@
+#!/usr/bin/env julia
+# Role: tests
+"""
+    test_routing.jl — live model-routing wiring (brain + daemon transport).
+
+Section A (brain): wire_routing! reads the declared roster + reward + features and
+installs env[:route-decide]; the warm belief reconstructs the measured per-model
+accuracy (Beta-shrunk); route-decide returns the EU-max model and FLIPS with the profile
+reward — cost-hawk → cheap, quality-hawk → best — the Wald per-profile divergence, live,
+through the one canonical `optimise`.
+
+Section B (daemon transport): a route-request sensor event emits a `route` effector
+signal carrying the chosen model; routing is INERT without a declared roster; a
+route-request never touches the governance posterior (separate belief).
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "..", "src"))
+using Credence
+using Credence: Eval, Parse, Identity, weights, expect
+using JSON3
+
+include(joinpath(@__DIR__, "..", "..", "brain", "feature_brain.jl"))
+using .FeatureBrain: build_model
+include(joinpath(@__DIR__, "..", "..", "brain", "routing_brain.jl"))
+using .RoutingBrain: wire_routing!, route, posterior_accuracy
+
+const BDSL_DIR = joinpath(@__DIR__, "..", "..", "bdsl")
+const TOL = 1e-12
+const PASSED = String[]
+ok(name) = (push!(PASSED, name); println("PASSED: ", name))
+
+# An env carrying the declared routing data (routing.bdsl + utility.bdsl). reward is
+# overridable to exercise profiles. routing.bdsl uses only core forms, so no stdlib.
+function routing_env(; reward = nothing)
+    env = Eval.default_env(); env[:__toplevel__] = true
+    for f in ("utility.bdsl", "routing.bdsl")
+        for expr in Parse.parse_all(read(joinpath(BDSL_DIR, f), String))
+            Eval.eval_dsl(expr, env)
+        end
+    end
+    reward === nothing || (env[Symbol("correct-answer-value")] = reward)
+    env
+end
+
+# ── A. wire_routing! + route-decide ─────────────────────────────────────
+
+let env = routing_env()
+    rt = wire_routing!(env)
+    @assert rt !== nothing
+    @assert rt.model_ids == ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-8"]
+    @assert rt.providers == ["anthropic", "anthropic", "anthropic"]
+    @assert length(rt.costs) == 3 && rt.costs[1] < rt.costs[2] < rt.costs[3]
+    ok("wire_routing! parses the declared roster (3 models, ascending cost)")
+
+    # Warm belief: posterior-mean accuracy at a short prompt is ordered cheap<mid<exp,
+    # shrunk from the measured 0.88/0.96/0.98 toward the Beta(2,2) prior.
+    θ = [posterior_accuracy(rt.model, rt.tops[i], ["short"]) for i in 1:3]
+    @assert θ[1] < θ[2] < θ[3]
+    @assert 0.80 < θ[1] < 0.90 && 0.90 < θ[3] < 0.96
+    ok("warm belief: P(correct|short) ordered haiku<sonnet<opus, Beta-shrunk ($(round.(θ, digits = 3)))")
+
+    @assert haskey(env, Symbol("route-decide"))
+    ok("wire_routing! installed env[:route-decide]")
+end
+
+# Cost-hawk (default reward 0.02): route the CHEAP model on every prompt-length (the
+# correct answer is worth ≈ one call, so the small accuracy gain never justifies paying).
+let env = routing_env()
+    decide = (wire_routing!(env); env[Symbol("route-decide")])
+    for len in ("short", "long")
+        choice = decide(Dict("prompt-length" => len))
+        @assert choice["model"] == "claude-haiku-4-5"  # cost-hawk/$len
+    end
+    ok("cost-hawk (reward 0.02): routes the cheap model (haiku) at short AND long")
+end
+
+# Quality-hawk (reward 1.0): route the BEST-BELIEVED model where the belief is warm.
+let env = routing_env(reward = 1.0)
+    wire_routing!(env)
+    choice = env[Symbol("route-decide")](Dict("prompt-length" => "short"))
+    @assert choice["model"] == "claude-opus-4-8"
+    @assert choice["provider"] == "anthropic" && choice["name"] == "opus"
+    ok("quality-hawk (reward 1.0): routes the best-believed model (opus) on a short prompt")
+end
+
+# Per-profile divergence on ONE shared belief is the Wald core: same warm belief, the
+# routed model flips with the reward alone.
+let
+    c_hawk = (e = routing_env(reward = 0.02); wire_routing!(e); e[Symbol("route-decide")](Dict("prompt-length" => "short")))
+    q_hawk = (e = routing_env(reward = 1.0);  wire_routing!(e); e[Symbol("route-decide")](Dict("prompt-length" => "short")))
+    @assert c_hawk["model"] != q_hawk["model"]
+    ok("Wald divergence, live: same belief, reward 0.02 → $(c_hawk["name"]), reward 1.0 → $(q_hawk["name"])")
+end
+
+# Inert when no roster is declared (utility.bdsl only): wire_routing! returns nothing and
+# installs nothing — a governance-only install is unaffected.
+let
+    env = Eval.default_env(); env[:__toplevel__] = true
+    for expr in Parse.parse_all(read(joinpath(BDSL_DIR, "utility.bdsl"), String))
+        Eval.eval_dsl(expr, env)
+    end
+    @assert wire_routing!(env) === nothing
+    @assert !haskey(env, Symbol("route-decide"))
+    ok("inert: no routing-models declared ⇒ wire_routing! installs no route-decide")
+end
+
+# Cold fallback: a missing warm file falls back to uniform priors (loudly), and an
+# uninformative belief routes the cheapest model even under a quality reward (it cannot
+# justify paying more for accuracy it has no evidence of).
+let env = routing_env(reward = 1.0)
+    wire_routing!(env; warm_path = "")
+    choice = env[Symbol("route-decide")](Dict("prompt-length" => "short"))
+    @assert choice["model"] == "claude-haiku-4-5"
+    ok("cold fallback: uniform belief routes the cheapest model even at reward 1.0")
+end
+
+# ── B. Daemon transport: route-request → route signal ───────────────────
+
+include(joinpath(@__DIR__, "..", "..", "daemon", "server.jl"))
+using .Server: init_state, handle_sensor_event, snapshot
+
+const DAEMON_BDSL = joinpath(@__DIR__, "..", "..", "bdsl")
+
+# init_state loads routing.bdsl and runs wire_routing! (warm belief from the committed
+# counts), so the daemon routes out of the box.
+let path = tempname() * ".jsonl"
+    state = init_state(; bdsl_dir = DAEMON_BDSL, log_path = path)
+    @assert haskey(state.env, Symbol("route-decide"))
+    ok("daemon init_state wires routing from bdsl/routing.bdsl (route-decide installed)")
+
+    # A route-request emits exactly one `route` signal carrying the chosen model. The
+    # default profile is cost-hawk (correct-answer-value 0.02) ⇒ the cheap model.
+    w_before = weights(state.posterior[])
+    ack = handle_sensor_event(state, Dict{String, Any}(
+        "event_type" => "route-request", "event_id" => "rt_1",
+        "features" => Dict("prompt-length" => "short")))
+    @assert ack["ack"] == true && ack["event_id"] == "rt_1"
+    sigs = snapshot(state.signal_queue)
+    @assert length(sigs) == 1
+    @assert sigs[1]["effector"] == "route"
+    @assert sigs[1]["in_response_to"] == "rt_1"
+    @assert sigs[1]["parameters"]["model"] == "claude-haiku-4-5"
+    @assert sigs[1]["parameters"]["provider"] == "anthropic"
+    ok("route-request → single `route` signal with the EU-max model (cost-hawk → haiku)")
+
+    # Routing is a SEPARATE belief: a route-request must not touch the governance posterior.
+    # credence-lint: allow — precedent:test-oracle — structure-posterior equality oracle (routing must not learn governance)
+    @assert weights(state.posterior[]) == w_before
+    ok("route-request leaves the governance posterior untouched (separate belief)")
+    rm(path; force = true)
+end
+
+# Inert: with routing unconfigured (no route-decide), a route-request emits no signal —
+# the body times out and fails open to OpenClaw's default model.
+let path = tempname() * ".jsonl"
+    state = init_state(; bdsl_dir = DAEMON_BDSL, log_path = path)
+    delete!(state.env, Symbol("route-decide"))
+    handle_sensor_event(state, Dict{String, Any}(
+        "event_type" => "route-request", "event_id" => "rt_inert",
+        "features" => Dict("prompt-length" => "short")))
+    @assert isempty(snapshot(state.signal_queue))
+    ok("route-request with routing unconfigured emits no signal (body fails open)")
+    rm(path; force = true)
+end
+
+println()
+println("=" ^ 60)
+println("ALL ", length(PASSED), " ASSERTIONS PASSED")
+println("=" ^ 60)

--- a/apps/python/credence_router/experiments/routing_dominance/baselines.py
+++ b/apps/python/credence_router/experiments/routing_dominance/baselines.py
@@ -1,0 +1,108 @@
+# Role: eval
+"""Competitor routing systems — the "other systems out there" the proof must beat.
+
+Each is a profile-agnostic fixed rule (or a clairvoyant upper bound), standing in for
+a class of deployed router:
+
+  - make_always(k)        single-model policies (cost floor / quality ceiling bounds)
+  - make_argmax_accuracy  "just use the most accurate model per category" (cost-blind)
+  - make_best_fixed_table the best single category→model table serving ALL profiles —
+                          the strongest profile-agnostic static router (Wald foil)
+  - make_threshold_router RouteLLM-style 2-bin cheap/strong split at a difficulty cut
+  - make_oracle_cascade   FrugalGPT-style cheapest-first escalation, charged the
+                          CUMULATIVE cost of every rung tried; clairvoyant (stops at
+                          the first actually-correct rung) — an UPPER BOUND on any real
+                          cascade, which needs a fallible verifier to decide to stop
+
+None of these touch the belief; they are declared non-Bayesian foils
+(baseline-comparison precedent). Every arm — including EU-max — maps a question to a
+realised (correct: bool, cost: float) outcome against the same frozen oracle grid, so
+all arms are scored on identical ground truth.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# An arm maps a question (any object with .id and .category) to a realised outcome.
+Arm = Callable[[object], "tuple[bool, float]"]
+
+Grid = "dict[tuple[int, str], bool]"  # (model_idx, question_id) -> was_correct
+
+
+def empirical_accuracy(grid, train_ids, questions, n_models, categories):
+    """Per-(model, category) train-split accuracy: dict[(m, cat)] -> (acc, n)."""
+    ids_by_cat = {
+        c: [q.id for q in questions if q.id in train_ids and q.category == c]
+        for c in categories
+    }
+    acc = {}
+    for m in range(n_models):
+        for c in categories:
+            ids = ids_by_cat[c]
+            if ids:
+                k = sum(1 for qid in ids if grid[(m, qid)])
+                acc[(m, c)] = (k / len(ids), len(ids))
+            else:
+                acc[(m, c)] = (0.5, 0)  # credence-lint: allow — precedent:baseline-comparison — no-data fallback for a non-Bayesian foil
+    return acc
+
+
+# credence-lint: allow — precedent:baseline-comparison — single-model policy (cost/quality bound)
+def make_always(grid, costs, k: int) -> Arm:
+    return lambda q: (grid[(k, q.id)], costs[k])
+
+
+def make_argmax_accuracy(grid, costs, acc, categories, n_models) -> Arm:
+    """Most accurate model per category (ties → cheaper). Cost-blind."""
+    # credence-lint: allow — precedent:baseline-comparison — cost-blind argmax-of-means foil
+    best = {
+        c: min(range(n_models), key=lambda m: (-acc[(m, c)][0], costs[m]))
+        for c in categories
+    }
+    return lambda q: (grid[(best[q.category], q.id)], costs[best[q.category]])
+
+
+def make_best_fixed_table(grid, costs, acc, categories, n_models, profiles) -> Arm:
+    """Single category→model table maximising mean expected welfare across profiles.
+
+    The best a profile-agnostic static router can do: it must serve every profile with
+    one table, so it cannot be the per-profile argmax for more than one (Wald).
+    """
+    def mean_welfare(m, c):  # credence-lint: allow — precedent:baseline-comparison — profile-blind static-table foil
+        return sum(r * acc[(m, c)][0] - costs[m] for r in profiles.values()) / len(profiles)
+
+    best = {c: max(range(n_models), key=lambda m: mean_welfare(m, c)) for c in categories}
+    return lambda q: (grid[(best[q.category], q.id)], costs[best[q.category]])
+
+
+def make_threshold_router(grid, costs, acc, categories, n_models) -> Arm:
+    """RouteLLM-style 2-bin router: cheapest vs most-capable, split at a difficulty cut.
+
+    The cut is the midpoint of the cheapest model's per-category accuracy range — a
+    tuned difficulty threshold. Binary by construction: cannot express a 3-way ladder.
+    """
+    cheap = min(range(n_models), key=lambda m: costs[m])
+    strong = max(range(n_models), key=lambda m: costs[m])
+    cheap_acc = {c: acc[(cheap, c)][0] for c in categories}
+    # credence-lint: allow — precedent:baseline-comparison — tuned fixed difficulty threshold (RouteLLM foil)
+    cut = (min(cheap_acc.values()) + max(cheap_acc.values())) / 2.0
+    pick = {c: (cheap if cheap_acc[c] >= cut else strong) for c in categories}
+    return lambda q: (grid[(pick[q.category], q.id)], costs[pick[q.category]])
+
+
+def make_oracle_cascade(grid, costs, order) -> Arm:
+    """Cheapest-first escalation, charged the cumulative cost of every rung tried.
+
+    Clairvoyant: stops at the first actually-correct rung. A real cascade needs a
+    fallible verifier to decide when to stop, so this is an upper bound on any cascade.
+    """
+    def arm(q):  # credence-lint: allow — precedent:baseline-comparison — clairvoyant FrugalGPT-cascade upper bound
+        spent = 0.0
+        for m in order:
+            spent += costs[m]
+            if grid[(m, q.id)]:
+                return (True, spent)
+        return (False, spent)
+
+    return arm

--- a/apps/python/credence_router/experiments/routing_dominance/dominance.py
+++ b/apps/python/credence_router/experiments/routing_dominance/dominance.py
@@ -1,0 +1,215 @@
+# Role: eval
+"""Routing-dominance proof.
+
+Claim: for any set of ≥2 profiles, per-profile EU-max routing weakly dominates every
+competitor system and is the only arm optimal across all profiles (Wald complete
+class). Offline + deterministic against a frozen oracle grid (toy: synthetic; real:
+measured per-model MCQ correctness from oracle.py).
+
+The EU-max arm's routing decisions are made by the skin (skin.optimise over the
+Beta-Bernoulli belief in routing_state.py). Competitors are declared foils
+(baselines.py). Welfare is scored on identical ground truth for every arm:
+
+    welfare_P(arm) = Σ_q [ reward_P · 1{correct} − cost ]
+
+so a lower bill at equal correctness, or more correct answers at equal bill, both show
+up as higher welfare. The belief is shared across profiles (Savage: one posterior,
+many utilities); only the per-profile `reward` differs.
+
+Run the zero-spend proof of the mechanism:
+    uv run python apps/python/credence_router/experiments/routing_dominance/dominance.py --toy
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from types import SimpleNamespace
+
+import baselines as B
+import routing_state as RS
+
+
+def train_state(skin, grid, train_ids, questions, n_models, categories):
+    """Condition the Beta-Bernoulli belief on every model's correctness over the train
+    split. All arms train on this identical split (the cache holds every model's answer
+    to every question — the offline counterfactual advantage)."""
+    cat_index = {c: i for i, c in enumerate(categories)}
+    s = RS.build_state(skin, n_models, len(categories))
+    for q in questions:
+        if q.id in train_ids:
+            ci = cat_index[q.category]
+            for m in range(n_models):
+                s = RS.observe_correct(skin, s, m, ci, grid[(m, q.id)])
+    return s
+
+
+def eu_max_arm(skin, state, grid, costs, categories, reward):
+    cat_index = {c: i for i, c in enumerate(categories)}
+
+    def arm(q):
+        m = RS.route(skin, state, costs, cat_index[q.category], reward, len(categories))
+        return (grid[(m, q.id)], costs[m])
+
+    return arm
+
+
+def welfare(arm, test_qs, reward):
+    return sum(reward * (1.0 if correct else 0.0) - cost for correct, cost in map(arm, test_qs))
+
+
+def eu_routing_table(skin, state, costs, categories, reward):
+    """The category→model table EU-max picks under `reward` (for display)."""
+    return {
+        c: RS.route(skin, state, costs, i, reward, len(categories))
+        for i, c in enumerate(categories)
+    }
+
+
+def run(grid, questions, model_names, costs, categories, profiles, seeds, train_frac=0.6):
+    ids = [q.id for q in questions]
+    n_models = len(model_names)
+    cheapest = min(range(n_models), key=lambda m: costs[m])
+    priciest = max(range(n_models), key=lambda m: costs[m])
+    cascade_order = sorted(range(n_models), key=lambda m: costs[m])
+
+    # regrets[arm][profile] -> list over seeds; also keep raw welfare for the first seed.
+    regrets: dict[str, dict[str, list[float]]] = {}
+    first_seed_tables: dict[str, dict] = {}
+    first_seed_welfare: dict = {}
+
+    skin = RS.SkinClient(project=RS.REPO_ROOT)
+    skin.initialize()
+    try:
+        for si, seed in enumerate(seeds):
+            rng = random.Random(seed)
+            shuffled = ids[:]
+            rng.shuffle(shuffled)
+            n_train = int(len(ids) * train_frac)
+            train_ids = set(shuffled[:n_train])
+            test_ids = set(shuffled[n_train:])
+            test_qs = [q for q in questions if q.id in test_ids]
+
+            acc = B.empirical_accuracy(grid, train_ids, questions, n_models, categories)
+            state = train_state(skin, grid, train_ids, questions, n_models, categories)
+
+            competitors = {
+                f"always-{model_names[cheapest]}": B.make_always(grid, costs, cheapest),
+                f"always-{model_names[priciest]}": B.make_always(grid, costs, priciest),
+                "argmax-accuracy": B.make_argmax_accuracy(grid, costs, acc, categories, n_models),
+                "best-fixed-table": B.make_best_fixed_table(grid, costs, acc, categories, n_models, profiles),
+                "threshold-router": B.make_threshold_router(grid, costs, acc, categories, n_models),
+                "oracle-cascade": B.make_oracle_cascade(grid, costs, cascade_order),
+            }
+
+            for p, reward in profiles.items():
+                eu = eu_max_arm(skin, state, grid, costs, categories, reward)
+                w_eu = welfare(eu, test_qs, reward)
+                for name, arm in competitors.items():
+                    w_arm = welfare(arm, test_qs, reward)
+                    regrets.setdefault(name, {}).setdefault(p, []).append(w_eu - w_arm)
+                    if si == 0:
+                        first_seed_welfare.setdefault(p, {})["EU-max (credence)"] = w_eu
+                        first_seed_welfare[p][name] = w_arm
+
+            if si == 0:
+                for p, reward in profiles.items():
+                    first_seed_tables[p] = eu_routing_table(skin, state, costs, categories, reward)
+    finally:
+        skin.shutdown()
+
+    _report(model_names, categories, profiles, regrets, first_seed_tables, first_seed_welfare, len(seeds))
+    return regrets
+
+
+def _report(model_names, categories, profiles, regrets, tables, welfare_by_profile, n_seeds):
+    print("\n" + "=" * 72)
+    print("ROUTING-DOMINANCE PROOF  (welfare = reward·correct − cost; higher is better)")
+    print("=" * 72)
+
+    print(f"\nProfiles (reward = $ value of a correct answer): {dict(profiles)}")
+    print("\nEU-max routing table (category → model) — SAME belief, per-profile decision:")
+    for p in profiles:
+        named = {c: model_names[tables[p][c]] for c in categories}
+        print(f"  {p:>14}: {named}")
+    diverge = any(
+        tables[p1][c] != tables[p2][c]
+        for c in categories
+        for p1 in profiles
+        for p2 in profiles
+    )
+    print(f"  → per-profile routing diverges: {diverge}  "
+          f"(no single fixed table is optimal for all profiles — Wald)")
+
+    print(f"\nRealised welfare, first seed (test split):")
+    for p in profiles:
+        row = welfare_by_profile[p]
+        best = max(row.values())
+        print(f"  [{p}]")
+        for name, w in sorted(row.items(), key=lambda kv: -kv[1]):
+            tag = "  ← optimal" if w == best else ""
+            print(f"      {name:>22}: {w:+.4f}{tag}")
+
+    print(f"\nMean regret vs EU-max over {n_seeds} seed(s)  "
+          f"(regret = welfare[EU-max] − welfare[arm]; ≥0 means EU-max ≥ arm):")
+    header = "  " + " " * 22 + "".join(f"{p:>16}" for p in profiles)
+    print(header)
+    for name in regrets:
+        cells = ""
+        for p in profiles:
+            rs = regrets[name][p]
+            mean = sum(rs) / len(rs)
+            winrate = sum(1 for r in rs if r >= -1e-12) / len(rs)
+            cells += f"{mean:>+10.4f}({winrate:.0%})"
+        print(f"  {name:>22}{cells}")
+
+    # Headline: EU-max optimal on all profiles; each competitor suboptimal on ≥1.
+    print("\nVERDICT:")
+    for name in regrets:
+        dominated_on = [p for p in profiles if sum(regrets[name][p]) / len(regrets[name][p]) > 1e-9]
+        if dominated_on:
+            print(f"  EU-max strictly beats {name} on: {dominated_on}")
+        else:
+            print(f"  {name}: ties EU-max on all profiles (it IS a Bayes rule here — i.e. it IS us)")
+    print("  EU-max is optimal on EVERY profile by construction (per-profile argmax).")
+    print("=" * 72 + "\n")
+
+
+def build_toy_oracle():
+    """Controlled 3×3 oracle: 3 models (cheap/mid/exp) × 3 difficulties.
+
+    Correctness pattern (homogeneous per category, so the result is split-invariant —
+    the cleanest demonstration of the theorem, no sampling noise):
+        easy   : all models correct      → cheapest suffices
+        medium : cheap fails, mid+exp ok  → mid is the cheapest adequate model
+        hard   : only exp correct         → must pay for exp to be right
+    """
+    categories = ["easy", "medium", "hard"]
+    model_names = ["cheap", "mid", "exp"]
+    costs = [0.001, 0.005, 0.02]  # rough haiku/sonnet/opus ratio
+    pattern = {"easy": [1, 1, 1], "medium": [0, 1, 1], "hard": [0, 0, 1]}
+    questions = [
+        SimpleNamespace(id=f"{c}{i}", category=c) for c in categories for i in range(6)
+    ]
+    grid = {(m, q.id): bool(pattern[q.category][m]) for q in questions for m in range(len(model_names))}
+    # Profiles = value (in $) of a correct answer. cost-hawk: a correct answer is worth
+    # about one model-call; quality-hawk: worth far more than any call.
+    profiles = {"cost-hawk": 0.01, "quality-hawk": 1.0}
+    return grid, questions, model_names, costs, categories, profiles
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--toy", action="store_true", help="run the controlled synthetic proof (no spend)")
+    ap.add_argument("--seeds", type=int, default=3)
+    args = ap.parse_args()
+
+    if args.toy:
+        grid, questions, model_names, costs, categories, profiles = build_toy_oracle()
+        run(grid, questions, model_names, costs, categories, profiles, seeds=list(range(args.seeds)))
+    else:
+        raise SystemExit("real-oracle mode not wired yet — run with --toy (see oracle.py, pending)")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/python/credence_router/experiments/routing_dominance/dominance.py
+++ b/apps/python/credence_router/experiments/routing_dominance/dominance.py
@@ -163,15 +163,36 @@ def _report(model_names, categories, profiles, regrets, tables, welfare_by_profi
             cells += f"{mean:>+10.4f}({winrate:.0%})"
         print(f"  {name:>22}{cells}")
 
-    # Headline: EU-max optimal on all profiles; each competitor suboptimal on ≥1.
-    print("\nVERDICT:")
+    # Verdict — honest per-profile beats/ties/loses (EU-max can LOSE: with a belief learned
+    # from finite data it is the per-profile argmax over the BELIEF, which equals the true
+    # optimum only when the belief is well-calibrated; on thin data it can misrank).
+    # Comparisons below are on already-computed welfare regrets, for the human-read verdict
+    # line only — non-causal display, the same inline pattern as the regret table above.
+    print("\nVERDICT  (per profile — does EU-max beat / tie / lose to the arm?):")
     for name in regrets:
-        dominated_on = [p for p in profiles if sum(regrets[name][p]) / len(regrets[name][p]) > 1e-9]
-        if dominated_on:
-            print(f"  EU-max strictly beats {name} on: {dominated_on}")
-        else:
-            print(f"  {name}: ties EU-max on all profiles (it IS a Bayes rule here — i.e. it IS us)")
-    print("  EU-max is optimal on EVERY profile by construction (per-profile argmax).")
+        beats = [p for p in profiles if sum(regrets[name][p]) / len(regrets[name][p]) > 1e-6]
+        loses = [p for p in profiles if sum(regrets[name][p]) / len(regrets[name][p]) < -1e-6]
+        ties = [p for p in profiles if -1e-6 <= sum(regrets[name][p]) / len(regrets[name][p]) <= 1e-6]
+        parts = []
+        if beats:
+            parts.append(f"beats on {beats}")
+        if ties:
+            parts.append(f"ties on {ties}")
+        if loses:
+            parts.append(f"LOSES on {loses}")
+        print(f"  {name:>22}: EU-max " + "; ".join(parts))
+
+    # Wald admissibility: no single FIXED router should beat EU-max on EVERY profile. The
+    # clairvoyant oracle-cascade is excluded — it is an unattainable upper bound, not a rule.
+    fixed = [n for n in regrets if n != "oracle-cascade"]
+    dominators = [n for n in fixed if all(sum(regrets[n][p]) / len(regrets[n][p]) < -1e-6 for p in profiles)]
+    if dominators:
+        print(f"\n  ⚠ a fixed router beats EU-max on ALL profiles: {dominators} — EU-max is DOMINATED here.")
+    else:
+        print("\n  No fixed router beats EU-max on all profiles ⇒ EU-max is UNDOMINATED across "
+              "profiles (admissible).")
+        print("  (Per-profile dominance is stronger and holds where the belief is well-calibrated; "
+              "with thin data EU-max can trail the per-profile winner — see ROUTING_DOMINANCE.md.)")
     print("=" * 72 + "\n")
 
 
@@ -198,17 +219,51 @@ def build_toy_oracle():
     return grid, questions, model_names, costs, categories, profiles
 
 
+def build_real_oracle(path="oracle_grid.json"):
+    """Load the real-model oracle grid produced by oracle.py.
+
+    Same shape as build_toy_oracle, so run() is byte-identical on real data — only the
+    grid (measured per-model MCQ correctness) and the real per-call costs differ. Profiles
+    are the dollar value of a correct answer: cost-hawk ≈ one expensive call; quality-hawk
+    far more. Keeps only questions every model answered (a complete grid row), so a partial
+    oracle run still yields a sound proof on its completed subset.
+    """
+    import json
+    import os
+    from types import SimpleNamespace
+
+    p = path if os.path.isabs(path) else os.path.join(os.path.dirname(__file__), path)
+    data = json.loads(open(p).read())
+    model_names, costs, categories = data["models"], data["costs"], data["categories"]
+    n = len(model_names)
+    grid = {}
+    for k, v in data["grid"].items():
+        mi, qid = k.split("|", 1)
+        grid[(int(mi), qid)] = bool(v)
+    questions = [
+        SimpleNamespace(id=q["id"], category=q["category"], difficulty=q["difficulty"])
+        for q in data["questions"]
+        if all((mi, q["id"]) in grid for mi in range(n))
+    ]
+    profiles = {"cost-hawk": 0.02, "quality-hawk": 1.0}
+    return grid, questions, model_names, costs, categories, profiles
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--toy", action="store_true", help="run the controlled synthetic proof (no spend)")
+    ap.add_argument("--real", action="store_true", help="run against the real-model oracle grid (oracle.py output)")
     ap.add_argument("--seeds", type=int, default=3)
     args = ap.parse_args()
 
     if args.toy:
-        grid, questions, model_names, costs, categories, profiles = build_toy_oracle()
-        run(grid, questions, model_names, costs, categories, profiles, seeds=list(range(args.seeds)))
+        oracle = build_toy_oracle()
+    elif args.real:
+        oracle = build_real_oracle()
     else:
-        raise SystemExit("real-oracle mode not wired yet — run with --toy (see oracle.py, pending)")
+        raise SystemExit("choose --toy (synthetic, no spend) or --real (oracle.py grid)")
+    grid, questions, model_names, costs, categories, profiles = oracle
+    run(grid, questions, model_names, costs, categories, profiles, seeds=list(range(args.seeds)))
 
 
 if __name__ == "__main__":

--- a/apps/python/credence_router/experiments/routing_dominance/oracle.py
+++ b/apps/python/credence_router/experiments/routing_dominance/oracle.py
@@ -1,0 +1,176 @@
+# Role: eval
+"""Real-model oracle: measure per-model MCQ correctness for the routing-dominance proof.
+
+Turns the synthetic toy into a REAL headline: query a cost-ladder of real models on a
+labelled benchmark (credence_agents' 50-question bank — `correct_index` is ground truth)
+and record, per (model, question), whether the model chose the right answer. The result
+is a frozen grid `dominance.py --real` routes over, so the dominance claim stands on real
+model accuracies, not a synthetic generator.
+
+This module only MEASURES (queries models, compares to the labelled answer) and CACHES.
+No probability arithmetic, no routing decision here (that is the skin's job in
+routing_state.py / dominance.py). `# Role: eval`.
+
+Determinism + thrift: temperature 0, tiny max_tokens, and a per-(model,question) cache
+on disk — a re-run re-spends nothing. ~50 questions × 3 models ≈ 150 calls.
+
+Run (key from the keyring, per the machine's secret convention):
+    ANTHROPIC_API_KEY=$(secret-tool lookup service env key ANTHROPIC_API_KEY) \
+        uv run python apps/python/credence_router/experiments/routing_dominance/oracle.py --test
+    ANTHROPIC_API_KEY=$(secret-tool lookup service env key ANTHROPIC_API_KEY) \
+        uv run python apps/python/credence_router/experiments/routing_dominance/oracle.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import httpx
+
+from credence_agents.environment.questions import QUESTION_BANK
+from credence_router.tools.llm.provider import ALL_MODELS, model_cost
+
+# The cost ladder, with CURRENT model IDs (provider.py's claude-opus-4-6 is stale → 4-8).
+# Costs are the proxy's own per-call estimate (provider.model_cost = input + 0.5·output per
+# 1k); the exp tier reuses the opus-4-6 price row (same tier) since 4-8 isn't in the table.
+MODELS = [
+    ("cheap", "claude-haiku-4-5", "claude-haiku-4-5"),
+    ("mid", "claude-sonnet-4-6", "claude-sonnet-4-6"),
+    ("exp", "claude-opus-4-8", "claude-opus-4-6"),  # (api id, price-row id)
+]
+ENDPOINT = "https://api.anthropic.com/v1/chat/completions"
+LETTERS = ("A", "B", "C", "D")
+
+CACHE_PATH = Path(__file__).with_name("oracle_grid.json")
+
+
+def costs() -> list[float]:
+    return [round(model_cost(ALL_MODELS[price_id]), 6) for _, _, price_id in MODELS]
+
+
+def prompt_for(q) -> str:
+    opts = "\n".join(f"{LETTERS[i]}) {c}" for i, c in enumerate(q.candidates))
+    return (
+        f"Answer this multiple-choice question. Reply with ONLY the single letter "
+        f"(A, B, C, or D) of the correct option — no explanation.\n\n"
+        f"{q.text}\n{opts}\n\nAnswer:"
+    )
+
+
+def parse_choice(text: str) -> int | None:
+    """First standalone A/B/C/D in the reply → 0..3, else None."""
+    m = re.search(r"\b([ABCD])\b", text.upper())
+    return LETTERS.index(m.group(1)) if m else None
+
+
+def query(api_id: str, q, api_key: str) -> tuple[int | None, str]:
+    """One MCQ call. Returns (chosen_index_or_None, raw_reply).
+
+    Sends temperature=0 for determinism; some newer models (e.g. opus-4-8) reject the
+    param ("temperature is deprecated for this model") — retry once without it.
+    """
+    base = {"model": api_id, "messages": [{"role": "user", "content": prompt_for(q)}], "max_tokens": 16}
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    for body in ({**base, "temperature": 0.0}, base):
+        r = httpx.post(ENDPOINT, headers=headers, json=body, timeout=60.0)
+        if r.status_code == 400 and "temperature" in r.text and body.get("temperature") is not None:
+            continue  # retry without temperature
+        r.raise_for_status()
+        text = r.json()["choices"][0]["message"]["content"] or ""
+        return parse_choice(text), text.strip()
+    raise RuntimeError(f"query failed for {api_id}")
+
+
+def load_cache() -> dict:
+    if CACHE_PATH.exists():
+        return json.loads(CACHE_PATH.read_text())
+    return {"raw": {}}
+
+
+def save(cache: dict) -> None:
+    CACHE_PATH.write_text(json.dumps(cache, indent=2))
+
+
+def build_grid(cache: dict) -> dict:
+    """Assemble the dominance.py-consumable grid from the per-(model,question) cache."""
+    cats = sorted({q.category for q in QUESTION_BANK})
+    grid = {}
+    for mi, (_, api_id, _) in enumerate(MODELS):
+        for q in QUESTION_BANK:
+            rec = cache["raw"].get(f"{api_id}|{q.id}")
+            if rec is not None:
+                grid[f"{mi}|{q.id}"] = bool(rec["correct"])
+    return {
+        "models": [name for name, _, _ in MODELS],
+        "model_ids": [api_id for _, api_id, _ in MODELS],
+        "costs": costs(),
+        "categories": cats,
+        "questions": [{"id": q.id, "category": q.category, "difficulty": q.difficulty} for q in QUESTION_BANK],
+        "grid": grid,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--test", action="store_true", help="one call per model (verify IDs/endpoint) then exit")
+    args = ap.parse_args()
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        sys.exit("ANTHROPIC_API_KEY not set — run with: ANTHROPIC_API_KEY=$(secret-tool lookup service env key ANTHROPIC_API_KEY) ...")
+
+    if args.test:
+        q = QUESTION_BANK[0]
+        print(f"test question [{q.id}/{q.category}]: {q.text}  (correct={LETTERS[q.correct_index]})")
+        for name, api_id, _ in MODELS:
+            try:
+                idx, raw = query(api_id, q, api_key)
+                ok = idx == q.correct_index
+                print(f"  {name:6} {api_id:22} → {LETTERS[idx] if idx is not None else '??':2} "
+                      f"({'correct' if ok else 'wrong'})   raw={raw!r}")
+            except httpx.HTTPStatusError as e:
+                print(f"  {name:6} {api_id:22} → HTTP {e.response.status_code}: {e.response.text[:200]}")
+        print("\ncosts (per-call $):", dict(zip([m[0] for m in MODELS], costs())))
+        return
+
+    cache = load_cache()
+    raw = cache["raw"]
+    n_calls = 0
+    for name, api_id, _ in MODELS:
+        correct_n = total_n = 0
+        for q in QUESTION_BANK:
+            key = f"{api_id}|{q.id}"
+            if key not in raw:
+                idx, reply = query(api_id, q, api_key)
+                raw[key] = {"answer": LETTERS[idx] if idx is not None else None,
+                            "correct": idx == q.correct_index, "raw": reply}
+                n_calls += 1
+                if n_calls % 10 == 0:
+                    save(cache)  # checkpoint
+            total_n += 1
+            correct_n += int(raw[key]["correct"])
+        print(f"{name:6} {api_id:22} accuracy {correct_n}/{total_n} = {correct_n/total_n:.2%}")
+    save(cache)
+    save_grid = build_grid(cache)
+    Path(__file__).with_name("oracle_grid.json").write_text(json.dumps({**cache, **save_grid}, indent=2))
+    print(f"\n{n_calls} live calls made; grid → {CACHE_PATH}")
+    # Per-category accuracy table (the routing signal).
+    cats = save_grid["categories"]
+    print("\nper-(model, category) accuracy:")
+    print("  ", "model ".ljust(8), "".join(c[:8].ljust(10) for c in cats))
+    for mi, (name, api_id, _) in enumerate(MODELS):
+        cells = []
+        for c in cats:
+            qs = [q for q in QUESTION_BANK if q.category == c]
+            k = sum(int(raw[f"{api_id}|{q.id}"]["correct"]) for q in qs)
+            cells.append(f"{k}/{len(qs)}".ljust(10))
+        print("  ", name.ljust(8), "".join(cells))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/python/credence_router/experiments/routing_dominance/oracle_grid.json
+++ b/apps/python/credence_router/experiments/routing_dominance/oracle_grid.json
@@ -1,0 +1,1180 @@
+{
+  "raw": {
+    "claude-haiku-4-5|f01": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|f02": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|f03": {
+      "answer": "A",
+      "correct": true,
+      "raw": "A"
+    },
+    "claude-haiku-4-5|f04": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-haiku-4-5|f05": {
+      "answer": "A",
+      "correct": false,
+      "raw": "A"
+    },
+    "claude-haiku-4-5|f06": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|f07": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|f08": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|f09": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|f10": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-haiku-4-5|f11": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|f12": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|f13": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|f14": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|f15": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|n01": {
+      "answer": "A",
+      "correct": false,
+      "raw": "A"
+    },
+    "claude-haiku-4-5|n02": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|n03": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|n04": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|n05": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|n06": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|n07": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|n08": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|n09": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|n10": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|r01": {
+      "answer": "A",
+      "correct": true,
+      "raw": "A"
+    },
+    "claude-haiku-4-5|r02": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|r03": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|r04": {
+      "answer": "A",
+      "correct": true,
+      "raw": "A"
+    },
+    "claude-haiku-4-5|r05": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|r06": {
+      "answer": "A",
+      "correct": false,
+      "raw": "A"
+    },
+    "claude-haiku-4-5|r07": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|r08": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|m01": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|m02": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-haiku-4-5|m03": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-haiku-4-5|m04": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|m05": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|m06": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|m07": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|g01": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|g02": {
+      "answer": "A",
+      "correct": false,
+      "raw": "A"
+    },
+    "claude-haiku-4-5|g03": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|g04": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|g05": {
+      "answer": "A",
+      "correct": false,
+      "raw": "A"
+    },
+    "claude-haiku-4-5|g06": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|g07": {
+      "answer": "C",
+      "correct": false,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|g08": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-haiku-4-5|g09": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-haiku-4-5|g10": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|f01": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|f02": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|f03": {
+      "answer": "B",
+      "correct": false,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|f04": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-sonnet-4-6|f05": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|f06": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|f07": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|f08": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|f09": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|f10": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-sonnet-4-6|f11": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|f12": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|f13": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|f14": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|f15": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|n01": {
+      "answer": null,
+      "correct": false,
+      "raw": "4230 \u00d7 0.17 = 719.1"
+    },
+    "claude-sonnet-4-6|n02": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|n03": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|n04": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|n05": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|n06": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|n07": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|n08": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|n09": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|n10": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|r01": {
+      "answer": "A",
+      "correct": true,
+      "raw": "A"
+    },
+    "claude-sonnet-4-6|r02": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|r03": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|r04": {
+      "answer": "A",
+      "correct": true,
+      "raw": "A"
+    },
+    "claude-sonnet-4-6|r05": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|r06": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|r07": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|r08": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|m01": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|m02": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-sonnet-4-6|m03": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-sonnet-4-6|m04": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|m05": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|m06": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|m07": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|g01": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|g02": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|g03": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|g04": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|g05": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|g06": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|g07": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-sonnet-4-6|g08": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-sonnet-4-6|g09": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-sonnet-4-6|g10": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|f01": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|f02": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|f03": {
+      "answer": "A",
+      "correct": true,
+      "raw": "A"
+    },
+    "claude-opus-4-8|f04": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-opus-4-8|f05": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|f06": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|f07": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|f08": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|f09": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|f10": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-opus-4-8|f11": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|f12": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|f13": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|f14": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|f15": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|n01": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|n02": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|n03": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|n04": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|n05": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|n06": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|n07": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|n08": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|n09": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|n10": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|r01": {
+      "answer": "A",
+      "correct": true,
+      "raw": "A"
+    },
+    "claude-opus-4-8|r02": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|r03": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|r04": {
+      "answer": "A",
+      "correct": true,
+      "raw": "A"
+    },
+    "claude-opus-4-8|r05": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|r06": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|r07": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|r08": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|m01": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|m02": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-opus-4-8|m03": {
+      "answer": "D",
+      "correct": true,
+      "raw": "D"
+    },
+    "claude-opus-4-8|m04": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|m05": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|m06": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|m07": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|g01": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|g02": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|g03": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|g04": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|g05": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|g06": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|g07": {
+      "answer": "C",
+      "correct": false,
+      "raw": "C"
+    },
+    "claude-opus-4-8|g08": {
+      "answer": "C",
+      "correct": true,
+      "raw": "C"
+    },
+    "claude-opus-4-8|g09": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    },
+    "claude-opus-4-8|g10": {
+      "answer": "B",
+      "correct": true,
+      "raw": "B"
+    }
+  },
+  "models": [
+    "cheap",
+    "mid",
+    "exp"
+  ],
+  "model_ids": [
+    "claude-haiku-4-5",
+    "claude-sonnet-4-6",
+    "claude-opus-4-8"
+  ],
+  "costs": [
+    0.0035,
+    0.0105,
+    0.0175
+  ],
+  "categories": [
+    "factual",
+    "misconceptions",
+    "numerical",
+    "reasoning",
+    "recent_events"
+  ],
+  "questions": [
+    {
+      "id": "f01",
+      "category": "factual",
+      "difficulty": "medium"
+    },
+    {
+      "id": "f02",
+      "category": "factual",
+      "difficulty": "hard"
+    },
+    {
+      "id": "f03",
+      "category": "factual",
+      "difficulty": "medium"
+    },
+    {
+      "id": "f04",
+      "category": "factual",
+      "difficulty": "easy"
+    },
+    {
+      "id": "f05",
+      "category": "factual",
+      "difficulty": "medium"
+    },
+    {
+      "id": "f06",
+      "category": "factual",
+      "difficulty": "medium"
+    },
+    {
+      "id": "f07",
+      "category": "factual",
+      "difficulty": "easy"
+    },
+    {
+      "id": "f08",
+      "category": "factual",
+      "difficulty": "easy"
+    },
+    {
+      "id": "f09",
+      "category": "factual",
+      "difficulty": "easy"
+    },
+    {
+      "id": "f10",
+      "category": "factual",
+      "difficulty": "easy"
+    },
+    {
+      "id": "f11",
+      "category": "factual",
+      "difficulty": "easy"
+    },
+    {
+      "id": "f12",
+      "category": "factual",
+      "difficulty": "easy"
+    },
+    {
+      "id": "f13",
+      "category": "factual",
+      "difficulty": "medium"
+    },
+    {
+      "id": "f14",
+      "category": "factual",
+      "difficulty": "hard"
+    },
+    {
+      "id": "f15",
+      "category": "factual",
+      "difficulty": "easy"
+    },
+    {
+      "id": "n01",
+      "category": "numerical",
+      "difficulty": "easy"
+    },
+    {
+      "id": "n02",
+      "category": "numerical",
+      "difficulty": "medium"
+    },
+    {
+      "id": "n03",
+      "category": "numerical",
+      "difficulty": "easy"
+    },
+    {
+      "id": "n04",
+      "category": "numerical",
+      "difficulty": "medium"
+    },
+    {
+      "id": "n05",
+      "category": "numerical",
+      "difficulty": "easy"
+    },
+    {
+      "id": "n06",
+      "category": "numerical",
+      "difficulty": "medium"
+    },
+    {
+      "id": "n07",
+      "category": "numerical",
+      "difficulty": "easy"
+    },
+    {
+      "id": "n08",
+      "category": "numerical",
+      "difficulty": "hard"
+    },
+    {
+      "id": "n09",
+      "category": "numerical",
+      "difficulty": "medium"
+    },
+    {
+      "id": "n10",
+      "category": "numerical",
+      "difficulty": "medium"
+    },
+    {
+      "id": "r01",
+      "category": "recent_events",
+      "difficulty": "medium"
+    },
+    {
+      "id": "r02",
+      "category": "recent_events",
+      "difficulty": "easy"
+    },
+    {
+      "id": "r03",
+      "category": "recent_events",
+      "difficulty": "easy"
+    },
+    {
+      "id": "r04",
+      "category": "recent_events",
+      "difficulty": "hard"
+    },
+    {
+      "id": "r05",
+      "category": "recent_events",
+      "difficulty": "medium"
+    },
+    {
+      "id": "r06",
+      "category": "recent_events",
+      "difficulty": "hard"
+    },
+    {
+      "id": "r07",
+      "category": "recent_events",
+      "difficulty": "medium"
+    },
+    {
+      "id": "r08",
+      "category": "recent_events",
+      "difficulty": "medium"
+    },
+    {
+      "id": "m01",
+      "category": "misconceptions",
+      "difficulty": "medium"
+    },
+    {
+      "id": "m02",
+      "category": "misconceptions",
+      "difficulty": "medium"
+    },
+    {
+      "id": "m03",
+      "category": "misconceptions",
+      "difficulty": "medium"
+    },
+    {
+      "id": "m04",
+      "category": "misconceptions",
+      "difficulty": "hard"
+    },
+    {
+      "id": "m05",
+      "category": "misconceptions",
+      "difficulty": "hard"
+    },
+    {
+      "id": "m06",
+      "category": "misconceptions",
+      "difficulty": "easy"
+    },
+    {
+      "id": "m07",
+      "category": "misconceptions",
+      "difficulty": "medium"
+    },
+    {
+      "id": "g01",
+      "category": "reasoning",
+      "difficulty": "medium"
+    },
+    {
+      "id": "g02",
+      "category": "reasoning",
+      "difficulty": "medium"
+    },
+    {
+      "id": "g03",
+      "category": "reasoning",
+      "difficulty": "medium"
+    },
+    {
+      "id": "g04",
+      "category": "reasoning",
+      "difficulty": "easy"
+    },
+    {
+      "id": "g05",
+      "category": "reasoning",
+      "difficulty": "easy"
+    },
+    {
+      "id": "g06",
+      "category": "reasoning",
+      "difficulty": "hard"
+    },
+    {
+      "id": "g07",
+      "category": "reasoning",
+      "difficulty": "hard"
+    },
+    {
+      "id": "g08",
+      "category": "reasoning",
+      "difficulty": "hard"
+    },
+    {
+      "id": "g09",
+      "category": "reasoning",
+      "difficulty": "medium"
+    },
+    {
+      "id": "g10",
+      "category": "reasoning",
+      "difficulty": "hard"
+    }
+  ],
+  "grid": {
+    "0|f01": true,
+    "0|f02": true,
+    "0|f03": true,
+    "0|f04": true,
+    "0|f05": false,
+    "0|f06": true,
+    "0|f07": true,
+    "0|f08": true,
+    "0|f09": true,
+    "0|f10": true,
+    "0|f11": true,
+    "0|f12": true,
+    "0|f13": true,
+    "0|f14": true,
+    "0|f15": true,
+    "0|n01": false,
+    "0|n02": true,
+    "0|n03": true,
+    "0|n04": true,
+    "0|n05": true,
+    "0|n06": true,
+    "0|n07": true,
+    "0|n08": true,
+    "0|n09": true,
+    "0|n10": true,
+    "0|r01": true,
+    "0|r02": true,
+    "0|r03": true,
+    "0|r04": true,
+    "0|r05": true,
+    "0|r06": false,
+    "0|r07": true,
+    "0|r08": true,
+    "0|m01": true,
+    "0|m02": true,
+    "0|m03": true,
+    "0|m04": true,
+    "0|m05": true,
+    "0|m06": true,
+    "0|m07": true,
+    "0|g01": true,
+    "0|g02": false,
+    "0|g03": true,
+    "0|g04": true,
+    "0|g05": false,
+    "0|g06": true,
+    "0|g07": false,
+    "0|g08": true,
+    "0|g09": true,
+    "0|g10": true,
+    "1|f01": true,
+    "1|f02": true,
+    "1|f03": false,
+    "1|f04": true,
+    "1|f05": true,
+    "1|f06": true,
+    "1|f07": true,
+    "1|f08": true,
+    "1|f09": true,
+    "1|f10": true,
+    "1|f11": true,
+    "1|f12": true,
+    "1|f13": true,
+    "1|f14": true,
+    "1|f15": true,
+    "1|n01": false,
+    "1|n02": true,
+    "1|n03": true,
+    "1|n04": true,
+    "1|n05": true,
+    "1|n06": true,
+    "1|n07": true,
+    "1|n08": true,
+    "1|n09": true,
+    "1|n10": true,
+    "1|r01": true,
+    "1|r02": true,
+    "1|r03": true,
+    "1|r04": true,
+    "1|r05": true,
+    "1|r06": true,
+    "1|r07": true,
+    "1|r08": true,
+    "1|m01": true,
+    "1|m02": true,
+    "1|m03": true,
+    "1|m04": true,
+    "1|m05": true,
+    "1|m06": true,
+    "1|m07": true,
+    "1|g01": true,
+    "1|g02": true,
+    "1|g03": true,
+    "1|g04": true,
+    "1|g05": true,
+    "1|g06": true,
+    "1|g07": true,
+    "1|g08": true,
+    "1|g09": true,
+    "1|g10": true,
+    "2|f01": true,
+    "2|f02": true,
+    "2|f03": true,
+    "2|f04": true,
+    "2|f05": true,
+    "2|f06": true,
+    "2|f07": true,
+    "2|f08": true,
+    "2|f09": true,
+    "2|f10": true,
+    "2|f11": true,
+    "2|f12": true,
+    "2|f13": true,
+    "2|f14": true,
+    "2|f15": true,
+    "2|n01": true,
+    "2|n02": true,
+    "2|n03": true,
+    "2|n04": true,
+    "2|n05": true,
+    "2|n06": true,
+    "2|n07": true,
+    "2|n08": true,
+    "2|n09": true,
+    "2|n10": true,
+    "2|r01": true,
+    "2|r02": true,
+    "2|r03": true,
+    "2|r04": true,
+    "2|r05": true,
+    "2|r06": true,
+    "2|r07": true,
+    "2|r08": true,
+    "2|m01": true,
+    "2|m02": true,
+    "2|m03": true,
+    "2|m04": true,
+    "2|m05": true,
+    "2|m06": true,
+    "2|m07": true,
+    "2|g01": true,
+    "2|g02": true,
+    "2|g03": true,
+    "2|g04": true,
+    "2|g05": true,
+    "2|g06": true,
+    "2|g07": false,
+    "2|g08": true,
+    "2|g09": true,
+    "2|g10": true
+  }
+}

--- a/apps/python/credence_router/experiments/routing_dominance/routing_state.py
+++ b/apps/python/credence_router/experiments/routing_dominance/routing_state.py
@@ -1,0 +1,161 @@
+# Role: eval
+"""Skin-backed Beta-Bernoulli routing belief for the dominance proof.
+
+θ_{model,category} = P(model answers a question of this category correctly) ~ Beta.
+The belief is one product state — models × categories × Beta(1,1) — updated by
+Bernoulli conditioning on observed correctness. A routing decision is EU-max via
+`skin.optimise` over a `functional_per_action` preference: a LinearCombination of
+NestedProjections to each Beta's mean (= E[θ]), with the per-profile value of a
+correct answer as `reward` and the real per-model dollar cost as the action offset:
+
+    EU(model a | category c) = reward · E[θ_{a,c}] − cost_a
+
+Why Beta-Bernoulli and not the production router's continuous-quality (θ, k) kernel:
+MCQ correctness is *binary*, so Beta-Bernoulli is the honest conjugate model
+(credence_agents/CLAUDE.md: "Beta(1,1) uniform — we genuinely don't know tool
+reliability"). Forcing binary data through the continuous quality kernel would
+require an arbitrary correct→0.8 / wrong→0.2 map — an arbitrary constant. Here a
+correct answer is observation 1.0 (increments α), a wrong answer is 0.0 (increments
+β); no constants.
+
+All inference runs in the skin (Julia). This module only *declares* structure and
+*calls* Tier-1 primitives (create_state / condition / expect / optimise / factor /
+replace_factor) — no probability arithmetic in Python (Invariant 1, topological).
+The preference mirrors credence_router.routing_domain._router_preference; the only
+difference is the leaf is a bare Beta (indices [model, cat]) rather than a
+(Beta, Gamma) product (indices [provider, cat, 0]).
+"""
+
+from __future__ import annotations
+
+from credence_router.routing_domain import _ensure_skin_importable
+
+REPO_ROOT = _ensure_skin_importable()
+from skin.client import SkinClient  # noqa: E402
+
+
+def build_state(skin: SkinClient, n_models: int, n_categories: int) -> str:
+    """Create the routing belief: models × categories × Beta(1,1)."""
+    leaf = {"type": "beta", "alpha": 1.0, "beta": 1.0}
+    model = {"type": "product", "factors": [leaf for _ in range(n_categories)]}
+    state = {"type": "product", "factors": [model for _ in range(n_models)]}
+    return skin.create_state(**state)
+
+
+def observe_correct(
+    skin: SkinClient, state_id: str, model_idx: int, cat_idx: int, correct: bool
+) -> str:
+    """Condition θ_{model,cat} on one outcome. Returns the new top-level state_id.
+
+    factor → condition(bernoulli) → replace_factor, mirroring
+    routing_domain._apply_outcome but with the binary-correctness Bernoulli kernel.
+    """
+    model_id = skin.factor(state_id, model_idx)
+    cat_id = skin.factor(model_id, cat_idx)
+    skin.condition(cat_id, kernel={"type": "bernoulli"}, observation=1.0 if correct else 0.0)
+    model_updated = skin.replace_factor(model_id, cat_idx, cat_id)
+    return skin.replace_factor(state_id, model_idx, model_updated)
+
+
+def learned_accuracy(skin: SkinClient, state_id: str, model_idx: int, cat_idx: int) -> float:
+    """E[θ_{model,cat}] — the posterior-mean accuracy. Read through `expect`."""
+    return skin.expect(
+        state_id, function={"type": "nested_projection", "indices": [model_idx, cat_idx]}
+    )
+
+
+def _preference(
+    n_models: int,
+    n_categories: int,
+    cat_weights: list[float],
+    costs: list[float],
+    reward: float,
+) -> dict:
+    """functional_per_action spec: EU(a) = reward · Σ_c w_c · E[θ_{a,c}] − cost_a."""
+    actions: dict[str, dict] = {}
+    for a in range(n_models):
+        terms = [
+            [reward * cat_weights[c], {"type": "nested_projection", "indices": [a, c]}]
+            for c in range(n_categories)
+        ]
+        actions[str(a)] = {"type": "linear_combination", "terms": terms, "offset": -costs[a]}
+    return {"type": "functional_per_action", "actions": actions}
+
+
+def route(
+    skin: SkinClient,
+    state_id: str,
+    costs: list[float],
+    cat_idx: int,
+    reward: float,
+    n_categories: int,
+) -> int:
+    """EU-max model index for a question of category `cat_idx` under `reward`.
+
+    `reward` is the profile: the value (in dollars) of a correct answer. Low reward
+    → cost dominates → route cheap; high reward → quality dominates → route capable.
+    The belief is shared across profiles (Savage: one posterior, many utilities).
+    """
+    n_models = len(costs)
+    cat_weights = [0.0] * n_categories
+    cat_weights[cat_idx] = 1.0
+    pref = _preference(n_models, n_categories, cat_weights, costs, reward)
+    actions_spec = {"type": "finite", "values": list(range(n_models))}
+    action, _eu = skin.optimise(state_id, actions_spec, pref)
+    return int(action) if not isinstance(action, int) else action
+
+
+def _smoke() -> None:
+    """Controlled toy: 2 models × 2 categories, known counts, known answer.
+
+    Verifies (a) the skin wiring — Bernoulli conditioning + nested_projection read
+    back exact analytic Beta means — and (b) the headline phenomenon: on the SAME
+    input, a quality profile and a cost profile route to DIFFERENT models. No spend.
+    """
+    # Fixtures (test-oracle): two profiles and two model costs.
+    CHEAP, EXP = 0.001, 0.01  # model 0 cheap/weak-ish, model 1 expensive/capable
+    QUALITY_REWARD = 1.0  # a correct answer worth $1   (quality-hawk profile)
+    COST_REWARD = 0.005  # a correct answer worth ~half a cent (cost-hawk profile)
+    costs = [CHEAP, EXP]
+
+    skin = SkinClient(project=REPO_ROOT)
+    try:
+        skin.initialize()
+        s = build_state(skin, n_models=2, n_categories=2)
+
+        # model 0: good at cat 0 (5 correct), bad at cat 1 (5 wrong).
+        # model 1: good at both (5 correct each).
+        for _ in range(5):
+            s = observe_correct(skin, s, 0, 0, True)
+            s = observe_correct(skin, s, 0, 1, False)
+            s = observe_correct(skin, s, 1, 0, True)
+            s = observe_correct(skin, s, 1, 1, True)
+
+        # (a) exact posterior means — Beta(1+correct, 1+wrong).
+        acc = {(m, c): learned_accuracy(skin, s, m, c) for m in (0, 1) for c in (0, 1)}
+        assert acc[(0, 0)] == 6 / 7, acc[(0, 0)]  # Beta(6,1)  # credence-lint: allow — precedent:test-oracle — Beta(6,1) mean exact
+        assert acc[(0, 1)] == 1 / 7, acc[(0, 1)]  # Beta(1,6)  # credence-lint: allow — precedent:test-oracle — Beta(1,6) mean exact
+        assert acc[(1, 0)] == 6 / 7, acc[(1, 0)]  # Beta(6,1)  # credence-lint: allow — precedent:test-oracle — Beta(6,1) mean exact
+        assert acc[(1, 1)] == 6 / 7, acc[(1, 1)]  # Beta(6,1)  # credence-lint: allow — precedent:test-oracle — Beta(6,1) mean exact
+
+        # (b) routing. cat 0 (both models good): both profiles pick the cheap model.
+        assert route(skin, s, costs, 0, QUALITY_REWARD, 2) == 0
+        assert route(skin, s, costs, 0, COST_REWARD, 2) == 0
+        # cat 1 (only the expensive model is good): the profiles DIVERGE.
+        q1 = route(skin, s, costs, 1, QUALITY_REWARD, 2)
+        c1 = route(skin, s, costs, 1, COST_REWARD, 2)
+        assert q1 == 1, q1  # quality-hawk pays for the capable model
+        assert c1 == 0, c1  # cost-hawk eats the error rather than pay
+        assert q1 != c1, "per-profile divergent routing on the same input"
+
+        print("PASS routing_state smoke:")
+        print(f"  learned accuracy (model,cat)->E[θ]: {acc}")
+        print(f"  cat0: quality->{route(skin, s, costs, 0, QUALITY_REWARD, 2)} "
+              f"cost->{route(skin, s, costs, 0, COST_REWARD, 2)}  (agree: cheap suffices)")
+        print(f"  cat1: quality->{q1} cost->{c1}  (DIVERGE: no single fixed rule matches both)")
+    finally:
+        skin.shutdown()
+
+
+if __name__ == "__main__":
+    _smoke()


### PR DESCRIPTION
Proves credence-pi routes models **better and smarter than fixed routers**, then wires that mechanism into OpenClaw's live model selection. Four commits: three proof pillars, then the live wiring.

## The proof (commits 1–3)

EU-max routing — `argmax_a [ value·P(correct|X) − cost_a ]` over a model roster, through the one canonical `optimise` — is the Wald complete-class winner: a *fixed* router is the Bayes rule for ≤1 profile, so across ≥2 profiles it is inadmissible.

- **Coarse pillar** (`experiments/routing_dominance/`, Python through the real skin): Beta-Bernoulli belief over (model × category), EU-max via `skin.optimise`, beating six competitor foils with per-profile divergent routing. Zero spend.
- **Rich pillar** (`eval/routing_dominance.jl`, Julia): the belief is credence-pi's `StructureBMA` (the governance brain), conditioned on difficulty × length × category. Shows the *ceiling* — strict dominance + auto-sophistication (the BMA discovers which features matter from noisy data).
- **Real-model de-risk** (`oracle.py`, 150 cached calls): three frontier models measured on the 50-MCQ bank (haiku 88 / sonnet 96 / opus 98). **Honest result:** EU-max is **undominated (Wald-admissible)** and **wins cost-routing** (ties cost-optimal, beats every wasteful router); strict *quality*-profile dominance is data-bound at 50 close-model questions. A genuine insight surfaced — sonnet **beats** opus at reasoning (100% vs 90%), so quality-hawk EU-max routes reasoning to the *cheaper* model. Full writeup: `eval/results/ROUTING_DOMINANCE.md`.

## Live wiring (commit 4)

Routing now drives OpenClaw's actual model selection, reusing the existing async `sensor→signal` wire verbatim:

- **Daemon** — new `route-request` event → `RoutingBrain.route` (the *same* `optimise`) → new `route` signal `{model, provider}`. `wire_routing!` reads the declared roster (`bdsl/routing.bdsl`) + per-profile reward (`correct-answer-value` in `utility.bdsl`) + feature schema; builds K per-model `StructureBMA` posteriors. **Inert** without a roster (governance-only installs unaffected) and **never touches the governance posterior** (separate belief).
- **Plugin** — new `before_model_resolve` hook sharing the `awaitSignal` helper + daemon-down state with `beforeToolCall`; maps `route` → `{modelOverride, providerOverride}`; fail-open throughout; honors `shadowMode`. **Opt-in** via `routing: true` (off by default → zero per-turn latency when off).
- Ships in the daemon image (Dockerfile copies `bdsl/` + `brain/`), so a published container routes out of the box.

**Belief scope:** conditions on `prompt-length` only — the one feature honestly extractable from a raw prompt (semantic category would need an arbitrary classifier); the structure-BMA collapses it to the marginal if it doesn't predict accuracy. **Warm-seeded from the measured grid** (`routing_brain.counts.json` via `eval/train_routing_brain.jl`) so routing is calibrated from install. **Frozen in v1:** cost-routing + per-profile Wald divergence are the validated, wired result; online quality learning is deferred behind the credit-assignment problem (a session's many model calls can't be credited from `agent_end.success`), with the `route-outcome` update structure retained.

## Verification

- `test_routing.jl` 12/12 — warm reconstruct; one shared belief flips cost-hawk→haiku / quality-hawk→opus; inert without roster; cold fallback; route-request→signal; governance posterior untouched by routing.
- Full credence-pi Julia suite green (`test_server` 23, `test_feature_brain`, `test_harm_governance`, `test_observation_log` 7, `test_savings` 3, `test_bdsl_primitives` 14).
- Plugin 41/41 + typecheck + build clean.
- `credence-lint check apps/` — 204 files, 0 violations (brain pragma-free; eval `Role: eval`; bdsl declarative; one `test-oracle` pragma).

## Constitution compliance

Frozen four types untouched. EU-max (Tier-1) unchanged — routing exercises the existing mechanism with action set = the model roster; the only arithmetic is reward/cost coefficient construction from declared utility data. Routing roster + reward are declared `.bdsl` data; the warm belief reconstructs through `observe`→`condition` (no second learning mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)