### PR TITLE
credence-pi: online correctness learning for live model routing

### DIFF
--- a/apps/credence-pi/bdsl/routing.bdsl
+++ b/apps/credence-pi/bdsl/routing.bdsl
@@ -50,3 +50,18 @@
     (list "haiku"  "anthropic" "claude-haiku-4-5"  0.0035)
     (list "sonnet" "anthropic" "claude-sonnet-4-6" 0.0105)
     (list "opus"   "anthropic" "claude-opus-4-8"   0.0175)))
+
+; --- Emission prior: the confound model's starting belief (declared DATA) ---
+;
+; Online learning never sees model correctness directly — only whether the
+; proposed call executed cleanly (the exec signal), a NOISY emission of latent
+; correctness confounded by TOOL RELIABILITY. The brain learns two shared latents
+; per context: ρ = P(exec-clean | correct), σ = P(exec-clean | incorrect), so a
+; flaky tool is absorbed by ρ rather than mis-blamed on the model. These are the
+; (ρα ρβ σα σβ) of their Beta PRIORS — weakly-informative and DIRECTIONAL: the
+; only load-bearing fact is E[ρ]=2/3 > E[σ]=1/3 (correct calls execute more often
+; than incorrect ones), which breaks the EM label-symmetry. The magnitudes are a
+; pseudo-count of 3 and are washed out by data. Auditable here, not a buried
+; constant; the brain falls back to this same default if undeclared.
+(define emission-prior
+  (list 2.0 1.0 1.0 2.0))

--- a/apps/credence-pi/brain/feature_brain.jl
+++ b/apps/credence-pi/brain/feature_brain.jl
@@ -33,7 +33,7 @@ module FeatureBrain
 
 using Main.Credence: BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision,
     ProductPrevision, MixturePrevision,
-    Prevision, Kernel, Interval, Finite, BetaBernoulli, Flat, FiringByTag, Identity,
+    Prevision, Kernel, Interval, Finite, BetaBernoulli, SoftBernoulli, Flat, FiringByTag, Identity,
     Projection, LinearCombination, TestFunction, GeometricTail, mean, FeatureDecl, condition, expect,
     cell_at, wrap_in_measure
 import Main.Credence.Ontology: optimise, value, voi, net_voi, with_components,
@@ -42,7 +42,7 @@ using JSON3
 
 export StructureBMA, build_model, build_model_from_env, build_model_from_decls,
        build_prior, build_prior_dense, wire_brain!, context_from_features, firing_tags,
-       belief_at_context, observe, decide, decide_multi,
+       belief_at_context, observe, observe_soft, decide, decide_multi,
        reconstruct_posterior, reconstruct_harm_posterior
 
 # ── The model: feature spec + structure enumeration + tag bookkeeping ──
@@ -257,6 +257,35 @@ Bayesian update of the persistent belief on one `(context, response)`: a single
 """
 observe(model::StructureBMA, top::MixturePrevision, X::AbstractVector, obs) =
     condition(top, _learn_kernel(firing_tags(model, X)), obs)
+
+# Soft-evidence log-density: the firing cell's predictive marginal under virtual
+# evidence with likelihoods (r, w) = (P(S|label=1), P(S|label=0)) — the chain-rule
+# term the BMA reweights structures by. Generalises `_approve_logdensity`: the hard
+# label o=1 is (r,w)=(1,0) ⇒ log(mean), o=0 is (0,1) ⇒ log(1-mean).
+_soft_logdensity(m, obs) = (a = mean(m.beta); r = obs[1]; w = obs[2];
+                            log(max(r * a + w * (1.0 - a), 1e-300)))
+
+# Per-context SOFT-EVIDENCE learning kernel: SoftBernoulli on the cells in F(X),
+# Flat elsewhere. The cell update is the mean-exact ADF collapse (α += π, β += 1-π,
+# π = r·θ̄/(r·θ̄+w·(1-θ̄))); structures reweight by `_soft_logdensity`.
+_soft_learn_kernel(fires::Set{Int}) =
+    Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta, _soft_logdensity;
+           likelihood_family = FiringByTag(fires, SoftBernoulli(), Flat()))
+
+"""
+    observe_soft(model, top, X, r, w) -> MixturePrevision
+
+Bayesian update on INDIRECT evidence about the (latent) label at context X: `r`
+and `w` are the likelihoods of the observed signal under label = 1 / label = 0
+(P(S|1), P(S|0)). A single `condition` through the canalised path with a
+`SoftBernoulli` kernel — the firing cell's mean-exact soft-count, the BMA
+structure-reweight by the signal's predictive marginal. Reduces EXACTLY to
+`observe(model, top, X, 1)` at (r,w)=(1,0) and `observe(…, 0)` at (0,1) — the
+hard label is the degenerate certain-signal corner.
+"""
+observe_soft(model::StructureBMA, top::MixturePrevision, X::AbstractVector,
+             r::Real, w::Real) =
+    condition(top, _soft_learn_kernel(firing_tags(model, X)), (Float64(r), Float64(w)))
 
 # Select a structure component's cell-for-X by tag. Two representations:
 # sparse (O(1) dict-backed cell_at) and dense (linear scan of factors). Both

--- a/apps/credence-pi/brain/routing_brain.jl
+++ b/apps/credence-pi/brain/routing_brain.jl
@@ -33,18 +33,20 @@ independence across models is the ProductMeasure, exactly as the waste⊗harm jo
 """
 module RoutingBrain
 
-using Main.Credence: MixturePrevision, Projection, LinearCombination, TestFunction,
-    Identity, expect, wrap_in_measure
+using Main.Credence: MixturePrevision, BetaPrevision, Projection, LinearCombination,
+    TestFunction, Identity, Kernel, Interval, Finite, WeightedBernoulli, mean,
+    condition, expect, wrap_in_measure
 import Main.Credence.Ontology: optimise, ProductMeasure, Measure
 # `..FeatureBrain` (the sibling submodule), NOT `Main.FeatureBrain`: this resolves both
 # when the eval includes both brains at Main (siblings of Main) and when the daemon
 # includes both inside `module Server` (siblings of Server). FeatureBrain itself reaches
 # Credence via the always-Main `Main.Credence`, so only this sibling ref needs to be relative.
 using ..FeatureBrain: StructureBMA, belief_at_context, context_from_features,
-    build_model_from_decls, build_prior, observe
+    build_model_from_decls, build_prior, observe, observe_soft
 using JSON3
 
-export route, route_eu, posterior_accuracy, wire_routing!
+export route, route_eu, posterior_accuracy, wire_routing!,
+    RoutingState, EmissionBelief, route_outcome!, decode_correctness
 
 # Per-action EU functional: reward·θ_a − cost_a, expressed over the joint belief's
 # a-th component (Projection(a) = θ_a). `reward` and `cost` are declared utility DATA;
@@ -153,8 +155,144 @@ function _reconstruct_routing_tops(model::StructureBMA, K::Int, warm_path)
     end
 end
 
+# ── Online correctness learning: latent per-turn correctness + learned confounds ──
+#
+# The deferred online signal (ROUTING_DOMINANCE.md). We never observe model correctness
+# directly; we observe a per-turn signal — did the proposed call execute cleanly (e). e is
+# a NOISY emission of the latent C = "the model's turn was correct", confounded by TOOL
+# RELIABILITY: a correct call can still error on a flaky tool, a wrong call can still
+# execute. We model the confound explicitly and learn it, so a flaky tool is absorbed by
+# the reliability latent, NOT mis-attributed to the model.
+#
+#   θ_a(X) = P(C=1 | model a, context X)   — the routing belief (its own prior for C)
+#   ρ_X    = P(e=1 | C=1)                  — tool reliability (correct ⇒ clean exec)
+#   σ_X    = P(e=1 | C=0)                  — false-success (wrong ⇒ clean exec anyway)
+#
+# ρ_X, σ_X are SHARED across models at a context (the environment doesn't know which model
+# proposed the call) — the identification lever: the cross-model spread in observed e-rate,
+# against the (oracle-anchored) θ_a, pins ρ and σ. They are LATENT Beta beliefs
+# (weakly-informative directional prior E[ρ]>E[σ], refined by data — not fixed constants),
+# updated only through `condition`.
+#
+# Per turn (no human label): decode π = P(C=1 | e) with θ_a(X) as prior and the emission
+# means as likelihoods (emission uncertainty integrated via `expect`/`mean` — P(e|C) is
+# linear in ρ,σ, so the mean IS the integrated likelihood). Then ONE coupled coordinate
+# step (the EM the constitution treats as a computational strategy, invisible to the DSL):
+#   * routing belief: observe_soft(model, top_a, X, r, w)  — mean-exact soft-count
+#   * emissions (M-step): ρ_X ← (e, weight π),  σ_X ← (e, weight 1−π)   (WeightedBernoulli)
+# A human approve/reject, when present, makes C KNOWN — a clean hard `observe` on θ_a and a
+# unit-weight emission update — the gold anchor (no human-emission constant).
+
+# Default weakly-informative DIRECTIONAL emission prior: E[ρ0]=2/3 > E[σ0]=1/3. Only the
+# inequality is load-bearing (it breaks the EM label-symmetry); the magnitudes are weak
+# (pseudo-count 3) and washed out by data. Overridable via the declared `emission-prior`
+# (routing.bdsl) — auditable data, not a buried constant.
+const _DEFAULT_EMISSION_PRIOR = (2.0, 1.0, 1.0, 2.0)  # (ρα, ρβ, σα, σβ)
+
+mutable struct EmissionBelief
+    rho_cells::Dict{String, BetaPrevision}     # P(e=1|C=1) per context-key, lazily populated
+    sigma_cells::Dict{String, BetaPrevision}   # P(e=1|C=0) per context-key
+    rho0::BetaPrevision                        # directional prior, E[ρ0] > E[σ0]
+    sigma0::BetaPrevision
+end
+
+EmissionBelief(prior::NTuple{4, Float64} = _DEFAULT_EMISSION_PRIOR) =
+    EmissionBelief(Dict{String, BetaPrevision}(), Dict{String, BetaPrevision}(),
+                   BetaPrevision(prior[1], prior[2]), BetaPrevision(prior[3], prior[4]))
+
+# The live routing belief: per-model posteriors `tops` (MUTATED by route_outcome!) and the
+# shared emission belief. Captured by the `route-decide` closure, so routing reads the live
+# belief — un-frozen vs v1's closure-captured constant.
+mutable struct RoutingState
+    model::StructureBMA
+    tops::Vector{MixturePrevision}
+    emission::EmissionBelief
+    names::Vector{String}
+    providers::Vector{String}
+    model_ids::Vector{String}
+    costs::Vector{Float64}
+    reward::Float64
+end
+
+_ctx_key(X::AbstractVector) = join(string.(X), "|")
+
+# WeightedBernoulli kernel for the emission Beta updates (fractional pseudo-counts). The
+# conjugate update keys on likelihood_family; generate/log_density are not consulted.
+_emission_kernel() = Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta,
+                            (h, o) -> 0.0; likelihood_family = WeightedBernoulli())
+
+# Emission likelihoods of the exec signal e under each correctness hypothesis:
+# r = P(e | C=1), w = P(e | C=0), from the emission belief means (`mean` = the integrated
+# likelihood, since P(e|C) is linear in ρ/σ).
+function _emission_likelihoods(em::EmissionBelief, key::AbstractString, e::Bool)
+    ρ̄ = mean(get(em.rho_cells,   key, em.rho0))
+    σ̄ = mean(get(em.sigma_cells, key, em.sigma0))
+    e ? (ρ̄, σ̄) : (1.0 - ρ̄, 1.0 - σ̄)
+end
+
 """
-    wire_routing!(env; warm_path) -> NamedTuple | nothing
+    decode_correctness(em, θ̄, key, e) -> (r, w, π)
+
+The signal→correctness likelihood: r = P(e|C=1), w = P(e|C=0) from the emission belief, and
+π = P(C=1 | e) = r·θ̄/(r·θ̄ + w·(1−θ̄)) with the routing belief θ̄ as the coherent prior. π is
+the soft correctness label; (r,w) is the virtual evidence the routing belief conditions on
+(SoftBernoulli). Pure readout — `mean` and Bayes, no mutation.
+"""
+function decode_correctness(em::EmissionBelief, θ̄::Float64, key::AbstractString, e::Bool)
+    r, w = _emission_likelihoods(em, key, e)
+    denom = r * θ̄ + w * (1.0 - θ̄)
+    π = denom > 0.0 ? r * θ̄ / denom : θ̄
+    (r, w, π)
+end
+
+# Update one reliability cell. `into_rho` selects ρ (the C=1 cell) vs σ (the C=0 cell); the
+# outcome is the exec signal e, credited `weight` pseudo-counts (WeightedBernoulli).
+function _update_emission!(em::EmissionBelief, key::AbstractString, into_rho::Bool,
+                           e::Bool, weight::Float64)
+    weight > 0.0 || return em
+    d  = into_rho ? em.rho_cells : em.sigma_cells
+    p0 = into_rho ? em.rho0 : em.sigma0
+    cur = get(d, key, p0)
+    d[key] = condition(cur, _emission_kernel(), (e ? 1 : 0, weight))
+    em
+end
+
+"""
+    route_outcome!(rt, model_id, features, success; human=nothing) -> RoutingState
+
+Learn from one routed turn's per-turn outcome. `features` is the route-request feature dict
+(converted to the context via `context_from_features`). `success` = the proposed call executed
+cleanly (the exec signal e). With no `human` label, decode the latent correctness from e
+(confound-aware) and take one coupled coordinate step: the routing belief conditions on the
+virtual evidence (mean-exact soft-count via `observe_soft`); the shared emission belief
+takes the EM M-step (ρ←(e,π), σ←(e,1−π) through `condition`). A `human` approve/reject makes
+C known: a hard `observe` on the routed model and a unit-weight emission update — the gold
+anchor. The single learning mechanism is `condition` throughout; the θ↔emission coupling is
+coordinate computation (a strategy), invisible to the DSL. Mutates `rt` in place.
+"""
+function route_outcome!(rt::RoutingState, model_id::AbstractString, features::AbstractDict,
+                        success::Bool; human::Union{Nothing, Bool} = nothing)
+    a = findfirst(==(String(model_id)), rt.model_ids)
+    a === nothing && error("route_outcome!: unknown model id $(model_id)")
+    X = context_from_features(rt.model, features)
+    key = _ctx_key(X)
+    e = success
+    if human !== nothing
+        C = human ? 1 : 0                                   # known correctness
+        rt.tops[a] = observe(rt.model, rt.tops[a], X, C)
+        _update_emission!(rt.emission, key, C == 1, e, 1.0)
+    else
+        θ̄ = posterior_accuracy(rt.model, rt.tops[a], X)     # E[θ_a|X] — the decode prior
+        r, w, π = decode_correctness(rt.emission, θ̄, key, e)
+        rt.tops[a] = observe_soft(rt.model, rt.tops[a], X, r, w)
+        _update_emission!(rt.emission, key, true,  e, π)        # ρ gets weight π
+        _update_emission!(rt.emission, key, false, e, 1.0 - π)  # σ gets weight 1−π
+    end
+    rt
+end
+
+"""
+    wire_routing!(env; warm_path) -> RoutingState | nothing
 
 Inject `env[:route-decide]` — the daemon's model-routing closure — from the declared
 routing manifest (routing.bdsl) and the per-profile reward (utility.bdsl). Mirrors
@@ -164,10 +302,13 @@ daemon call-site (`env[:route-decide](features)`) is unchanged in shape.
 
 INERT (returns `nothing`, installs no closure) unless `routing-models` is declared —
 so a governance-only install with no routing.bdsl is unaffected. The K per-model
-`StructureBMA` posteriors are warm-seeded from `warm_path` (measured per-model accuracy)
-and FROZEN: v1 ships the measured belief; online learning of a correctness signal is
-deferred (it needs credit assignment — see ROUTING_DOMINANCE.md). `route-decide` returns
-`Dict("model"=>id, "provider"=>provider, "name"=>name)` for the daemon's route signal.
+`StructureBMA` posteriors are warm-seeded from `warm_path` (measured per-model accuracy);
+they are held LIVE in the returned `RoutingState` and the `route-decide` closure reads them,
+so `route_outcome!` updates flow into subsequent routing decisions (the deferred online
+signal, now landed — per-turn decoded correctness with learned confounds; see
+ROUTING_DOMINANCE.md). `route-decide` returns `Dict("model"=>id, "provider"=>provider,
+"name"=>name)` for the daemon's route signal. The daemon stores the returned `RoutingState`
+and drives learning via `route_outcome!`.
 """
 function wire_routing!(env;
                        warm_path = get(env, Symbol("routing-brain-path"),
@@ -187,24 +328,33 @@ function wire_routing!(env;
 
     reward = Float64(get(env, Symbol("correct-answer-value"), 0.02))
 
+    # Emission prior: declared (`emission-prior`) auditable data, else the directional default.
+    ep = get(env, Symbol("emission-prior"), nothing)
+    emission_prior = (ep isa AbstractVector && length(ep) == 4) ?
+        (Float64(ep[1]), Float64(ep[2]), Float64(ep[3]), Float64(ep[4])) :
+        _DEFAULT_EMISSION_PRIOR
+
     rfeat = get(env, Symbol("routing-features"), nothing)
     rfeat isa AbstractVector ||
         error("routing: routing-models declared but routing-features missing (declare it in routing.bdsl)")
     rmodel = build_model_from_decls(rfeat)
     tops = _reconstruct_routing_tops(rmodel, K, warm_path)
 
+    rt = RoutingState(rmodel, tops, EmissionBelief(emission_prior), names, providers,
+                      model_ids, costs, reward)
+
     # The daemon's routing call-site: a feature dict → the chosen model's wire fields.
-    # The argmax is the single canonical `optimise` inside `route` (Invariant 1); the
-    # only arithmetic is reward/cost coefficient construction from declared utility data.
+    # Reads `rt.tops` LIVE (route_outcome! mutates them); the argmax is the single canonical
+    # `optimise` inside `route` (Invariant 1); the only arithmetic is reward/cost coefficient
+    # construction from declared utility data.
     env[Symbol("route-decide")] = (features) -> begin
-        X = context_from_features(rmodel, features)
-        a = route(rmodel, tops, X, costs, reward)
-        Dict{String, Any}("model" => model_ids[a], "provider" => providers[a],
-                          "name" => names[a])
+        X = context_from_features(rt.model, features)
+        a = route(rt.model, rt.tops, X, rt.costs, rt.reward)
+        Dict{String, Any}("model" => rt.model_ids[a], "provider" => rt.providers[a],
+                          "name" => rt.names[a])
     end
 
-    (model = rmodel, tops = tops, names = names, providers = providers,
-     model_ids = model_ids, costs = costs, reward = reward)
+    rt
 end
 
 end # module RoutingBrain

--- a/apps/credence-pi/daemon/observation_log.jl
+++ b/apps/credence-pi/daemon/observation_log.jl
@@ -28,6 +28,7 @@ using Dates: now, UTC, format
 using JSON3
 
 export append_event!, read_log, replay_user_responses, replay_contexts, LogRecord
+export replay_route_outcomes
 export SCHEMA_VERSION
 
 const SCHEMA_VERSION = "credence-pi/v1"
@@ -192,6 +193,33 @@ function replay_contexts(path::AbstractString)::Vector{Tuple{Any, Int}}
             features === nothing && continue
             push!(out, (features, response == "yes" ? 1 : 0))
         end
+    end
+    out
+end
+
+"""
+    replay_route_outcomes(path) -> Vector{Tuple{String, Any, Bool, Union{Nothing, Bool}}}
+
+Pass-2 ROUTING replay: the sequence of `(model_id, features, success, human)` to fold
+through `RoutingBrain.route_outcome!` on top of the warm `tops`, reconstructing the live
+routing belief after a restart. Reads the derived `route-outcome` events the daemon appends
+when it credits a routed model from a tool-completed. Because `route_outcome!` is
+deterministic given the event order, replaying this sequence reproduces the live belief
+EXACTLY (no summary approximation) — the same durability the governance posterior gets from
+`replay_contexts`. A record missing `model`/`features`/`success` is skipped (cannot be
+placed). `human` is `nothing` unless a human approve/reject was recorded for the turn.
+"""
+function replay_route_outcomes(path::AbstractString)
+    out = Tuple{String, Any, Bool, Union{Nothing, Bool}}[]
+    for record in read_log(path)
+        get(record.event, "event_type", "") == "route-outcome" || continue
+        model = get(record.event, "model", nothing)
+        features = get(record.event, "features", nothing)
+        success = get(record.event, "success", nothing)
+        (model === nothing || features === nothing || success === nothing) && continue
+        h = get(record.event, "human", nothing)
+        human = h === nothing ? nothing : Bool(h)
+        push!(out, (String(model), features, Bool(success), human))
     end
     out
 end

--- a/apps/credence-pi/daemon/server.jl
+++ b/apps/credence-pi/daemon/server.jl
@@ -33,7 +33,7 @@ using Random: randstring
 using Serialization: deserialize
 
 include(joinpath(@__DIR__, "observation_log.jl"))
-using .ObservationLog: append_event!, replay_user_responses, replay_contexts
+using .ObservationLog: append_event!, replay_user_responses, replay_contexts, replay_route_outcomes
 
 # Pull the parent's Credence module — server.jl runs under the test/run
 # loader which has already done `using Credence`.
@@ -52,7 +52,7 @@ using .FeatureBrain: wire_brain!, build_model_from_env, reconstruct_posterior
 # via `..FeatureBrain` (the sibling submodule), so it resolves here under Server exactly
 # as it does at Main in the eval. INERT unless a roster is declared.
 include(joinpath(@__DIR__, "..", "brain", "routing_brain.jl"))
-using .RoutingBrain: wire_routing!
+using .RoutingBrain: wire_routing!, route_outcome!
 
 export start_daemon, stop_daemon, DaemonState
 export SignalQueue, enqueue!, snapshot, drain!
@@ -135,15 +135,23 @@ mutable struct DaemonState
     # conditions on the right cell. Both are transport bookkeeping, not reasoning.
     last_cost::Ref{Any}
     pending_contexts::Dict{String, Any}
+    # Model routing (Pass 2 / live learning). `routing` is the live `RoutingState` (per-model
+    # posteriors + the shared confound belief) or `nothing` for a governance-only install.
+    # `pending_routes` rejoins a tool-completed to its turn's routed model by session_id, so
+    # the per-turn correctness signal credits the right model (transport bookkeeping, not
+    # reasoning — like `pending_contexts`).
+    routing::Any
+    pending_routes::Dict{String, Any}
 end
 
 """
-    load_env(bdsl_dir) -> Eval.Env
+    load_env(bdsl_dir) -> (Eval.Env, Union{RoutingState, Nothing})
 
 Build a fresh BDSL environment with stdlib + the five Pass-1 programs
-loaded in dependency order.
+loaded in dependency order. Returns the env and the live `RoutingState`
+that `wire_routing!` built (or `nothing` for a governance-only install).
 """
-function load_env(bdsl_dir::AbstractString)::Eval.Env
+function load_env(bdsl_dir::AbstractString)
     env = Eval.default_env()
     env[:__toplevel__] = true
     stdlib_path = joinpath(@__DIR__, "..", "..", "..", "src", "stdlib.bdsl")
@@ -171,8 +179,8 @@ function load_env(bdsl_dir::AbstractString)::Eval.Env
         end
     end
     wire_brain!(env)
-    wire_routing!(env)   # installs env[:route-decide] iff a roster was declared; else no-op
-    env
+    routing = wire_routing!(env)   # RoutingState iff a roster was declared; else nothing
+    (env, routing)
 end
 
 """
@@ -215,11 +223,13 @@ end
 Build a fresh daemon state. Calls `load_env`, builds an empty signal
 queue, loads the starting posterior (warm brain if configured, else cold prior),
 and reconstructs on top of it by replaying every `user-responded` event in
-`log_path` through `observe-response`.
+`log_path` through `observe-response`. If routing is configured, it likewise replays
+every `route-outcome` event through `route_outcome!` on top of the warm `tops` —
+deterministic replay reproduces the live routing belief exactly.
 """
 function init_state(; bdsl_dir::AbstractString, log_path::AbstractString,
                     warm_brain_path=nothing)::DaemonState
-    env = load_env(bdsl_dir)
+    env, routing = load_env(bdsl_dir)
     posterior = load_starting_posterior(env, warm_brain_path)
     obs_fn = env[Symbol("observe-response")]
     # Pass 2: replay each user-responded REJOINED to its tool-proposed features
@@ -228,8 +238,15 @@ function init_state(; bdsl_dir::AbstractString, log_path::AbstractString,
     for (features, o) in replay_contexts(log_path)
         posterior = obs_fn(posterior, features, o)
     end
+    # Pass 2 routing: replay route-outcomes onto the warm tops (exact, deterministic).
+    if routing !== nothing
+        for (model_id, features, success, human) in replay_route_outcomes(log_path)
+            route_outcome!(routing, model_id, features, success; human = human)
+        end
+    end
     DaemonState(env, Ref{Any}(posterior), SignalQueue(), log_path, bdsl_dir,
-                Threads.Atomic{Bool}(false), Ref{Any}(nothing), Dict{String, Any}())
+                Threads.Atomic{Bool}(false), Ref{Any}(nothing), Dict{String, Any}(),
+                routing, Dict{String, Any}())
 end
 
 # ── Signal templating ──────────────────────────────────────────────────
@@ -428,7 +445,29 @@ function handle_sensor_event(state::DaemonState,
         end
 
     elseif event_type == "tool-completed"
-        # Pass 1: log only. Pass 2 will condition on outcome features.
+        # Pass 2: the per-turn correctness signal for ROUTING. Credit the routed model of
+        # this session's current turn with the exec outcome (did the proposed call execute
+        # cleanly?). The signal is NOISY — `route_outcome!` decodes it against the LEARNED
+        # tool-reliability confound, so a flaky tool is absorbed by ρ, not blamed on the
+        # model. This NEVER touches the governance posterior (a separate belief). A derived
+        # `route-outcome` event is logged so a restart replays this learning exactly.
+        if state.routing !== nothing
+            session_id = string(get(event_dict, "session_id", ""))
+            routed = get(state.pending_routes, session_id, nothing)
+            if routed !== nothing
+                model_id, features = routed
+                outcome = get(event_dict, "outcome", nothing)
+                success = outcome isa AbstractDict && get(outcome, "success", true) == true
+                route_outcome!(state.routing, model_id, features, success)
+                append_event!(state.log_path, Dict{String, Any}(
+                    "event_type" => "route-outcome",
+                    "event_id"   => string(get(event_dict, "event_id", "")),
+                    "model"      => model_id,
+                    "features"   => features,
+                    "success"    => success,
+                ))
+            end
+        end
 
     elseif event_type == "turn-cost"
         # Per-turn USD cost (OpenClaw-plugin llm_output hook). Logged for the
@@ -442,9 +481,9 @@ function handle_sensor_event(state::DaemonState,
         # Model routing (before_model_resolve). Read the request features and let the
         # brain's route-decide closure pick the EU-max model; emit a `route` signal the
         # body maps to providerOverride/modelOverride. This NEVER touches the governance
-        # posterior — routing is a separate (warm, frozen) belief. If routing is not
-        # configured (no roster declared ⇒ no route-decide), emit nothing: the body
-        # times out and fails open to OpenClaw's default model.
+        # posterior — routing is a SEPARATE belief (its own per-model posteriors). If
+        # routing is not configured (no roster declared ⇒ no route-decide), emit nothing:
+        # the body times out and fails open to OpenClaw's default model.
         route_decide = get(state.env, Symbol("route-decide"), nothing)
         if route_decide === nothing
             @warn "route-request received but routing is not configured; ignoring (body fails open)"
@@ -455,6 +494,13 @@ function handle_sensor_event(state::DaemonState,
                 error("route-request event $event_id missing required 'features'")
             choice = route_decide(features)
             emit_route_signal!(state, event_id, choice)
+            # Remember this turn's routed model so its tool-completed outcomes credit it
+            # (per-session; overwritten next turn). Transport bookkeeping, like pending_contexts.
+            if state.routing !== nothing
+                session_id = string(get(event_dict, "session_id", ""))
+                isempty(session_id) ||
+                    (state.pending_routes[session_id] = (choice["model"], features))
+            end
         end
 
     else

--- a/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
+++ b/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
@@ -159,14 +159,36 @@ What ships live, and what is deliberately deferred:
   per-profile cost-routing (`correct-answer-value` in `utility.bdsl` is the dial) and
   Wald per-profile divergence (low value → cheap, high value → best-believed), through
   the one canonical `optimise`.
-- **The belief is frozen in v1; online learning is deferred.** Closing the quality-regime
-  gap needs *online calibration data* — exactly what a deployed router accumulates. But
-  the honest online signal is unsolved: a session makes many model calls and the only
-  run-level outcome (`agent_end.success`) cannot attribute success to a *specific* call's
-  model. A naive credit rule conflates model quality with task difficulty and tool
-  reliability, which is the credit-assignment layer the paper flags as unsolved. So v1
-  routes on the frozen measured belief; the daemon retains the structure (a `route-outcome`
-  update is a one-function addition) for when a defensible signal is designed.
+- **The belief now learns online (per-turn, confound-aware).** Closing the quality-regime
+  gap needs *online calibration data* — exactly what a deployed router accumulates. The
+  credit-assignment wall is real but specific to *run-level* success (`agent_end.success`
+  cannot attribute a session outcome to one call's model, conflating model-quality with
+  task-difficulty and tool-reliability). We sidestep it by learning from the **per-turn**
+  signal, which *is* per-call attributable: did the routed model's proposed call execute
+  cleanly (`tool-completed.success`)? That signal is itself noisy — a correct call can fail
+  on a flaky tool — so we model the confound explicitly and learn it: shared per-context
+  latents `ρ = P(clean | correct)`, `σ = P(clean | incorrect)`, identified by the
+  cross-model spread against the oracle-anchored accuracy. The signal is decoded to a soft
+  correctness `π` (the routing belief is its own coherent prior), and the belief conditions
+  on the resulting **virtual evidence** (`SoftBernoulli`) — a mean-exact ADF collapse, so
+  the posterior *mean* (what routing's EU reads) is exact; only the variance is approximated.
+  Every update is `condition`; the decode is `expect`; no arbitrary constants (the emission
+  prior is declared, directional, and washed out by data). A human approve/reject, when
+  present, is the gold anchor (a hard label). Mechanism + tests:
+  `brain/routing_brain.jl` (`route_outcome!`), `test_routing.jl` §C/§D.
+- **What confound-partialling buys (the test that matters).** A pure tool-flakiness stream
+  — every call fails for every model, true accuracy unchanged — leaves the accuracy belief
+  essentially flat (drift < 0.005), because the failures are absorbed by the learned `ρ`,
+  not blamed on the models. The naive `fail ⇒ incorrect` credit rule craters the same
+  belief by ~0.5. That gap is the deferral's worry, addressed.
+- **Honest limits of the online layer.** `ρ` (the dominant confound for high-accuracy
+  models) identifies tightly; `σ` (false-success) only weakly — when models are mostly
+  correct, `C=0` is rare, so little data bears on it (its decode influence is proportionally
+  small). The per-turn proxy is *not* ground-truth correctness; identification leans on the
+  oracle anchor and drifts if the live task-mix departs from it. **Run-level** success and
+  multi-call credit assignment remain deferred. The exact-vs-ADF decode *fidelity* is itself
+  a metareasonable axis (EU-max over fidelity-vs-compute) — flagged, not yet built. The
+  belief is durable: `route-outcome` events are logged and replayed on restart (exact).
 - **Only `prompt-length` is conditioned on live.** It is the one feature honestly
   extractable from a raw prompt (semantic category — the offline signal — would need a
   classifier, an arbitrary unmeasured component). The structure-BMA collapses it to the

--- a/apps/credence-pi/eval/train_routing_brain.jl
+++ b/apps/credence-pi/eval/train_routing_brain.jl
@@ -15,8 +15,9 @@
 # short-prompt accuracy and treats long prompts as partly-unknown (the marginal structure
 # still lends them the overall signal; the length structure's long cell is at prior).
 #
-# v1 ships this belief FROZEN. Online learning of a live correctness signal is deferred —
-# it needs credit assignment across a session's many model calls (ROUTING_DOMINANCE.md).
+# This is the WARM SEED (a prior): the daemon then learns online from each routed turn's
+# per-turn outcome, confound-aware (brain/routing_brain.jl `route_outcome!`). Run-level /
+# multi-call credit assignment stays deferred (ROUTING_DOMINANCE.md).
 #
 # NON-CAUSAL (Role: eval): reads measured data, tallies counts, writes + verifies a
 # fixture. No belief drives a decision here. Run from repo root:
@@ -62,9 +63,9 @@ function main()
         "models" => models, "model_ids" => model_ids,
         "features" => FEATS, "feature_values" => VALS,
         "note" => "All items are short MCQ ⇒ short cell only; long cell stays at prior. " *
-                  "Daemon reconstructs K posteriors by replaying these counts via observe. " *
-                  "Frozen in v1 (no live correctness signal yet — needs credit assignment).",
-        "trained_at" => string(now()), "frozen" => true,
+                  "Daemon reconstructs K posteriors by replaying these counts via observe, " *
+                  "then learns online per routed turn (confound-aware; see routing_brain.jl).",
+        "trained_at" => string(now()), "warm_seed" => true,
         "per_model" => per_model)
     open(OUT, "w") do io; JSON3.pretty(io, out); end
     println("wrote per-model counts → $OUT")

--- a/apps/credence-pi/openclaw-plugin/README.md
+++ b/apps/credence-pi/openclaw-plugin/README.md
@@ -106,13 +106,21 @@ under the active profile.
 **What the belief is.** The per-model accuracy belief is **warm-seeded from
 measured data** (`brain/routing_brain.counts.json`, distilled from the
 3-frontier-model oracle grid by `eval/train_routing_brain.jl`) so routing is
-calibrated from install. It is **frozen** in this version: the cost-routing
-behaviour is the proven result, but online learning of a live correctness
-signal is deferred — it needs credit assignment across a session's many
-model calls (see `eval/results/ROUTING_DOMINANCE.md`). Only `prompt-length`
-is conditioned on, because it is the one feature honestly extractable from a
-raw prompt; the structure-BMA collapses it to the marginal if it doesn't
-predict accuracy.
+calibrated from install, and it **learns online**: each routed turn's
+per-turn outcome — did the proposed call execute cleanly
+(`tool-completed.success`)? — updates the routed model's belief. That signal
+is noisy (a correct call can fail on a flaky tool), so the brain models the
+confound explicitly and learns it (per-context tool-reliability), and a flaky
+tool is absorbed by the reliability latent rather than blamed on the model;
+the belief conditions on the decoded soft correctness through the canonical
+`condition` (mean-exact, so routing's EU is exact). A human approve/reject is
+the gold anchor. Honest limits — per-turn proxy ≠ ground-truth correctness;
+the false-success rate is only weakly identified; run-level / multi-call
+credit assignment stays deferred — are in `eval/results/ROUTING_DOMINANCE.md`.
+The belief is durable (route-outcomes are logged and replayed on restart).
+Only `prompt-length` is conditioned on, because it is the one feature honestly
+extractable from a raw prompt; the structure-BMA collapses it to the marginal
+if it doesn't predict accuracy.
 
 ## Develop
 

--- a/apps/credence-pi/openclaw-plugin/src/index.ts
+++ b/apps/credence-pi/openclaw-plugin/src/index.ts
@@ -346,6 +346,9 @@ export function createGovernor(
       event_type: "tool-completed",
       event_id: newEventId(),
       in_response_to: event.toolCallId ?? "",
+      // session_id lets the daemon credit this outcome to the turn's routed model
+      // (online routing learning). The governance path correlates by toolCallId, not this.
+      session_id: ctx.sessionId ?? ctx.sessionKey ?? "",
       timestamp: new Date().toISOString(),
       outcome: {
         success: event.error == null,

--- a/apps/credence-pi/openclaw-plugin/tests/index.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/index.test.ts
@@ -164,9 +164,11 @@ test("after_tool_call: posts tool-completed correlated by toolCallId", async () 
   const h = harness();
   await h.gov.afterToolCall({ toolName: "bash", toolCallId: "tc1", params: {}, durationMs: 12 }, ctx);
   const tc = h.find("tool-completed") as
-    | { in_response_to: string; outcome: { success: boolean; duration_ms: number } }
+    | { in_response_to: string; session_id: string; outcome: { success: boolean; duration_ms: number } }
     | undefined;
   assert.equal(tc?.in_response_to, "tc1");
+  // session_id lets the daemon credit this outcome to the turn's routed model (online routing).
+  assert.equal(tc?.session_id, "s1");
   assert.equal(tc?.outcome.success, true);
   assert.equal(tc?.outcome.duration_ms, 12);
   h.gov.cleanup();

--- a/apps/credence-pi/tests/julia/test_routing.jl
+++ b/apps/credence-pi/tests/julia/test_routing.jl
@@ -16,13 +16,14 @@ route-request never touches the governance posterior (separate belief).
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "..", "src"))
 using Credence
-using Credence: Eval, Parse, Identity, weights, expect
+using Credence: Eval, Parse, Identity, weights, expect, mean
 using JSON3
+using Random: MersenneTwister
 
 include(joinpath(@__DIR__, "..", "..", "brain", "feature_brain.jl"))
-using .FeatureBrain: build_model
+using .FeatureBrain: build_model, observe, observe_soft
 include(joinpath(@__DIR__, "..", "..", "brain", "routing_brain.jl"))
-using .RoutingBrain: wire_routing!, route, posterior_accuracy
+using .RoutingBrain: wire_routing!, route, posterior_accuracy, route_outcome!, _ctx_key
 
 const BDSL_DIR = joinpath(@__DIR__, "..", "..", "bdsl")
 const TOL = 1e-12
@@ -160,6 +161,126 @@ let path = tempname() * ".jsonl"
         "features" => Dict("prompt-length" => "short")))
     @assert isempty(snapshot(state.signal_queue))
     ok("route-request with routing unconfigured emits no signal (body fails open)")
+    rm(path; force = true)
+end
+
+# ── C. Online correctness learning (brain): soft evidence + learned confounds ───
+#
+# The deferred online signal, landed. We never see model correctness; we see whether the
+# proposed call executed cleanly (e), a NOISY emission of latent correctness confounded by
+# tool reliability. route_outcome! decodes e against a LEARNED confound (ρ,σ) and conditions
+# the routing belief on the resulting virtual evidence — so a flaky tool is absorbed by ρ,
+# not blamed on the model. All updates are `condition`; the decode is `expect`.
+
+const FEAT_SHORT = Dict("prompt-length" => "short")
+θat(rt, a) = posterior_accuracy(rt.model, rt.tops[a], ["short"])
+ρ̄of(rt) = mean(get(rt.emission.rho_cells, _ctx_key(["short"]), rt.emission.rho0))
+
+# C1. Reduces EXACTLY to the hard observe at the certain-signal corners: (r,w)=(1,0) is a
+# hard 1, (0,1) is a hard 0 — observe_soft generalises observe (the substrate-equivalence guard).
+let rt = wire_routing!(routing_env())
+    top = rt.tops[1]
+    h1 = posterior_accuracy(rt.model, observe(rt.model, top, ["short"], 1), ["short"])
+    s1 = posterior_accuracy(rt.model, observe_soft(rt.model, top, ["short"], 1.0, 0.0), ["short"])
+    h0 = posterior_accuracy(rt.model, observe(rt.model, top, ["short"], 0), ["short"])
+    s0 = posterior_accuracy(rt.model, observe_soft(rt.model, top, ["short"], 0.0, 1.0), ["short"])
+    @assert s1 == h1 && s0 == h0
+    ok("soft evidence reduces EXACTLY to the hard observe at (1,0)/(0,1)")
+end
+
+# C2. Direction: clean per-turn successes raise the routed model's accuracy belief.
+let rt = wire_routing!(routing_env())
+    before = θat(rt, 1)
+    for _ in 1:30; route_outcome!(rt, rt.model_ids[1], FEAT_SHORT, true); end
+    @assert θat(rt, 1) > before
+    ok("clean successes raise θ ($(round(before, digits = 3)) → $(round(θat(rt, 1), digits = 3)))")
+end
+
+# C3. CONFOUND-PARTIALLING — the property the deferral was about. A pure tool-flakiness
+# stream (every call fails for EVERY model, true accuracy unchanged) must NOT collapse θ:
+# the failures are absorbed by the learned reliability ρ, not blamed on the models. Contrast
+# a NAIVE hard "fail ⇒ incorrect" rule, which craters the same belief — the mis-attribution
+# the decode exists to avoid.
+let rt = wire_routing!(routing_env())
+    before = [θat(rt, a) for a in 1:3]
+    for _ in 1:60, a in 1:3; route_outcome!(rt, rt.model_ids[a], FEAT_SHORT, false); end
+    drift = maximum(abs.([θat(rt, a) for a in 1:3] .- before))
+    @assert drift < 0.03          # θ essentially flat
+    @assert ρ̄of(rt) < 0.2         # ρ learned LOW: correct calls failed too ⇒ the tool is flaky
+    ok("confound-partialling: pure flakiness leaves θ flat (max drift $(round(drift, digits = 4))), absorbed by ρ̄=$(round(ρ̄of(rt), digits = 3)))")
+
+    naive = wire_routing!(routing_env())   # baseline: same failures as hard "incorrect" labels
+    # credence-lint: allow — precedent:baseline-comparison — naive hard-label credit rule, the conflation the decode avoids
+    for _ in 1:60, a in 1:3; naive.tops[a] = observe(naive.model, naive.tops[a], ["short"], 0); end
+    collapsed = maximum(before .- [θat(naive, a) for a in 1:3])
+    @assert collapsed > 0.3
+    ok("contrast: naive hard fail⇒incorrect collapses θ by $(round(collapsed, digits = 3))")
+end
+
+# C4. Human approve/reject is the gold anchor: a KNOWN label drives θ hard.
+let rt = wire_routing!(routing_env())
+    before = θat(rt, 1)
+    for _ in 1:25; route_outcome!(rt, rt.model_ids[1], FEAT_SHORT, false; human = false); end
+    @assert θat(rt, 1) < before - 0.2
+    ok("human reject is the gold anchor: θ falls sharply ($(round(before, digits = 3)) → $(round(θat(rt, 1), digits = 3)))")
+end
+
+# C5. Identifiability (seeded synthetic stream). ρ (correct ⇒ clean-exec, the dominant
+# confound for high-accuracy models) recovers tightly; θ stays anchored-stable. σ (wrong ⇒
+# clean-exec) is only WEAKLY identified — C=0 is rare when models are mostly correct, so
+# little data bears on it (an honest limit; its decode influence is proportionally small).
+# Seeded ⇒ reproducible; bands carry comfortable margin.
+let rt = wire_routing!(routing_env())
+    ρ_true, σ_true = 0.9, 0.25
+    θtrue = [θat(rt, a) for a in 1:3]            # the warm anchors — data is consistent with them
+    σ̄of(r) = mean(get(r.emission.sigma_cells, _ctx_key(["short"]), r.emission.sigma0))
+    rng = MersenneTwister(20260616)
+    for _ in 1:1500
+        a = rand(rng, 1:3)
+        C = rand(rng) < θtrue[a]
+        e = rand(rng) < (C ? ρ_true : σ_true)
+        route_outcome!(rt, rt.model_ids[a], FEAT_SHORT, e)
+    end
+    Δθ = maximum(abs.([θat(rt, a) for a in 1:3] .- θtrue))
+    @assert abs(ρ̄of(rt) - ρ_true) < 0.06        # ρ tightly identified
+    @assert Δθ < 0.05                            # θ anchored-stable under consistent data
+    @assert abs(σ̄of(rt) - σ_true) < 0.25         # σ weakly identified (rare C=0) — honest loose band
+    ok("identifiability: ρ̄=$(round(ρ̄of(rt), digits = 3))≈$(ρ_true) (tight), θ stable (Δ$(round(Δθ, digits = 3))); σ weakly identified")
+end
+
+# ── D. Online learning through the daemon: route-outcome → live tops, exact replay ──
+#
+# Cross-module note: `state.routing` is built by the daemon's nested `Server.RoutingBrain`,
+# so its readouts go through `Server.RoutingBrain.posterior_accuracy` (the top-level
+# RoutingBrain is a different module instance with different types).
+
+let path = tempname() * ".jsonl"
+    state = init_state(; bdsl_dir = DAEMON_BDSL, log_path = path)
+    @assert state.routing !== nothing
+    θd(a) = Server.RoutingBrain.posterior_accuracy(state.routing.model, state.routing.tops[a], ["short"])
+    w_before = weights(state.posterior[])
+    before = θd(1)
+    # A routed turn (session S1) whose proposed call executes cleanly, ×20.
+    for i in 1:20
+        handle_sensor_event(state, Dict{String, Any}("event_type" => "route-request",
+            "event_id" => "rq$i", "session_id" => "S1", "features" => Dict("prompt-length" => "short")))
+        handle_sensor_event(state, Dict{String, Any}("event_type" => "tool-completed",
+            "event_id" => "tc$i", "session_id" => "S1", "outcome" => Dict("success" => true)))
+    end
+    @assert θd(1) > before
+    ok("daemon: route-request→tool-completed(success) raises the routed model's θ live ($(round(before, digits = 3)) → $(round(θd(1), digits = 3)))")
+
+    # Routing is a SEPARATE belief: learning to route never touches the governance posterior.
+    # credence-lint: allow — precedent:test-oracle — governance-posterior equality oracle (routing must not learn governance)
+    @assert weights(state.posterior[]) == w_before
+    ok("daemon: route learning leaves the governance posterior untouched (separate belief)")
+
+    # Durability: a fresh daemon replays the route-outcome log and reconstructs θ EXACTLY.
+    learned = θd(1)
+    state2 = init_state(; bdsl_dir = DAEMON_BDSL, log_path = path)
+    # credence-lint: allow — precedent:test-oracle — exact-replay equality oracle
+    @assert Server.RoutingBrain.posterior_accuracy(state2.routing.model, state2.routing.tops[1], ["short"]) == learned
+    ok("daemon: restart replays route-outcomes and reconstructs the routing belief EXACTLY")
     rm(path; force = true)
 end
 

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -38,7 +38,7 @@ export run_dsl, load_dsl, parse_sexpr, parse_all
 export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals, support
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, EnumerationMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target
-export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, WeightedBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
+export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, WeightedBernoulli, SoftBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
 export NormalNormal, Categorical, NormalGammaLikelihood, Exponential
 export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
 export indicator_kernel, feature_value, BOOLEAN_SPACE

--- a/src/conjugate.jl
+++ b/src/conjugate.jl
@@ -14,6 +14,8 @@ function maybe_conjugate(p::BetaPrevision, k::Kernel)
         return ConjugatePrevision(p, k.likelihood_family)
     elseif k.likelihood_family isa WeightedBernoulli
         return ConjugatePrevision(p, k.likelihood_family)
+    elseif k.likelihood_family isa SoftBernoulli
+        return ConjugatePrevision(p, k.likelihood_family)
     elseif k.likelihood_family isa Flat
         return ConjugatePrevision(p, k.likelihood_family)
     end
@@ -48,6 +50,26 @@ function update(cp::ConjugatePrevision{BetaPrevision, WeightedBernoulli}, obs)
         BetaPrevision(cp.prior.alpha + w * o, cp.prior.beta + w * (1.0 - o)),
         cp.likelihood,
     )
+end
+
+# Virtual-evidence update. `obs = (r, w)` are the likelihoods of an indirect
+# signal under the event being true / false: r = P(S | θ-event), w = P(S | ¬).
+# The exact posterior under L(θ) = r·θ + w·(1−θ) is a 2-component Beta mixture;
+# this is its mean-exact ADF collapse — π = r·θ̄/(r·θ̄ + w·(1−θ̄)) is the implied
+# posterior P(event | S), and Beta(α+π, β+(1−π)) reproduces the exact posterior
+# mean (α+π)/(α+β+1) (derivation in kernels.jl). Reduces to the unit-count
+# BetaBernoulli at (r,w) = (1,0) [hard 1] and (0,1) [hard 0]. The structure-
+# reweight predictive (r·E[θ] + w·(1−E[θ])) is the kernel's log_density.
+function update(cp::ConjugatePrevision{BetaPrevision, SoftBernoulli}, obs)
+    r, w = obs
+    r = Float64(r); w = Float64(w)
+    (r >= 0.0 && w >= 0.0) || error("SoftBernoulli update: likelihoods must be ≥ 0, got ($r, $w)")
+    α = cp.prior.alpha; β = cp.prior.beta
+    θ̄ = α / (α + β)
+    denom = r * θ̄ + w * (1.0 - θ̄)
+    denom > 0.0 || error("SoftBernoulli update: evidence has zero marginal likelihood (r=$r, w=$w)")
+    π = r * θ̄ / denom
+    ConjugatePrevision(BetaPrevision(α + π, β + (1.0 - π)), cp.likelihood)
 end
 
 # ── Pair: (GaussianPrevision, NormalNormal) ──

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -24,6 +24,20 @@ struct BetaBernoulli <: LeafFamily end
 # `BetaBernoulli` above is left untouched (it still errors on non-{0,1}).
 # Rationale + worked example: docs/paper1/move-2c-design.md.
 struct WeightedBernoulli <: LeafFamily end
+# Virtual / soft EVIDENCE on a latent Bernoulli. The observation is a pair
+# `(r, w)` of likelihoods `r = P(evidence | θ-event true)`,
+# `w = P(evidence | θ-event false)` — Pearl's λ-message, not an outcome. The
+# exact posterior under `L(θ) = r·θ + w·(1−θ)` is a 2-component Beta mixture;
+# the conjugate `update` here is its MEAN-EXACT ADF collapse:
+#   π = r·θ̄ / (r·θ̄ + w·(1−θ̄)),   α += π,  β += (1−π)    (θ̄ = α/(α+β))
+# which reproduces the exact posterior mean (α+π)/(α+β+1) — so any decision
+# reading E[θ] is exact; only the belief's variance is approximated. The
+# predictive marginal `r·E[θ] + w·(1−E[θ])` (the BMA structure-reweight term)
+# is supplied by the kernel's `log_density`. Reduces EXACTLY to BetaBernoulli
+# at `(r,w) = (1,0)` (a hard 1) and `(0,1)` (a hard 0). Distinct from
+# WeightedBernoulli, which tempers a KNOWN outcome by a weight; SoftBernoulli
+# carries the likelihood of an indirect signal and decodes per-cell.
+struct SoftBernoulli <: LeafFamily end
 struct Flat <: LeafFamily end
 struct PushOnly <: LikelihoodFamily end
 

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -34,7 +34,7 @@ import ..Previsions: Indicator, apply
 export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals, support
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, EnumerationMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target, kernel_params
-export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, WeightedBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
+export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, WeightedBernoulli, SoftBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
 export NormalNormal, Categorical, NormalGammaLikelihood, Exponential
 export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
 export indicator_kernel, feature_value, BOOLEAN_SPACE

--- a/test/test_prevision_soft_bernoulli.jl
+++ b/test/test_prevision_soft_bernoulli.jl
@@ -1,0 +1,122 @@
+# test_prevision_soft_bernoulli.jl — Stratum-2 for the
+# (BetaPrevision, SoftBernoulli) conjugate pair.
+#
+# SoftBernoulli is VIRTUAL EVIDENCE on a latent Bernoulli: obs = (r, w) are the
+# likelihoods of an indirect signal under the event being true / false
+# (Pearl's λ-message), NOT an outcome. The exact posterior under
+# L(θ) = r·θ + w·(1−θ) is a 2-component Beta mixture
+#     π·Beta(α+1,β) + (1−π)·Beta(α,β+1),   π = r·θ̄ / (r·θ̄ + w·(1−θ̄))
+# and the conjugate update here is its MEAN-EXACT ADF collapse Beta(α+π, β+1−π).
+#
+# Discipline (per test_prevision_weighted_bernoulli.jl): assert
+# `_dispatch_path == :conjugate` BEFORE the value, so a silent registry miss is
+# caught. Three load-bearing properties:
+#   1. MEAN-EXACT — the collapsed posterior mean == the exact 2-component
+#      mixture mean (computed independently), so any decision reading E[θ] is
+#      exact. (==/rtol 1e-12, not "close enough".)
+#   2. UNINFORMATIVE INVARIANCE — a signal equally likely under both (r == w)
+#      leaves E[θ] EXACTLY unchanged (it only adds concentration). This is the
+#      substrate root of confound-partialling: a non-diagnostic signal moves
+#      nothing.
+#   3. HARD REDUCTION — (r,w)=(1,0) ≡ BetaBernoulli(1) and (0,1) ≡
+#      BetaBernoulli(0), EXACTLY (==) — the substrate-change equivalence guard.
+#
+# Run from the repo root:
+#     julia test/test_prevision_soft_bernoulli.jl
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: ConjugatePrevision, maybe_conjugate, update, _dispatch_path
+using Credence: BetaPrevision
+using Credence.Ontology: wrap_in_measure
+
+function check(name, cond, detail="")
+    if cond
+        println("PASSED: $name")
+    else
+        println("FAILED: $name — $detail")
+        error("Stratum-2 assertion failed: $name")
+    end
+end
+
+bmean(p) = p.alpha / (p.alpha + p.beta)
+
+# Conjugate path is registry-driven; the kernel's generate/log_density are not
+# consulted by update() (the predictive log_density is exercised in the brain
+# tests). likelihood_family is the load-bearing declaration.
+soft_kernel() = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
+    h -> wrap_in_measure(CategoricalPrevision([0.0, 0.0]), Finite([0, 1])),
+    (h, o) -> 0.0;
+    likelihood_family = SoftBernoulli())
+
+bbern_kernel() = Kernel(Interval(0.0, 1.0), Finite([0, 1]),
+    h -> wrap_in_measure(CategoricalPrevision([0.0, 0.0]), Finite([0, 1])),
+    (h, o) -> o == 1 ? log(max(h, 1e-300)) : log(max(1 - h, 1e-300));
+    likelihood_family = BetaBernoulli())
+
+println("="^60)
+println("Stratum 2 — (BetaPrevision, SoftBernoulli)")
+println("="^60)
+
+let k = soft_kernel()
+    p = BetaPrevision(2.0, 3.0)
+
+    # Dispatch path FIRST.
+    check("BetaPrevision + SoftBernoulli → :conjugate",
+          _dispatch_path(p, k) === :conjugate, "got $(_dispatch_path(p, k))")
+
+    cp = maybe_conjugate(p, k)
+    check("maybe_conjugate returns ConjugatePrevision{BetaPrevision, SoftBernoulli}",
+          cp isa ConjugatePrevision{BetaPrevision, SoftBernoulli}, "got $(typeof(cp))")
+
+    # ── 1. MEAN-EXACT vs the exact 2-component mixture (independent compute) ──
+    α, β = 2.0, 3.0
+    θ̄ = α / (α + β)
+    r, w = 3.0, 1.0                      # signal 3× more likely if the event is true
+    π = r * θ̄ / (r * θ̄ + w * (1.0 - θ̄))
+    # Exact posterior is π·Beta(α+1,β) + (1−π)·Beta(α,β+1); its mean:
+    exact_mean = π * (α + 1.0) / (α + β + 1.0) + (1.0 - π) * α / (α + β + 1.0)
+    u = update(cp, (r, w)).prior
+    check("collapsed α = α + π exactly",
+          u.alpha == α + π && u.beta == β + (1.0 - π),
+          "got α=$(u.alpha), β=$(u.beta); expected ($(α+π), $(β+1-π))")
+    check("collapsed mean == exact 2-component mixture mean (rtol 1e-12)",
+          isapprox(bmean(u), exact_mean; rtol = 1e-12),
+          "collapsed=$(bmean(u)) exact=$(exact_mean)")
+
+    # ── 2. UNINFORMATIVE INVARIANCE: r == w leaves E[θ] exactly unchanged ──
+    ui = update(cp, (0.42, 0.42)).prior
+    check("uninformative signal (r==w) leaves E[θ] EXACTLY unchanged",
+          isapprox(bmean(ui), θ̄; rtol = 1e-12),
+          "before=$(θ̄) after=$(bmean(ui))")
+    check("uninformative signal still adds concentration mass (+1)",
+          isapprox(ui.alpha + ui.beta, α + β + 1.0; rtol = 1e-12),
+          "mass=$(ui.alpha + ui.beta)")
+
+    # Zero marginal likelihood rejected (r==w==0 would divide by zero).
+    threw = false
+    try; update(cp, (0.0, 0.0)); catch; threw = true; end
+    check("SoftBernoulli rejects zero-marginal evidence (r=w=0)", threw)
+end
+
+# ── 3. HARD REDUCTION: (1,0) ≡ BetaBernoulli(1), (0,1) ≡ BetaBernoulli(0) ──
+let wp = BetaPrevision(2.0, 3.0)
+    scp = maybe_conjugate(wp, soft_kernel())
+    bcp = maybe_conjugate(wp, bbern_kernel())
+
+    s1 = update(scp, (1.0, 0.0)).prior     # signal certain under true, impossible under false ⇒ π=1
+    b1 = update(bcp, 1).prior
+    check("(r,w)=(1,0) ≡ BetaBernoulli(1): Beta(3,3) exactly",
+          s1.alpha == b1.alpha && s1.beta == b1.beta && s1.alpha == 3.0 && s1.beta == 3.0,
+          "soft=($(s1.alpha),$(s1.beta)) unit=($(b1.alpha),$(b1.beta))")
+
+    s0 = update(scp, (0.0, 1.0)).prior     # π=0
+    b0 = update(bcp, 0).prior
+    check("(r,w)=(0,1) ≡ BetaBernoulli(0): Beta(2,4) exactly",
+          s0.alpha == b0.alpha && s0.beta == b0.beta && s0.alpha == 2.0 && s0.beta == 4.0,
+          "soft=($(s0.alpha),$(s0.beta)) unit=($(b0.alpha),$(b0.beta))")
+end
+
+println("="^60)
+println("ALL CHECKS PASSED — (BetaPrevision, SoftBernoulli)")
+println("="^60)


### PR DESCRIPTION
## What

Un-freezes the routing belief that PR #120 shipped warm-but-frozen. The router now **learns online** from each routed turn's per-turn outcome, with the credit-assignment confound modelled and learned rather than assumed — the "sophisticated likelihood model" the deferral called for.

## The model (within the Bayesian paradigm, no arbitrary constants)

We never observe model correctness directly; we observe whether the model's proposed call executed cleanly (`tool-completed.success`) — a **per-turn** signal that *is* per-call attributable, so it sidesteps the run-level credit-assignment wall the repo deferred (`agent_end.success` can't attribute a session outcome to one call's model).

That signal is noisy (a correct call can fail on a flaky tool), so the confound is **learned**:

- `θ_a(X) = P(correct | model a, ctx X)` — the routing belief, **its own coherent prior** for the latent correctness `C`.
- `ρ_X = P(clean | C=1)`, `σ_X = P(clean | C=0)` — shared per-context latents (tool reliability / false-success), **identified by the cross-model spread** against the oracle-anchored accuracy.
- **Decode** `π = P(C=1 | signal)` integrating emission uncertainty via `expect`; the belief conditions on the resulting **virtual evidence** through a new `SoftBernoulli` conjugate family — a **mean-exact** ADF collapse (so routing's EU, which reads `E[θ]`, is *exact*; only variance is approximated). The confound takes the EM M-step via `WeightedBernoulli`.
- A **human approve/reject**, when present, is the gold anchor (a hard label).

Every belief update is `condition`; the decode is `expect`; the one emission prior is **declared** (`routing.bdsl`), directional, and washed out by data. The single approximation (ADF) is the move-2c-consented one, reused.

## The test that matters (confound-partialling)

A pure tool-flakiness stream — every call fails for every model, true accuracy unchanged — leaves the accuracy belief **flat** (drift `< 0.005`), because failures are absorbed by the learned `ρ`. A **naive `fail ⇒ incorrect`** credit rule craters the same belief by **~0.5**. That gap is the deferral's worry, addressed.

## Changes

| Layer | Change |
|---|---|
| substrate (`src/`) | `SoftBernoulli` virtual-evidence family + conjugate `update`/predictive; `test_prevision_soft_bernoulli.jl` (mean-exactness @ 1e-12, hard-reduction `==`) |
| brain | `feature_brain.observe_soft`; `routing_brain` `EmissionBelief` / `decode_correctness` / `route_outcome!` / live `RoutingState` |
| daemon | live `RoutingState`; per-session route bookkeeping; `tool-completed` credits the routed model + logs a `route-outcome`; **exact** restart replay; governance posterior untouched |
| body | `tool-completed` carries `session_id` (the one plugin change) |
| docs | `ROUTING_DOMINANCE.md` + plugin README: online-learning + honest limits |

## Honest limits (in `ROUTING_DOMINANCE.md`)

Per-turn proxy ≠ ground-truth correctness; `σ` (false-success) only weakly identified when models are mostly correct (`C=0` rare); identification leans on the oracle anchor and drifts if the live task-mix departs from it; **run-level / multi-call** credit assignment stays deferred; exact-vs-ADF decode *fidelity* is a metareasonable axis (EU-max over fidelity-vs-compute), flagged not built.

## Verification

- credence-pi Julia suite **7/7** (incl. `test_routing` 21 assertions: §C brain learning, §D daemon learning + exact replay).
- substrate `test_prevision_soft_bernoulli` + `test_product_bma_routing` + core green.
- `credence-lint` **0 violations** across 209 files (brain/daemon pragma-free).
- plugin **typecheck + build + 41 tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)