### PR TITLE
credence-pi: turn-key install (Compose + restart-resilient daemon, routing-on docs)

### DIFF
--- a/apps/credence-pi/README.md
+++ b/apps/credence-pi/README.md
@@ -26,13 +26,21 @@ not negotiable.
 ## Install
 
 ```bash
-# the brain
-docker run -p 8787:8787 -v ~/.credence-pi:/root/.credence-pi ghcr.io/gfrmin/credence-pi-daemon
+# the brain (Bayesian daemon) — detached, restart-resilient, state in ~/.credence-pi
+docker run -d --name credence-pi --restart unless-stopped \
+  -p 127.0.0.1:8787:8787 -v ~/.credence-pi:/root/.credence-pi \
+  ghcr.io/gfrmin/credence-pi-daemon
 
-# the body
+# the body (OpenClaw plugin) — governance + EU-max model routing, both ON by default
 openclaw plugins install @gfrmin/credence-pi-openclaw
 openclaw plugins enable credence-pi
 ```
+
+That's it. **Model routing is on by default**: credence-pi auto-discovers your
+configured models and routes each turn to the cheapest one whose expected accuracy
+justifies its cost — no config, and it learns from your traffic (`routing: false`
+to disable; a single-model setup is a no-op). Prefer Compose? `docker compose -f
+apps/credence-pi/docker-compose.yml up -d` runs the same daemon.
 
 ## See it work (no agent, no data needed)
 

--- a/apps/credence-pi/daemon/README.md
+++ b/apps/credence-pi/daemon/README.md
@@ -26,8 +26,13 @@ expects `Credence` already loaded in `Main` — it is `include`d by
 `main.jl`, the tests, and the demo, not run directly.) Or run the
 published image:
 
-    docker run -p 8787:8787 -v ~/.credence-pi:/root/.credence-pi \
+    docker run -d --name credence-pi --restart unless-stopped \
+      -p 127.0.0.1:8787:8787 -v ~/.credence-pi:/root/.credence-pi \
       ghcr.io/gfrmin/credence-pi-daemon
+
+Or via Compose (same daemon, restart-resilient across reboots):
+
+    docker compose -f apps/credence-pi/docker-compose.yml up -d
 
 Default bind is `127.0.0.1:8787`. Override via environment:
 `CREDENCE_PI_HOST`, `CREDENCE_PI_PORT`, `CREDENCE_PI_BDSL_DIR`,

--- a/apps/credence-pi/docker-compose.yml
+++ b/apps/credence-pi/docker-compose.yml
@@ -1,0 +1,20 @@
+# credence-pi daemon — the Bayesian brain.
+#
+#     docker compose -f apps/credence-pi/docker-compose.yml up -d
+#
+# Brings up the daemon and keeps it up across reboots (restart: unless-stopped). The body
+# (the OpenClaw plugin) talks to it on 127.0.0.1:8787. State — the learned beliefs + the
+# append-only observation log — persists in ~/.credence-pi on the host (inspectable; ${HOME}
+# is expanded by Compose). Bound to loopback only: the brain is local to your machine.
+#
+# Model routing + governance are ON by default once the plugin is installed; no daemon config
+# needed. See apps/credence-pi/openclaw-plugin/README.md.
+services:
+  credence-pi:
+    image: ghcr.io/gfrmin/credence-pi-daemon
+    container_name: credence-pi
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8787:8787"
+    volumes:
+      - ${HOME}/.credence-pi:/root/.credence-pi

--- a/apps/credence-pi/openclaw-plugin/README.md
+++ b/apps/credence-pi/openclaw-plugin/README.md
@@ -32,11 +32,11 @@ interception point is an OpenClaw **plugin** `before_tool_call` hook. See
 
 ## Install (operator)
 
-1. Start the brain daemon — it listens on `http://127.0.0.1:8787`. Either run
-   the published image
-   (`docker run -p 8787:8787 -v ~/.credence-pi:/root/.credence-pi ghcr.io/gfrmin/credence-pi-daemon`)
-   or run it from source
-   (`julia --project=<repo-root> apps/credence-pi/daemon/main.jl`).
+1. Start the brain daemon — it listens on `http://127.0.0.1:8787`. Detached +
+   restart-resilient: `docker run -d --name credence-pi --restart unless-stopped -p
+   127.0.0.1:8787:8787 -v ~/.credence-pi:/root/.credence-pi ghcr.io/gfrmin/credence-pi-daemon`
+   (or `docker compose -f ../docker-compose.yml up -d`, or from source:
+   `julia --project=<repo-root> apps/credence-pi/daemon/main.jl`).
    See `apps/credence-pi/daemon/README.md`.
 2. Build the plugin: `cd apps/credence-pi/openclaw-plugin && npm install && npm run build`.
 3. Install it into OpenClaw. From a published registry:


### PR DESCRIPTION
## What

Workstream 1 (install/use) — make credence-pi turn-key for OpenClaw users and align the docs with routing-on-by-default (landed in #123).

- **`docker-compose.yml`** — `docker compose up -d`: `restart: unless-stopped`, loopback-bound (`127.0.0.1:8787`), state bind-mounted to `~/.credence-pi` (inspectable). Survives reboots; the bare foreground `docker run` did not.
- **Main README install** — detached + `--restart unless-stopped` daemon one-liner, and an explicit *"model routing is ON by default — auto-discovers your models, routes to the cheapest one worth it, no config, learns from traffic"* note (single-model = no-op; `routing: false` to disable).
- **daemon + plugin READMEs** — the restart-resilient run + the Compose alternative.

Docs + compose only; no code change. Compose validated (`docker compose config: OK`).

## Follow-ups (tracked)

Routing covariates, calibration eval, and the `api.on` → `registerHook` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)