### PR TITLE
credence-pi: roster-aware model routing, ON by default

### DIFF
--- a/apps/credence-pi/brain/routing_brain.jl
+++ b/apps/credence-pi/brain/routing_brain.jl
@@ -241,13 +241,31 @@ EmissionBelief(prior::NTuple{4, Float64} = _DEFAULT_EMISSION_PRIOR) =
 # belief — un-frozen vs v1's closure-captured constant.
 mutable struct RoutingState
     model::StructureBMA
-    tops::Vector{MixturePrevision}
+    tops::Vector{MixturePrevision}              # warm beliefs for the DEFAULT roster (positional)
+    extra_tops::Dict{String, MixturePrevision}  # beliefs for models NOT in the default roster —
+                                                # the user's OWN models: cold prior on first sight,
+                                                # then learned online; keyed by model id
     emission::EmissionBelief
+    # The DEFAULT roster (declared in routing.bdsl): the warm/known models, and the fallback
+    # used when a route-request carries no live roster. The LIVE roster (the user's actual
+    # OpenClaw models) arrives PER REQUEST — that is what makes routing roster-aware.
     names::Vector{String}
     providers::Vector{String}
     model_ids::Vector{String}
     costs::Vector{Float64}
     reward::Float64
+end
+
+# Fetch model_id's belief plus a setter to write an update back. KNOWN models (the default
+# roster) live in the positional `tops`; the user's OWN models live in `extra_tops` (cold
+# `build_prior` on first sight, then learned). No error on an unknown model — routing is
+# roster-aware, so any model the body routes to gets a coherent belief.
+function _belief_slot(rt::RoutingState, model_id::AbstractString)
+    a = findfirst(==(String(model_id)), rt.model_ids)
+    a !== nothing && return (rt.tops[a], top -> (rt.tops[a] = top))
+    id = String(model_id)
+    cur = get!(() -> build_prior(rt.model), rt.extra_tops, id)
+    (cur, top -> (rt.extra_tops[id] = top))
 end
 
 _ctx_key(X::AbstractVector) = join(string.(X), "|")
@@ -308,19 +326,18 @@ coordinate computation (a strategy), invisible to the DSL. Mutates `rt` in place
 """
 function route_outcome!(rt::RoutingState, model_id::AbstractString, features::AbstractDict,
                         success::Bool; human::Union{Nothing, Bool} = nothing)
-    a = findfirst(==(String(model_id)), rt.model_ids)
-    a === nothing && error("route_outcome!: unknown model id $(model_id)")
     X = context_from_features(rt.model, features)
     key = _ctx_key(X)
     e = success
+    top, setby = _belief_slot(rt, model_id)                 # known slot or the user's own model
     if human !== nothing
         C = human ? 1 : 0                                   # known correctness
-        rt.tops[a] = observe(rt.model, rt.tops[a], X, C)
+        setby(observe(rt.model, top, X, C))
         _update_emission!(rt.emission, key, C == 1, e, 1.0)
     else
-        θ̄ = posterior_accuracy(rt.model, rt.tops[a], X)     # E[θ_a|X] — the decode prior
+        θ̄ = posterior_accuracy(rt.model, top, X)            # E[θ|X] — the decode prior
         r, w, π = decode_correctness(rt.emission, θ̄, key, e)
-        rt.tops[a] = observe_soft(rt.model, rt.tops[a], X, r, w)
+        setby(observe_soft(rt.model, top, X, r, w))
         _update_emission!(rt.emission, key, true,  e, π)        # ρ gets weight π
         _update_emission!(rt.emission, key, false, e, 1.0 - π)  # σ gets weight 1−π
     end
@@ -376,21 +393,60 @@ function wire_routing!(env;
     rmodel = build_model_from_decls(rfeat)
     tops = _reconstruct_routing_tops(rmodel, K, warm_path)
 
-    rt = RoutingState(rmodel, tops, EmissionBelief(emission_prior), names, providers,
+    rt = RoutingState(rmodel, tops, Dict{String, MixturePrevision}(),
+                      EmissionBelief(emission_prior), names, providers,
                       model_ids, costs, reward)
 
-    # The daemon's routing call-site: a feature dict → the chosen model's wire fields.
-    # Reads `rt.tops` LIVE (route_outcome! mutates them); the argmax is the single canonical
-    # `optimise` inside `route` (Invariant 1); the only arithmetic is reward/cost coefficient
-    # construction from declared utility data.
-    env[Symbol("route-decide")] = (features) -> begin
-        X = context_from_features(rt.model, features)
-        a = route(rt.model, rt.tops, X, rt.costs, rt.reward)
-        Dict{String, Any}("model" => rt.model_ids[a], "provider" => rt.providers[a],
-                          "name" => rt.names[a])
-    end
+    # The daemon's routing call-site: (feature dict[, live roster]) → the chosen model's wire
+    # fields, or `nothing` (inert ⇒ body keeps OpenClaw's model). Reads rt's beliefs LIVE
+    # (route_outcome! mutates them); the argmax is the single canonical `optimise` inside
+    # `route` (Invariant 1); the only arithmetic is reward/cost coefficient construction.
+    env[Symbol("route-decide")] = (features, roster = nothing) -> _route_decide(rt, features, roster)
 
     rt
+end
+
+# Resolve a routing decision over the LIVE roster (the user's actual models, sent per request)
+# or the declared default roster. Returns `nothing` — body keeps OpenClaw's model — when fewer
+# than 2 candidates exist (routing is a no-op with nothing to choose between), so routing-on-
+# by-default is safe for a single-model install.
+function _route_decide(rt::RoutingState, features, roster)
+    names, providers, ids, costs, tops = _resolve_roster(rt, roster)
+    length(ids) >= 2 || return nothing
+    X = context_from_features(rt.model, features)
+    a = route(rt.model, tops, X, costs, rt.reward)
+    Dict{String, Any}("model" => ids[a], "provider" => providers[a], "name" => names[a])
+end
+
+# Aligned (names, providers, ids, costs, tops) for the decision. No live roster ⇒ the declared
+# default (warm beliefs). A live roster ⇒ each entry is (name provider model-id cost): a known
+# model reuses its warm/learned belief, an unknown one its cold/learned belief from extra_tops
+# (instantiated on first sight). This is how the user's OWN models get routed.
+function _resolve_roster(rt::RoutingState, roster)
+    (roster === nothing || (roster isa AbstractVector && isempty(roster))) &&
+        return (rt.names, rt.providers, rt.model_ids, rt.costs, rt.tops)
+    roster isa AbstractVector ||
+        error("route-decide: roster must be a list of (name provider model-id cost), got $(typeof(roster))")
+    names = String[]; providers = String[]; ids = String[]; costs = Float64[]
+    tops = MixturePrevision[]
+    for m in roster
+        name, provider, id, cost = _roster_entry(m)
+        push!(names, name); push!(providers, provider); push!(ids, id); push!(costs, cost)
+        push!(tops, _belief_slot(rt, id)[1])
+    end
+    (names, providers, ids, costs, tops)
+end
+
+# One roster entry off the wire: a 4-vector (name provider id cost) or a dict carrying those.
+function _roster_entry(m)
+    if m isa AbstractDict
+        id = String(get(m, "model", get(m, "model_id", get(m, "id", ""))))
+        return (String(get(m, "name", id)), String(get(m, "provider", "")), id,
+                Float64(get(m, "cost", 0.0)))
+    elseif m isa AbstractVector && length(m) == 4
+        return (string(m[1]), string(m[2]), string(m[3]), Float64(m[4]))
+    end
+    error("route-decide: roster entry must be (name provider model-id cost) or {model,provider,cost}, got $(m)")
 end
 
 end # module RoutingBrain

--- a/apps/credence-pi/daemon/server.jl
+++ b/apps/credence-pi/daemon/server.jl
@@ -492,14 +492,23 @@ function handle_sensor_event(state::DaemonState,
             event_id = string(get(event_dict, "event_id", ""))
             features === nothing &&
                 error("route-request event $event_id missing required 'features'")
-            choice = route_decide(features)
-            emit_route_signal!(state, event_id, choice)
-            # Remember this turn's routed model so its tool-completed outcomes credit it
-            # (per-session; overwritten next turn). Transport bookkeeping, like pending_contexts.
-            if state.routing !== nothing
-                session_id = string(get(event_dict, "session_id", ""))
-                isempty(session_id) ||
-                    (state.pending_routes[session_id] = (choice["model"], features))
+            # The user's LIVE model roster (roster-aware routing): the body sends the models
+            # OpenClaw actually has + their costs. Absent ⇒ route-decide falls back to the
+            # declared default roster (back-compat with an older body).
+            roster = get(event_dict, "models", nothing)
+            choice = route_decide(features, roster)
+            if choice === nothing
+                # Inert: fewer than 2 candidate models ⇒ nothing to route between. Emit no
+                # signal; the body keeps OpenClaw's model (fail open). No pending-route stash.
+            else
+                emit_route_signal!(state, event_id, choice)
+                # Remember this turn's routed model so its tool-completed outcomes credit it
+                # (per-session; overwritten next turn). Transport bookkeeping, like pending_contexts.
+                if state.routing !== nothing
+                    session_id = string(get(event_dict, "session_id", ""))
+                    isempty(session_id) ||
+                        (state.pending_routes[session_id] = (choice["model"], features))
+                end
             end
         end
 

--- a/apps/credence-pi/openclaw-plugin/README.md
+++ b/apps/credence-pi/openclaw-plugin/README.md
@@ -60,7 +60,7 @@ interception point is an OpenClaw **plugin** `before_tool_call` hook. See
 | `approvalTimeoutMs` | `120000` | how long OpenClaw waits for the user on an `ask` before denying |
 | `redactToolInputs` | `false` | omit tool-call inputs from sensor events (they can carry secrets); ask-preview becomes generic |
 | `shadowMode` | `false` | observe-only: brain decides + daemon logs, body never enforces or overrides the model |
-| `routing` | `false` | enable EU-max **model routing** via `before_model_resolve` (see below) |
+| `routing` | `true` | EU-max **model routing** via `before_model_resolve` — ON by default, roster-aware (see below); set `false` to disable |
 | `silent` | `false` | suppress info/warn logs |
 | `pricing` | — | per-model USD/Mtok overrides: `{ "<model>": { "input": n, "output": n, "cacheRead": n, "cacheWrite": n } }` |
 
@@ -73,54 +73,57 @@ dollars-saved figure for your providers. Unknown/unpriced models log
 `usd: null` (token counts still recorded; the Move-2 surface applies a
 token×price fallback).
 
-## Model routing (opt-in)
+## Model routing (on by default, roster-aware)
 
-With `routing: true` the plugin also registers a `before_model_resolve`
-hook: for each turn it posts a `route-request` (carrying the prompt's
-length feature) to the daemon and applies the brain's chosen model as
-OpenClaw's `modelOverride` / `providerOverride`. The decision is the
-**same EU-max** the governor runs — `argmax_a [ value·P(correct|X) − cost_a ]`
-over the declared roster, through the one canonical `optimise` — so
-credence-pi picks the cheapest model whose expected accuracy justifies it
-under the active profile.
+The plugin registers a `before_model_resolve` hook that routes each turn to the
+EU-max model. It discovers the models OpenClaw actually has — from `api.config`
+(the configured providers, their models, and per-Mtok pricing) — posts a
+`route-request` carrying that **live roster** plus the prompt's length feature,
+and applies the brain's chosen model as OpenClaw's `modelOverride` /
+`providerOverride`. The decision is the **same EU-max** the governor runs —
+`argmax_a [ value·P(correct|X) − cost_a ]` over the live roster, through the one
+canonical `optimise` — so credence-pi picks the cheapest model whose expected
+accuracy justifies it under the active profile.
 
 | brain effector | OpenClaw result |
 |---|---|
 | `route` | `{ modelOverride, providerOverride }` from the chosen model |
-| (timeout / daemon down / no roster) | no override — OpenClaw keeps its configured model (fail open) |
+| (timeout / daemon down / <2 priceable models / undiscoverable roster) | no override — OpenClaw keeps its configured model (fail open) |
 
-**To enable:**
+**On by default; safe by construction.** Routing is enabled unless you set
+`routing: false`. The hook registers only when the plugin discovers **≥2
+priceable models** to choose between, so a single-model install (or one whose
+models can't be priced) is a silent no-op that keeps OpenClaw's model. With equal
+cold priors the EU-max reduces to the **cheapest** model, then learns to escalate
+to a pricier one only where it earns its cost — cost-saving from day one, never
+mis-routing to a hardcoded default. `shadowMode: true` logs the would-route per
+turn without changing the model.
 
-1. The daemon must have a routing roster. The shipped `bdsl/routing.bdsl`
-   declares one (haiku / sonnet / opus) plus `correct-answer-value` in
-   `utility.bdsl` (the per-profile dial: low ⇒ cost-sensitive, high ⇒
-   quality-sensitive). Absent ⇒ routing stays inert and the daemon is
-   governance-only.
-2. Set `routing: true` in the plugin config. The `before_model_resolve`
-   hook is active out of the box on current OpenClaw (like `llm_output`);
-   the plugin registers it defensively, so an older host that lacks it just
-   runs without routing.
-3. `shadowMode: true` logs the would-route per turn without changing the
-   model — use it to see routing decisions on real traffic first.
+**The per-profile dial** lives in `bdsl/utility.bdsl` (`correct-answer-value`: low
+⇒ cost-sensitive, high ⇒ quality-sensitive). The shipped `bdsl/routing.bdsl`
+declares a default haiku/sonnet/opus roster used only as a fallback when a request
+carries no live roster (an older body); the live roster from `api.config` is what
+routing actually uses.
 
-**What the belief is.** The per-model accuracy belief is **warm-seeded from
-measured data** (`brain/routing_brain.counts.json`, distilled from the
-3-frontier-model oracle grid by `eval/train_routing_brain.jl`) so routing is
-calibrated from install, and it **learns online**: each routed turn's
-per-turn outcome — did the proposed call execute cleanly
-(`tool-completed.success`)? — updates the routed model's belief. That signal
-is noisy (a correct call can fail on a flaky tool), so the brain models the
-confound explicitly and learns it (per-context tool-reliability), and a flaky
-tool is absorbed by the reliability latent rather than blamed on the model;
-the belief conditions on the decoded soft correctness through the canonical
-`condition` (mean-exact, so routing's EU is exact). A human approve/reject is
-the gold anchor. Honest limits — per-turn proxy ≠ ground-truth correctness;
-the false-success rate is only weakly identified; run-level / multi-call
-credit assignment stays deferred — are in `eval/results/ROUTING_DOMINANCE.md`.
-The belief is durable (route-outcomes are logged and replayed on restart).
-Only `prompt-length` is conditioned on, because it is the one feature honestly
-extractable from a raw prompt; the structure-BMA collapses it to the marginal
-if it doesn't predict accuracy.
+**What the belief is.** Each model's accuracy belief `P(correct | X)` is its own
+structure-BMA. Models matching the shipped warm seed
+(`brain/routing_brain.counts.json`, distilled from a 3-frontier-model oracle grid)
+are **calibrated from install**; the user's **own** models start from a weak prior
+and **learn online** — each routed turn's per-turn outcome (did the proposed call
+execute cleanly, `tool-completed.success`?) updates the routed model's belief. That
+signal is noisy (a correct call can fail on a flaky tool), so the brain models the
+confound explicitly and learns it (per-context tool-reliability): a flaky tool is
+absorbed by the reliability latent, not blamed on the model. Updates go through the
+canonical `condition` (mean-exact, so routing's EU is exact); a human
+approve/reject is the gold anchor. Per-call **cost** comes from the user's config
+pricing (output-$/Mtok × a shared per-call token scale; a learned per-model
+`E[tokens/call]` is a follow-up). Honest limits — per-turn proxy ≠ ground-truth
+correctness; false-success is weakly identified; run-level credit assignment is
+deferred — are in `eval/results/ROUTING_DOMINANCE.md`. The belief is durable
+(route-outcomes are logged and replayed on restart). Routing currently conditions
+on `prompt-length` (the one feature honestly extractable from a raw prompt); the
+structure-BMA collapses it to the marginal if it doesn't predict accuracy. Richer
+covariates are a follow-up.
 
 ## Develop
 

--- a/apps/credence-pi/openclaw-plugin/package-lock.json
+++ b/apps/credence-pi/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gfrmin/credence-pi-openclaw",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gfrmin/credence-pi-openclaw",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/apps/credence-pi/openclaw-plugin/src/cost.ts
+++ b/apps/credence-pi/openclaw-plugin/src/cost.ts
@@ -25,9 +25,12 @@ export type PriceTable = Record<string, ModelPrice>;
 // the model id. Approximate; override via config `pricing`. Ordered by
 // specificity is not required — we pick the longest matching key.
 export const DEFAULT_PRICES: PriceTable = {
-  "claude-opus": { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  // Anthropic 4.x, verified 2026-06 (platform.claude.com): input / output /
+  // cache-read / 5m-cache-write, USD per million tokens. (The prior table was
+  // stale — opus 15/75 and haiku 0.8/4 were the retired generation.)
+  "claude-opus": { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   "claude-sonnet": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-  "claude-haiku": { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 },
+  "claude-haiku": { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
   "gpt-4o-mini": { input: 0.15, output: 0.6 },
   "gpt-4o": { input: 2.5, output: 10 },
   "gpt-4.1": { input: 2, output: 8 },

--- a/apps/credence-pi/openclaw-plugin/src/index.ts
+++ b/apps/credence-pi/openclaw-plugin/src/index.ts
@@ -32,6 +32,7 @@ import {
 import { FeatureTracker } from "./features.js";
 import { SafetyTracker } from "./safety.js";
 import { extractRoutingFeatures } from "./routing-features.js";
+import { buildRoster, type RoutingModel } from "./roster.js";
 import { buildPriceTable, computeTurnCost, type PriceTable } from "./cost.js";
 import type {
   PluginEntry,
@@ -147,6 +148,9 @@ export interface GovernorOpts {
    *  measure what governance WOULD do on real usage without affecting runs —
    *  the basis for counterfactual telemetry. Default false (enforcing). */
   shadowMode: boolean;
+  /** The user's model roster (discovered from api.config), sent in each route-request so the
+   *  brain routes over the models OpenClaw actually has. Empty ⇒ routing is not registered. */
+  roster: RoutingModel[];
   log: Logger;
 }
 
@@ -173,7 +177,7 @@ export function createGovernor(
   opts: GovernorOpts,
 ): Governor {
   const { hookTimeoutMs, approvalTimeoutMs, priceTable, redactToolInputs,
-    shadowMode, log } = opts;
+    shadowMode, roster, log } = opts;
   const tracker = new FeatureTracker();
   // Safety (multi-outcome): accumulates taint from tool results and emits the taint-flow
   // features the harm posterior conditions on. The daemon ignores them unless harm
@@ -310,6 +314,9 @@ export function createGovernor(
       session_id: ctx.sessionId ?? ctx.sessionKey ?? "",
       timestamp: new Date().toISOString(),
       features,
+      // The user's live model roster (roster-aware routing): the brain routes over THESE
+      // models + their costs, not a hardcoded list. Always ≥2 here (register gates on it).
+      models: roster,
     });
 
     if (!post.ok) {
@@ -416,7 +423,7 @@ const plugin: PluginEntry = {
     const silent = cfg.silent === true;
     const redactToolInputs = cfg.redactToolInputs === true;
     const shadowMode = cfg.shadowMode === true;
-    const routingEnabled = cfg.routing === true;
+    const routingEnabled = cfg.routing !== false; // model routing is ON by default
     const priceTable = buildPriceTable(cfg.pricing);
 
     const log: Logger = (m, e) => {
@@ -424,6 +431,18 @@ const plugin: PluginEntry = {
       const msg = e === undefined ? m : `${m} ${String(e)}`;
       api.logger?.warn?.(msg);
     };
+
+    // Roster-aware routing: discover the user's models (+ costs) from the host config. Guarded —
+    // a missing/odd config yields an empty roster ⇒ routing stays inactive (never mis-routes to
+    // a hardcoded default). The body reads config (IO); the brain stays config-agnostic.
+    let roster: RoutingModel[] = [];
+    try {
+      roster = buildRoster(api.config, priceTable);
+    } catch (err) {
+      log("credence-pi: could not read the model roster from config; routing inactive", err);
+    }
+    // Route only when there are ≥2 priceable models to choose between; else leave OpenClaw's.
+    const routingActive = routingEnabled && roster.length >= 2;
 
     const client = createDaemonClient({
       baseUrl: daemonUrl,
@@ -436,6 +455,7 @@ const plugin: PluginEntry = {
       priceTable,
       redactToolInputs,
       shadowMode,
+      roster,
       log,
     });
     if (shadowMode) log("credence-pi: SHADOW MODE — observing only, never enforcing");
@@ -458,23 +478,31 @@ const plugin: PluginEntry = {
       );
     }
 
-    // Model routing (opt-in). Off by default: it overrides which model runs, needs
-    // hooks.allowConversationAccess:true, and a daemon configured with a routing roster
-    // (bdsl/routing.bdsl). When off we register no hook, so a governance-only install
-    // adds zero per-turn latency. Fails open: daemon down / no roster ⇒ OpenClaw's model.
-    if (routingEnabled) {
+    // Model routing — ON by default, roster-aware. The body discovered the user's models from
+    // config; route only when ≥2 are priceable (else OpenClaw keeps its model — a no-op, so
+    // single-model installs and undiscoverable rosters are unaffected). Set `routing: false` to
+    // disable. Fails open: daemon down / slow ⇒ OpenClaw's model.
+    if (routingActive) {
       try {
         api.on("before_model_resolve", gov.beforeModelResolve, {
           priority: 100,
           timeoutMs: hookTimeoutMs + 1_000,
         });
-        log("credence-pi: model routing ENABLED (before_model_resolve)");
+        log(
+          `credence-pi: model routing ACTIVE over ${roster.length} models ` +
+            `(${roster.map((m) => m.model).join(", ")})`,
+        );
       } catch (err) {
         log(
           "credence-pi: before_model_resolve hook unavailable on this host; routing disabled",
           err,
         );
       }
+    } else if (routingEnabled) {
+      log(
+        `credence-pi: routing enabled but ${roster.length} priceable model(s) discovered ` +
+          `(need ≥2); routing inactive — keeping OpenClaw's model`,
+      );
     }
 
     // Close the SSE stream + drain awaiters on reset/delete/reload so a

--- a/apps/credence-pi/openclaw-plugin/src/openclaw-types.ts
+++ b/apps/credence-pi/openclaw-plugin/src/openclaw-types.ts
@@ -1,10 +1,11 @@
 // openclaw-types.ts — minimal local declarations of the OpenClaw plugin
 // API surface this body consumes.
 //
-// Sourced from OpenClaw (HEAD 36a596aa9f, 2026-06-02):
-//   - src/plugins/types.ts          (OpenClawPluginApi, api.on)
-//   - src/plugins/hook-types.ts     (before_tool_call / after_tool_call /
-//                                     llm_output events + results)
+// Sourced from OpenClaw (HEAD 7019da8c7b, 2026-06-17):
+//   - src/plugins/types.ts                         (OpenClawPluginApi, api.on, api.config)
+//   - src/plugins/hook-types.ts                    (before/after_tool_call, llm_output)
+//   - src/plugins/hook-before-agent-start.types.ts (before_model_resolve event/result)
+//   - src/config/types.models.ts                   (models.providers[*].models[*].cost)
 //
 // We declare ONLY what we consume so the plugin builds standalone with no
 // @openclaw/openclaw dependency — mirroring the dependency-free pattern of
@@ -53,6 +54,8 @@ export interface BeforeToolCallResult {
 // seam credence-pi uses to route by EU-max. Needs hooks.allowConversationAccess:true.
 export interface BeforeModelResolveEvent {
   prompt?: string;
+  /** Attachment metadata (current OpenClaw): kind + mimeType, for future file-aware routing. */
+  attachments?: Array<{ kind?: string; mimeType?: string }>;
 }
 
 export interface BeforeModelResolveResult {
@@ -114,11 +117,35 @@ export interface HookOpts {
   timeoutMs?: number;
 }
 
+// Narrow structural view of the OpenClawConfig slice we read to discover the user's model
+// roster (api.config). We declare ONLY these fields so the plugin stays dependency-free and
+// resilient to config churn; everything else on the real config is ignored.
+export interface OpenClawModelDefinitionSlice {
+  id: string;
+  name?: string;
+  input?: string[]; // supported modalities (text/image/…) — for future file-aware routing
+  cost?: { input?: number; output?: number }; // USD per million tokens
+}
+export interface OpenClawConfigSlice {
+  models?: {
+    providers?: Record<string, { models?: OpenClawModelDefinitionSlice[] }>;
+  };
+  agents?: {
+    // Allow-list of model refs ("provider/id") the agent may use, if configured.
+    defaults?: { models?: Record<string, unknown> };
+  };
+}
+
 export interface OpenClawPluginApi {
   id?: string;
   logger?: PluginLogger;
   // This plugin's resolved config (validated against openclaw.plugin.json).
   pluginConfig?: Record<string, unknown>;
+
+  // The host's resolved OpenClaw config (api-builder.ts attaches it). We read ONLY
+  // `models.providers` (the model catalog + pricing) and `agents.defaults.models` (the
+  // allow-list) to discover the routing roster — see OpenClawConfigSlice.
+  config?: OpenClawConfigSlice;
 
   // Cleanup hooks run on reset/delete/reload paths
   // (OpenClaw src/plugins/host-hooks.ts PluginRuntimeLifecycleRegistration).

--- a/apps/credence-pi/openclaw-plugin/src/roster.ts
+++ b/apps/credence-pi/openclaw-plugin/src/roster.ts
@@ -1,0 +1,102 @@
+// roster.ts — discover the user's MODEL ROSTER from the OpenClaw config and turn it into the
+// per-request routing roster the credence-pi brain routes over.
+//
+// before_model_resolve hands the plugin only the prompt, NOT the candidate models. But
+// register(api) carries api.config (the resolved OpenClawConfig), which lists the configured
+// providers + models + per-Mtok pricing. The BODY reads it (IO is the body's job; the brain
+// stays config-agnostic and just receives the roster as data) and sends the roster in each
+// route-request, so routing is over the user's ACTUAL models — not a hardcoded list.
+//
+// Cost coordinate: the brain's EU is reward·P(correct) − cost, with cost a per-CALL dollar
+// figure. We derive it as output-$/Mtok × NOMINAL_OUTPUT_TOKENS — the same scale the shipped
+// default roster uses (haiku 5×700e-6 = 0.0035, sonnet 0.0105, opus 0.0175). The nominal is a
+// shared weakly-informative per-call token estimate; being shared across models it sets only
+// the overall cost SCALE (calibrated against the profile reward), not the relative ordering.
+// The principled refinement — a learned per-model E[tokens/call] (the tb turns-belief move) —
+// is a follow-up; this is its cold-start.
+
+import type {
+  OpenClawConfigSlice,
+  OpenClawModelDefinitionSlice,
+} from "./openclaw-types.js";
+import type { PriceTable } from "./cost.js";
+
+export interface RoutingModel {
+  name: string;
+  provider: string;
+  model: string; // provider-facing model id
+  cost: number; // per-call USD = output-$/Mtok × NOMINAL_OUTPUT_TOKENS
+}
+
+// Shared per-call output-token estimate that turns output-$/Mtok into a per-call $. Matches
+// the shipped default roster's calibration (bdsl costs == output-$/Mtok × 700).
+export const NOMINAL_OUTPUT_TOKENS = 700;
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Resolve a model's output price (USD per million tokens): prefer the user's OWN configured
+// price, else the plugin price table (built-in defaults + `pricing` overrides), matched the
+// same way cost.ts does (exact id, provider/id ref, then longest family-substring).
+function resolveOutputPricePerM(
+  provider: string,
+  def: OpenClawModelDefinitionSlice,
+  priceTable: PriceTable,
+): number | undefined {
+  if (typeof def.cost?.output === "number") return def.cost.output;
+  const id = def.id.toLowerCase();
+  if (priceTable[id]) return priceTable[id].output;
+  const ref = `${provider}/${def.id}`.toLowerCase();
+  if (priceTable[ref]) return priceTable[ref].output;
+  let best: { key: string; out: number } | undefined;
+  for (const [key, p] of Object.entries(priceTable)) {
+    const re = new RegExp(`(^|[^a-z0-9])${escapeRegExp(key)}`);
+    if (re.test(id) && (best === undefined || key.length > best.key.length)) {
+      best = { key, out: p.output };
+    }
+  }
+  return best?.out;
+}
+
+/**
+ * Build the routing roster from the OpenClaw config. Returns the PRICEABLE models across the
+ * configured providers, narrowed to the agent's allow-list (agents.defaults.models) when one
+ * is configured. Models with no resolvable price are skipped — the brain can't make a
+ * cost-aware EU decision without a cost. The caller routes only when ≥2 remain (else it leaves
+ * OpenClaw's model alone), so an undiscoverable roster degrades to no-op, never mis-routing.
+ */
+export function buildRoster(
+  config: OpenClawConfigSlice | undefined,
+  priceTable: PriceTable,
+): RoutingModel[] {
+  const providers = config?.models?.providers;
+  if (!providers || typeof providers !== "object") return [];
+
+  // Allow-list (model refs "provider/id"); when present, route only among these.
+  const allow = config?.agents?.defaults?.models;
+  const allowSet =
+    allow && typeof allow === "object"
+      ? new Set(Object.keys(allow).map((r) => r.toLowerCase()))
+      : undefined;
+
+  const roster: RoutingModel[] = [];
+  for (const [provider, pc] of Object.entries(providers)) {
+    for (const def of pc?.models ?? []) {
+      if (!def || typeof def.id !== "string") continue;
+      const ref = `${provider}/${def.id}`.toLowerCase();
+      if (allowSet && !allowSet.has(ref) && !allowSet.has(def.id.toLowerCase())) {
+        continue;
+      }
+      const outPerM = resolveOutputPricePerM(provider, def, priceTable);
+      if (outPerM === undefined) continue; // unpriceable ⇒ not routable
+      roster.push({
+        name: def.name ?? def.id,
+        provider,
+        model: def.id,
+        cost: (outPerM / 1_000_000) * NOMINAL_OUTPUT_TOKENS,
+      });
+    }
+  }
+  return roster;
+}

--- a/apps/credence-pi/openclaw-plugin/tests/cost.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/cost.test.ts
@@ -4,14 +4,14 @@ import assert from "node:assert/strict";
 import { computeTurnCost, buildPriceTable } from "../src/cost.js";
 import type { LlmOutputEvent } from "../src/openclaw-types.js";
 
-test("known model reconstructs USD from token counts (opus: 15 in / 75 out per Mtok)", () => {
+test("known model reconstructs USD from token counts (opus: 5 in / 25 out per Mtok)", () => {
   const table = buildPriceTable(undefined);
   const ev: LlmOutputEvent = {
     model: "claude-opus-4-8",
     usage: { input: 1_000_000, output: 1_000_000 },
   };
   const tc = computeTurnCost(ev, table);
-  assert.equal(tc.usd, 90); // 15 + 75
+  assert.equal(tc.usd, 30); // 5 + 25 (verified 2026-06 prices)
   assert.equal(tc.total_tokens, 2_000_000);
   assert.equal(tc.model, "claude-opus-4-8");
 });

--- a/apps/credence-pi/openclaw-plugin/tests/index.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/index.test.ts
@@ -36,6 +36,7 @@ function harness(postOk = true, shadowMode = false) {
     priceTable: buildPriceTable(undefined),
     redactToolInputs: false,
     shadowMode,
+    roster: [],
     log: () => {},
   });
   const find = (t: string) => posted.find((e) => e.event_type === t);
@@ -135,6 +136,7 @@ test("redactToolInputs: tool input omitted from the sensor event", async () => {
     priceTable: buildPriceTable(undefined),
     redactToolInputs: true,
     shadowMode: false,
+    roster: [],
     log: () => {},
   });
   await gov.beforeToolCall(ev("bash", { params: { command: "secret-token-123" } }), ctx);
@@ -181,7 +183,9 @@ test("llm_output: posts turn-cost with reconstructed USD", async () => {
     ctx,
   );
   const t = h.find("turn-cost") as { usd: number; total_tokens: number } | undefined;
-  assert.equal(t?.usd, 90);
+  // opus $5 in + $25 out per Mtok (verified 2026-06): 1M·5 + 1M·25 = $30 (was $90 at the
+  // retired 15/75 pricing — corrected in cost.ts).
+  assert.equal(t?.usd, 30);
   assert.equal(t?.total_tokens, 2_000_000);
   h.gov.cleanup();
 });

--- a/apps/credence-pi/openclaw-plugin/tests/roster.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/roster.test.ts
@@ -1,0 +1,76 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildRoster, NOMINAL_OUTPUT_TOKENS } from "../src/roster.js";
+import { buildPriceTable } from "../src/cost.js";
+import type { OpenClawConfigSlice } from "../src/openclaw-types.js";
+
+const TABLE = buildPriceTable(undefined);
+// per-call cost = output-$/Mtok × NOMINAL_OUTPUT_TOKENS (the shipped default-roster scale)
+const perCall = (outPerM: number) => (outPerM / 1_000_000) * NOMINAL_OUTPUT_TOKENS;
+
+test("buildRoster: reads providers' models + derives per-call cost from config pricing", () => {
+  const cfg: OpenClawConfigSlice = {
+    models: {
+      providers: {
+        anthropic: {
+          models: [
+            { id: "claude-haiku-4-5", name: "haiku", cost: { input: 1, output: 5 } },
+            { id: "claude-opus-4-8", name: "opus", cost: { input: 5, output: 25 } },
+          ],
+        },
+      },
+    },
+  };
+  const roster = buildRoster(cfg, TABLE);
+  assert.equal(roster.length, 2);
+  const haiku = roster.find((m) => m.model === "claude-haiku-4-5")!;
+  assert.equal(haiku.provider, "anthropic");
+  assert.equal(haiku.name, "haiku");
+  assert.equal(haiku.cost, perCall(5)); // own config output price
+  const opus = roster.find((m) => m.model === "claude-opus-4-8")!;
+  assert.equal(opus.cost, perCall(25));
+  // matches the shipped default roster scale exactly (haiku 0.0035, opus 0.0175)
+  assert.ok(Math.abs(haiku.cost - 0.0035) < 1e-9 && Math.abs(opus.cost - 0.0175) < 1e-9);
+});
+
+test("buildRoster: falls back to the price table when config omits per-model cost", () => {
+  const cfg: OpenClawConfigSlice = {
+    models: { providers: { anthropic: { models: [{ id: "claude-sonnet-4-6" }] } } },
+  };
+  const roster = buildRoster(cfg, TABLE);
+  assert.equal(roster.length, 1);
+  assert.equal(roster[0].cost, perCall(15)); // sonnet output 15 from the price table
+});
+
+test("buildRoster: the agent allow-list narrows the roster", () => {
+  const cfg: OpenClawConfigSlice = {
+    models: {
+      providers: {
+        anthropic: {
+          models: [
+            { id: "claude-haiku-4-5", cost: { input: 1, output: 5 } },
+            { id: "claude-opus-4-8", cost: { input: 5, output: 25 } },
+          ],
+        },
+      },
+    },
+    agents: { defaults: { models: { "anthropic/claude-haiku-4-5": {} } } },
+  };
+  const roster = buildRoster(cfg, TABLE);
+  assert.equal(roster.length, 1);
+  assert.equal(roster[0].model, "claude-haiku-4-5");
+});
+
+test("buildRoster: unpriceable models are skipped (no cost-aware EU without a cost)", () => {
+  const cfg: OpenClawConfigSlice = {
+    models: { providers: { custom: { models: [{ id: "totally-unknown-model" }] } } },
+  };
+  assert.equal(buildRoster(cfg, TABLE).length, 0);
+});
+
+test("buildRoster: missing/empty config → empty roster (routing stays inactive)", () => {
+  assert.deepEqual(buildRoster(undefined, TABLE), []);
+  assert.deepEqual(buildRoster({}, TABLE), []);
+  assert.deepEqual(buildRoster({ models: { providers: {} } }, TABLE), []);
+});

--- a/apps/credence-pi/tests/julia/test_routing.jl
+++ b/apps/credence-pi/tests/julia/test_routing.jl
@@ -149,6 +149,55 @@ let env = routing_env(reward = 1.0)
     ok("escalation_next gate ≡ reward·E[θ|X] ≥ cost (boundary exact, via optimise)")
 end
 
+# ── A''. Roster-aware routing: the LIVE roster (the user's actual models) ────────
+# route-decide takes an optional per-request roster — the models OpenClaw actually has +
+# their costs. Known models reuse the warm belief; the user's OWN (unknown) models get a
+# cold prior + online learning; fewer than 2 candidates ⇒ inert (keep OpenClaw's model).
+# This is what makes routing safe to turn ON by default for any roster.
+
+# Known models in a live roster reuse the WARM belief: at equal cost, quality-hawk picks the
+# best-believed (opus) — the warm seed is used, not ignored, for a roster sent per request.
+let env = routing_env(reward = 1.0)
+    wire_routing!(env); decide = env[Symbol("route-decide")]
+    roster = [["haiku", "anthropic", "claude-haiku-4-5", 0.001],
+              ["opus",  "anthropic", "claude-opus-4-8",  0.001]]
+    @assert decide(Dict("prompt-length" => "short"), roster)["model"] == "claude-opus-4-8"
+    ok("roster-aware: known models in a live roster reuse the warm belief (quality-hawk → opus)")
+end
+
+# The user's OWN models (unknown to the warm seed) get a COLD prior (θ=0.5 each) ⇒ EU-max
+# reduces to CHEAPEST — the safe cost-saving default for an unseen roster — then learns up.
+let env = routing_env()   # cost-hawk reward 0.02
+    wire_routing!(env); decide = env[Symbol("route-decide")]
+    c1 = decide(Dict("prompt-length" => "short"),
+                [["cheapo", "x", "cheapo-1", 0.001], ["premium", "y", "premium-1", 0.5]])
+    @assert c1["model"] == "cheapo-1" && c1["provider"] == "x"
+    c2 = decide(Dict("prompt-length" => "short"),   # flip the costs ⇒ the other model
+                [["cheapo", "x", "cheapo-1", 0.5], ["premium", "y", "premium-1", 0.001]])
+    @assert c2["model"] == "premium-1"
+    ok("roster-aware: unknown models get a cold prior ⇒ EU-max picks the cheapest (cost-saving default)")
+end
+
+# Inert: a single-model roster has nothing to route between ⇒ route-decide returns nothing
+# (the body keeps OpenClaw's model). An EMPTY roster falls back to the declared default (≥2).
+let env = routing_env()
+    decide = (wire_routing!(env); env[Symbol("route-decide")])
+    @assert decide(Dict("prompt-length" => "short"), [["solo", "x", "solo-1", 0.01]]) === nothing
+    @assert decide(Dict("prompt-length" => "short"), Any[]) !== nothing
+    ok("roster-aware: <2 candidate models ⇒ route-decide is inert (returns nothing)")
+end
+
+# The user's own model LEARNS online and persists in extra_tops (keyed by id), exactly like a
+# default-roster model — so an unknown roster gets calibrated by real traffic over time.
+let rt = wire_routing!(routing_env())
+    @assert !haskey(rt.extra_tops, "mymodel-1")
+    for _ in 1:30; route_outcome!(rt, "mymodel-1", Dict("prompt-length" => "short"), true); end
+    @assert haskey(rt.extra_tops, "mymodel-1")
+    after = posterior_accuracy(rt.model, rt.extra_tops["mymodel-1"], ["short"])
+    @assert after > 0.5    # cold prior mean 0.5, raised by clean successes
+    ok("roster-aware: an unknown model learns online + persists in extra_tops (θ → $(round(after, digits = 3)))")
+end
+
 # ── B. Daemon transport: route-request → route signal ───────────────────
 
 include(joinpath(@__DIR__, "..", "..", "daemon", "server.jl"))
@@ -195,6 +244,30 @@ let path = tempname() * ".jsonl"
         "features" => Dict("prompt-length" => "short")))
     @assert isempty(snapshot(state.signal_queue))
     ok("route-request with routing unconfigured emits no signal (body fails open)")
+    rm(path; force = true)
+end
+
+# Roster-aware via the daemon: a route-request carrying the user's live `models` routes over
+# THAT roster (the user's own models, unknown to the warm seed), and a single-model roster is
+# inert (no signal). This is the on-by-default safety path end-to-end through the transport.
+let path = tempname() * ".jsonl"
+    state = init_state(; bdsl_dir = DAEMON_BDSL, log_path = path)
+    handle_sensor_event(state, Dict{String, Any}(
+        "event_type" => "route-request", "event_id" => "rr_dyn", "session_id" => "Sx",
+        "features" => Dict("prompt-length" => "short"),
+        "models" => Any[Dict("name" => "a", "provider" => "p", "model" => "my-cheap", "cost" => 0.001),
+                        Dict("name" => "b", "provider" => "p", "model" => "my-dear",  "cost" => 0.5)]))
+    sigs = snapshot(state.signal_queue)
+    @assert length(sigs) == 1 && sigs[1]["parameters"]["model"] == "my-cheap"
+    ok("daemon roster-aware: route-request with a live `models` roster routes the user's own models (cost-hawk → cheapest)")
+
+    state2 = init_state(; bdsl_dir = DAEMON_BDSL, log_path = tempname() * ".jsonl")
+    handle_sensor_event(state2, Dict{String, Any}(
+        "event_type" => "route-request", "event_id" => "rr_solo",
+        "features" => Dict("prompt-length" => "short"),
+        "models" => Any[Dict("name" => "a", "provider" => "p", "model" => "only-one", "cost" => 0.01)]))
+    @assert isempty(snapshot(state2.signal_queue))
+    ok("daemon roster-aware: single-model roster ⇒ no route signal (inert, fail open)")
     rm(path; force = true)
 end
 


### PR DESCRIPTION
## What

Model routing now routes over the **user's actual models** (not a hardcoded haiku/sonnet/opus list) and is **ON by default** — the groundwork for credence-pi to reduce OpenClaw cost out of the box.

## Why

Routing was hardcoded to a 3-model Anthropic roster, warm-seeded for exactly those models, and opt-in. To turn it on by default safely it has to adapt to whatever models a user actually has (GPT, ollama, a different Anthropic mix).

## How (brain / body split preserved)

- **Daemon (brain)** `e80cffd`: `RoutingState` gains `extra_tops::Dict{model_id => belief}` for the user's own models — cold prior on first sight, learned online via the same `condition` path. `route-decide` takes an optional **live roster** (models + costs, per request): known models reuse the warm belief, unknown ones the cold/learned one; returns inert for <2 candidates. `route_outcome!` no longer errors on an unknown model. The brain stays config-agnostic.
- **Body (plugin)** `eee9179`: discovers the roster from `api.config` (`buildRoster`), sends it in each `route-request`, and registers `before_model_resolve` only when ≥2 priceable models exist. Routing default-on (`routing: false` to disable). Per-call cost from config pricing × the calibrated scale.
- **API resync** `bfdae5d`: the plugin's OpenClaw API view was 3567 commits stale; resynced the parts we use (`api.config`, `attachments`), and fixed stale `DEFAULT_PRICES` (opus 15/75 → 5/25, etc.).
- **Docs** `a6c42b5`: README updated to on-by-default + roster-aware (was contradicting the code).

## Safety / why on-by-default is OK

- `<2` priceable models, or an undiscoverable roster ⇒ **silent no-op** (OpenClaw keeps its model). Single-model installs unaffected.
- With equal cold priors EU-max reduces to the **cheapest** model, then learns to escalate only where a pricier one earns its cost — cost-saving from day one, never mis-routing to a default.
- Fail-open everywhere (daemon down/slow ⇒ OpenClaw's model).

## Tests

- Julia routing: **30/30** (+6 roster-aware: known→warm, unknown→cold/cheapest, inert<2, unknown learns+persists, daemon dynamic roster, daemon single-model inert). Brain pragma-free, lint clean.
- Plugin: **46/46** (+6 `buildRoster`), typecheck clean.

## Follow-ups (tracked, not in this PR)

Install-UX pass (turn-key quickstart), routing covariates, calibration eval, and migrating the plugin off the deprecated `api.on` to `registerHook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)