### PR TITLE
answer-brain: the principled RAG agent on pi-mono (Moves 1–4)

### DIFF
--- a/apps/answer-brain/README.md
+++ b/apps/answer-brain/README.md
@@ -36,9 +36,24 @@ Landed (`docs/answer-brain/move-2-design.md`): a **stateless** HTTP surface over
   wire), `terminal_decide` behaviour preserved (Stage-1 regression green).
 - the parity boundary's Python side is `life-agent`'s `bridge/observations.py` (separate repo).
 
-Deferred to Stage 2b (Move 3, body-coupled): the `life-agent` bridge HTTP service
-(`retrieve`/`extract`/`probe_*` over the live corpus) and `extension/*` (the pi-mono TS body + the
-minimal answering app), then the end-to-end eval + gate.
+## Status — Move 3 (the capability bridge)
+
+Landed (`docs/answer-brain/move-3-design.md`, in the **life-agent** repo): a **stateless**
+JSON-over-HTTP service (`life_agent/bridge/server.py`) — the second backend the body drives,
+beside the daemon's `/decide`.
+
+- `POST /route /retrieve /extract /probe/{recency,subject,authority,corroborate}`, `GET /utility
+  /ready` — each a thin wrapper of an existing tested read. The bridge gathers + shapes evidence;
+  the daemon decides. It holds no posterior and no per-question state; the owner profile + utility
+  are read server-side (loopback-bound), never over the wire.
+- `/extract` returns exactly `to_abstract_observations`'s output, so its `{candidates,
+  observations, rho}` + the body's `u_bar` (`GET /utility`) compose directly into `POST /decide`.
+- Hermetic contract tests + one opt-in live round-trip (`retrieve → extract → probe → extract`);
+  the retrieval seam was promoted to `life_agent/core/retrieval.py` (the bridge reuses it, no
+  src↛scripts import).
+
+Deferred to **Move 4** (body-coupled): `extension/*` (the pi-mono TS body + the minimal answering
+app), then the end-to-end eval + gate, and with it the model-choice-under-PII resolution.
 
 ## Test
 

--- a/apps/answer-brain/README.md
+++ b/apps/answer-brain/README.md
@@ -24,8 +24,21 @@ against it.
 - `daemon/observation_log.jl` — append-only JSONL + deterministic replay.
 - `daemon/main.jl` — load-and-ready skeleton.
 
-Deferred to Stage 2 (body-coupled): `daemon/server.jl` (HTTP/SSE sensor→effector loop) and
-`extension/*` (the pi-mono TS body), whose event schema the body defines.
+## Status — Stage 2a (the decision wire)
+
+Landed (`docs/answer-brain/move-2-design.md`): a **stateless** HTTP surface over the Stage-1 brain.
+
+- `daemon/server.jl` — `POST /decide` (`observations + candidates + rho + u_bar → effector +
+  report_index + value + credences + p_none + eu`) + `GET /ready`. Request/response, not SSE — the
+  decision is synchronous (move-2 §5 Q2). Rebuilds the posterior per call, so no per-question state.
+  Wire parity proven against `stage0_parity.json` (`tests/julia/test_server.jl`, 48 checks).
+- `brain/answer_brain.jl` — adds `decide_full` (returns the report index `optimise` chose, for the
+  wire), `terminal_decide` behaviour preserved (Stage-1 regression green).
+- the parity boundary's Python side is `life-agent`'s `bridge/observations.py` (separate repo).
+
+Deferred to Stage 2b (Move 3, body-coupled): the `life-agent` bridge HTTP service
+(`retrieve`/`extract`/`probe_*` over the live corpus) and `extension/*` (the pi-mono TS body + the
+minimal answering app), then the end-to-end eval + gate.
 
 ## Test
 

--- a/apps/answer-brain/README.md
+++ b/apps/answer-brain/README.md
@@ -1,0 +1,40 @@
+# answer-brain
+
+A credence "brain" that governs **answering** the way `credence-pi` governs tool-call safety.
+Sibling app to `credence-pi`; the durable plan is `docs/answer-brain/master-plan.md`, the
+current move is `docs/answer-brain/move-1-design.md`.
+
+Belief: a `CategoricalMeasure` over K candidate values + an explicit NONE atom. The brain
+holds this posterior, conditions it on grounded observations (tempered noisy-channel kernels),
+and chooses a terminal effector (answer / ask-user / abstain) by EU under the owner's utility
+posterior Ū — pricing the forward `gather` steer by `net_voi`. It reuses `life-agent`'s
+retrieval/extraction/probes (it never derives); same Credence primitives the skin evaluates,
+now held statefully and decided natively.
+
+## Status — Stage 1 (the brain daemon)
+
+Landed: the native port of `life-agent`'s validated Stage-0 decision core, parity-tested
+against it.
+
+- `brain/answer_brain.jl` — the posterior (`candidate_posterior`), the terminal EU decide
+  (`terminal_decide`, K `report_j` actions + hedge/ask/abstain, argmax via `optimise`), and
+  the `net_voi`-priced gather/ask gate (`voi_gather`).
+- `bdsl/{capabilities,utility,features}.bdsl` — the effector manifest, the operator-set
+  channel priors (the brain's `CANONICAL_CHANNEL` mirrors them), the candidate-set features.
+- `daemon/observation_log.jl` — append-only JSONL + deterministic replay.
+- `daemon/main.jl` — load-and-ready skeleton.
+
+Deferred to Stage 2 (body-coupled): `daemon/server.jl` (HTTP/SSE sensor→effector loop) and
+`extension/*` (the pi-mono TS body), whose event schema the body defines.
+
+## Test
+
+```
+julia --project=. apps/answer-brain/tests/julia/test_answer_brain.jl
+```
+
+Asserts, on `tests/fixtures/stage0_parity.json` (life-agent `c1a781f`): the native brain
+reproduces Stage-0's posterior weights, chosen effector, and EU to `atol=1e-9` across 10 cases
+(ancestry/model tempering, the subject/time covariates, every terminal action as a winner);
+the `net_voi` gate prices a perfect probe above a useless one; and observation-log replay
+reconstructs the posterior exactly.

--- a/apps/answer-brain/app/README.md
+++ b/apps/answer-brain/app/README.md
@@ -1,0 +1,37 @@
+# answer-brain demo app
+
+A minimal pi-mono agent, driven by a local **Ollama** model, that answers the owner's
+point-fact questions through the answer-brain body. **This is the demo, not the gate** —
+the gate (`life-agent/scripts/answer_brain_gate.py`) certifies the decision math
+deterministically; this *shows* the govern+steer loop end-to-end with a real LLM driving
+the tools and the brain governing the answer. Its result is reported, not assumed.
+
+Everything runs on-machine (the corpus is the owner's real PII — no cloud model).
+
+## check.ts — deterministic, no Ollama
+
+Proves the app↔daemon plumbing: loads the extension against the live daemon, fetches
+`GET /manifest`, and verifies the body implements it + registers its tools.
+
+```bash
+npm install
+# daemon up on :8799 (julia --project=$HOME/git/credence apps/answer-brain/daemon/main.jl)
+npm run check
+```
+
+## main.ts — the full agent (opt-in)
+
+```bash
+# 1. daemon:  julia --project=$HOME/git/credence $HOME/git/credence/apps/answer-brain/daemon/main.jl
+# 2. bridge:  from a life-agent checkout WITH bridge era_split (branch bridge-era-split):
+#             uv run python -m life_agent.bridge.server
+# 3. Ollama:  the model pulled (default qwen2.5:7b-instruct)
+npm run ask -- "what is my mobile phone number?"
+```
+
+The agent calls `retrieve_documents → extract_candidates → answer`; on `answer` the brain
+posts the accumulated evidence to `/decide` and either lets the answer through (rewritten to
+the evidence-backed value), steers a recency gather (re-extract, re-decide), or withholds.
+
+Env: `ANSWER_BRAIN_DAEMON_URL` (:8799), `LIFE_AGENT_BRIDGE_URL` (:8798),
+`ANSWER_BRAIN_MODEL` (qwen2.5:7b-instruct), `OLLAMA_BASE_URL` (http://localhost:11434/v1).

--- a/apps/answer-brain/app/check.ts
+++ b/apps/answer-brain/app/check.ts
@@ -1,0 +1,49 @@
+/**
+ * check.ts — a deterministic wiring check, no Ollama, no bridge needed. Loads the
+ * answer-brain extension against the LIVE daemon (GET /manifest), and asserts the
+ * body verifies the manifest + registers its tools + the governor. This is the
+ * runnable, model-free half of the demo: it proves the app↔daemon plumbing and the
+ * fetch-manifest-and-verify path against the real daemon.
+ *
+ * Run (daemon up on :8799):  npx tsx check.ts
+ */
+
+import {
+	createAnswerBrainExtension,
+	type PiLike,
+	type PiToolDefinition,
+	type ToolCallHandler,
+} from "answer-brain-extension";
+
+const DAEMON_URL = process.env.ANSWER_BRAIN_DAEMON_URL ?? "http://127.0.0.1:8799";
+const EXPECTED_TOOLS = ["answer", "extract_candidates", "retrieve_documents"];
+
+async function main(): Promise<void> {
+	const tools = new Map<string, PiToolDefinition>();
+	let handler: ToolCallHandler | undefined;
+	const pi: PiLike = {
+		registerTool: (t) => void tools.set(t.name, t),
+		on: (_e, h) => void (handler = h),
+	};
+
+	await createAnswerBrainExtension(pi, {
+		daemonUrl: DAEMON_URL,
+		log: (m) => console.log(`  [answer-brain] ${m}`),
+	});
+
+	const names = [...tools.keys()].sort();
+	const toolsOk = EXPECTED_TOOLS.every((n) => tools.has(n));
+	const governorOk = handler !== undefined;
+	console.log(`daemon:    ${DAEMON_URL}`);
+	console.log(`tools:     ${names.join(", ")}`);
+	console.log(`governor:  ${governorOk ? "registered (tool_call)" : "MISSING"}`);
+	const ok = toolsOk && governorOk;
+	console.log(ok ? "\nOK — extension loaded + manifest verified against the live daemon." : "\nFAIL");
+	process.exit(ok ? 0 : 1);
+}
+
+main().catch((err: unknown) => {
+	console.error(`check failed: ${String(err)}`);
+	console.error("(is the daemon up?  julia --project=$HOME/git/credence apps/answer-brain/daemon/main.jl)");
+	process.exit(1);
+});

--- a/apps/answer-brain/app/main.ts
+++ b/apps/answer-brain/app/main.ts
@@ -1,0 +1,127 @@
+/**
+ * answer-brain demo app — a minimal pi-mono agent driven by a local Ollama model,
+ * answering the owner's point-fact questions through the answer-brain body
+ * (move-4-design §2E). THIS IS THE DEMO, NOT THE GATE: the gate
+ * (life-agent/scripts/answer_brain_gate.py) certifies the decision math
+ * deterministically; here a real LLM drives the tools and the brain governs the
+ * answer, to *show* the govern+steer loop end-to-end. Its result is reported, not
+ * assumed (the LLM is nondeterministic).
+ *
+ * Prereqs (all on-machine; the corpus is the owner's real PII, so no cloud model):
+ *   1. the daemon:  julia --project=$HOME/git/credence $HOME/git/credence/apps/answer-brain/daemon/main.jl
+ *   2. the bridge:  (from a checkout with bridge `era_split`) python -m life_agent.bridge.server
+ *   3. Ollama with the model pulled (default qwen2.5:7b-instruct).
+ *
+ * Run:  npx tsx main.ts "what is my mobile phone number?"
+ */
+
+import { getModel as _getModel } from "@earendil-works/pi-ai";
+import {
+	AuthStorage,
+	createAgentSession,
+	DefaultResourceLoader,
+	type ExtensionAPI,
+	getAgentDir,
+	ModelRegistry,
+	SessionManager,
+} from "@earendil-works/pi-coding-agent";
+
+import { createAnswerBrainExtension, type PiLike } from "answer-brain-extension";
+
+void _getModel; // (kept for reference; we register a local provider below)
+
+const DAEMON_URL = process.env.ANSWER_BRAIN_DAEMON_URL ?? "http://127.0.0.1:8799";
+const BRIDGE_URL = process.env.LIFE_AGENT_BRIDGE_URL ?? "http://127.0.0.1:8798";
+const MODEL_ID = process.env.ANSWER_BRAIN_MODEL ?? "qwen2.5:7b-instruct";
+const OLLAMA_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434/v1";
+
+const SYSTEM_PROMPT = `You are the owner's personal answer agent. For ANY question that asks for a
+specific fact about the owner or their documents (a number, ID, date, name, address, amount, status),
+you MUST use the tools — never answer from memory:
+  1. retrieve_documents(question)  — pass the user's question verbatim
+  2. extract_candidates()
+  3. answer(value)                 — your best value
+The answer brain governs the answer tool: it may rewrite your value to the evidence-backed one, send
+you back to gather more evidence, or withhold if the evidence is too uncertain. Trust its decision and
+relay it. After the answer tool returns, state the final answer to the owner in one sentence.`;
+
+// Adapt the real ExtensionAPI to the body's minimal PiLike. The casts bridge the
+// (wider) real tool/handler types to the body's subset; structurally compatible at runtime.
+function adaptPi(pi: ExtensionAPI): PiLike {
+	return {
+		registerTool: (tool) => pi.registerTool(tool as never),
+		on: (event, handler) => pi.on(event, handler as never),
+	};
+}
+
+async function main(): Promise<void> {
+	const question = process.argv.slice(2).join(" ").trim() || "What is my mobile phone number?";
+
+	const authStorage = AuthStorage.create();
+	const modelRegistry = ModelRegistry.create(authStorage);
+	// Register the local Ollama model (OpenAI-compatible). The apiKey is a dummy Ollama ignores.
+	modelRegistry.registerProvider("ollama", {
+		baseUrl: OLLAMA_URL,
+		apiKey: "ollama",
+		api: "openai-completions",
+		models: [
+			{
+				id: MODEL_ID,
+				name: `${MODEL_ID} (Ollama)`,
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 32768,
+				maxTokens: 4096,
+			},
+		],
+	});
+	const model = modelRegistry.find("ollama", MODEL_ID);
+	if (!model) throw new Error(`model ollama/${MODEL_ID} not registered`);
+
+	const resourceLoader = new DefaultResourceLoader({
+		cwd: process.cwd(),
+		agentDir: getAgentDir(),
+		systemPromptOverride: () => SYSTEM_PROMPT,
+		appendSystemPromptOverride: () => [],
+		extensionFactories: [
+			async (pi) => {
+				await createAnswerBrainExtension(adaptPi(pi), {
+					daemonUrl: DAEMON_URL,
+					bridgeUrl: BRIDGE_URL,
+					log: (m) => console.error(`  [answer-brain] ${m}`),
+				});
+			},
+		],
+	});
+	await resourceLoader.reload();
+
+	const { session } = await createAgentSession({
+		model,
+		authStorage,
+		modelRegistry,
+		resourceLoader,
+		sessionManager: SessionManager.inMemory(),
+		// Leave only the answer-brain tools active (no built-in read/bash/edit/write).
+		noTools: "builtin",
+		thinkingLevel: "off",
+	});
+
+	console.error(`Q: ${question}\n`);
+	try {
+		session.subscribe((event) => {
+			if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+				process.stdout.write(event.assistantMessageEvent.delta);
+			}
+		});
+		await session.prompt(question);
+		console.log();
+	} finally {
+		session.dispose();
+	}
+}
+
+main().catch((err: unknown) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/apps/answer-brain/app/package-lock.json
+++ b/apps/answer-brain/app/package-lock.json
@@ -1,0 +1,3687 @@
+{
+  "name": "answer-brain-app",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "answer-brain-app",
+      "version": "0.1.0",
+      "dependencies": {
+        "@earendil-works/pi-ai": "0.79.6",
+        "@earendil-works/pi-coding-agent": "0.79.6",
+        "answer-brain-extension": "file:../extension"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "../extension": {
+      "name": "answer-brain-extension",
+      "version": "0.1.0",
+      "dependencies": {
+        "@credence/brain-body": "file:../../../packages/brain-body",
+        "typebox": "1.1.38"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.22.tgz",
+      "integrity": "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.30",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.48.tgz",
+      "integrity": "sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.50.tgz",
+      "integrity": "sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
+      "integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.55.tgz",
+      "integrity": "sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-env": "^3.972.48",
+        "@aws-sdk/credential-provider-http": "^3.972.50",
+        "@aws-sdk/credential-provider-login": "^3.972.54",
+        "@aws-sdk/credential-provider-process": "^3.972.48",
+        "@aws-sdk/credential-provider-sso": "^3.972.54",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.54.tgz",
+      "integrity": "sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.57.tgz",
+      "integrity": "sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.48",
+        "@aws-sdk/credential-provider-http": "^3.972.50",
+        "@aws-sdk/credential-provider-ini": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.48",
+        "@aws-sdk/credential-provider-sso": "^3.972.54",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.48.tgz",
+      "integrity": "sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.54.tgz",
+      "integrity": "sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/token-providers": "3.1071.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1071.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1071.0.tgz",
+      "integrity": "sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.54.tgz",
+      "integrity": "sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.22.tgz",
+      "integrity": "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.18.tgz",
+      "integrity": "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.30.tgz",
+      "integrity": "sha512-kH6N4f/Fzi9r/dYap8EQ+Zk4NOz8pl4AtWKhzAoG2C1/4YkIHok9APp/e+75woreWQq264n+LkrJsJVZ0Q+M1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+      "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
+      "integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
+      "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.79.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.6.tgz",
+      "integrity": "sha512-KGepEdgEeWDs7Imwlp96tBsO8TjSIpcDBvazsCDtHRa81+uwJI/YGetTegI52pMlKhVpJFLIGajRi4PCGC5MUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.79.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.6.tgz",
+      "integrity": "sha512-xPQDoA3+4Q8UsInST8OGFHPHyi7JQIbx51ku5kf2VuhXrrTv/npjVTXYD3A3D5xs6QRebV0B2mQqHfXaxQAplw==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.79.6",
+        "@earendil-works/pi-ai": "^0.79.6",
+        "@earendil-works/pi-tui": "^0.79.6",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.1.38",
+        "undici": "8.3.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.79.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.6.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.79.6",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.79.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.6.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.79.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.6.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
+      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.1.tgz",
+      "integrity": "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.1.tgz",
+      "integrity": "sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.1.tgz",
+      "integrity": "sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.1.tgz",
+      "integrity": "sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/answer-brain-extension": {
+      "resolved": "../extension",
+      "link": true
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/apps/answer-brain/app/package.json
+++ b/apps/answer-brain/app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "answer-brain-app",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Minimal pi-mono demo app: a local-Ollama agent answering through the answer-brain body. The demo, not the gate.",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "check": "node --import tsx check.ts",
+    "ask": "node --import tsx main.ts"
+  },
+  "dependencies": {
+    "@earendil-works/pi-ai": "0.79.6",
+    "@earendil-works/pi-coding-agent": "0.79.6",
+    "answer-brain-extension": "file:../extension"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/apps/answer-brain/app/tsconfig.json
+++ b/apps/answer-brain/app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": [
+    "*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/apps/answer-brain/bdsl/capabilities.bdsl
+++ b/apps/answer-brain/bdsl/capabilities.bdsl
@@ -37,6 +37,7 @@
       (parameters (reason string)))
 
     ; --- gather: steer the body to fetch more evidence on a candidate ---
-    ;   target (string) — the candidate value to corroborate (the net_voi pick)
+    ;   probe  (string) — which probe to run (e.g. "recency"); the net_voi pick
+    ;   target (string) — the candidate value to corroborate
     (effector gather
-      (parameters (target string)))))
+      (parameters (probe string) (target string)))))

--- a/apps/answer-brain/bdsl/capabilities.bdsl
+++ b/apps/answer-brain/bdsl/capabilities.bdsl
@@ -1,0 +1,42 @@
+; ============================================================
+; capabilities.bdsl — the answering body's effector manifest.
+;
+; Each (effector ...) declares one tentacle the body has. The
+; brain's action-space is exactly the declared effectors. The
+; body's startup verifies every effector has a registered
+; implementation. Read by both sides; changes are deployment
+; events, not runtime events. (Param impls firm up with the
+; pi-mono body in Stage 2; this is the Stage-1 declaration.)
+;
+; Brain terminal action → effector mapping (move-1-design §"Q1"):
+;   report (report_j, the EU-max candidate) → answer  (crisp)
+;   hedge  (the named-set value)            → answer  (a candidate set)
+;   ask_clarify                             → ask-user
+;   abstain                                 → abstain
+; plus the forward steer (net_voi-priced):  → gather
+; ============================================================
+
+(define manifest
+  (list
+
+    ; --- answer: emit an answer to the owner ---
+    ;   value     (string) — the asserted value, or a "·"-joined candidate set (hedge)
+    ;   credence  (string) — the posterior credence(s), rendered
+    ;   citations (string) — the supporting card numbers
+    (effector answer
+      (parameters (value string) (credence string) (citations string)))
+
+    ; --- ask-user: put the question to the owner (the oracle) ---
+    ;   text (string) — what to ask; the evidence did not settle it
+    (effector ask-user
+      (parameters (text string)))
+
+    ; --- abstain: assert nothing (the gauge zero) ---
+    ;   reason (string) — why withheld (e.g. dispersed posterior)
+    (effector abstain
+      (parameters (reason string)))
+
+    ; --- gather: steer the body to fetch more evidence on a candidate ---
+    ;   target (string) — the candidate value to corroborate (the net_voi pick)
+    (effector gather
+      (parameters (target string)))))

--- a/apps/answer-brain/bdsl/features.bdsl
+++ b/apps/answer-brain/bdsl/features.bdsl
@@ -1,0 +1,38 @@
+; ============================================================
+; features.bdsl — the candidate-set state vocabulary (Stage 1).
+;
+; The brain's belief is a posterior over candidate values + NONE.
+; These features summarise that posterior's SHAPE — the signals a
+; steering policy reads to decide gather-vs-answer-vs-ask. Declared
+; here; their extractors (which read the live posterior) land with
+; the body in Stage 2. Stage-1 decisions run directly off the
+; posterior + Ū (terminal_decide), so nothing reads these yet.
+; ============================================================
+
+; How concentrated the posterior is on its leader.
+(define dispersion-space
+  (space :finite sharp moderate dispersed))
+
+; Where the leading candidate's credence sits relative to the
+; u_wrong-implied report bar.
+(define leader-band-space
+  (space :finite below-bar near-bar above-bar))
+
+; Do the candidates' supporting documents split across eras (the
+; precondition for a stale-vs-current confusion — recency
+; discriminates)? Decouples recency from the router's time_indexed.
+(define era-split-space
+  (space :finite no yes))
+
+; Is the question owner-scoped ("my X")? Only then can whose-document
+; protect an identity fact; a relational/third-party question takes
+; the conservative path (gather amplifies no confound it cannot see).
+(define owner-scoped-space
+  (space :finite no yes))
+
+(define features
+  (list
+    (feature posterior-dispersion   dispersion-space)
+    (feature leader-credence-band   leader-band-space)
+    (feature candidates-era-split   era-split-space)
+    (feature owner-scoped           owner-scoped-space)))

--- a/apps/answer-brain/bdsl/utility.bdsl
+++ b/apps/answer-brain/bdsl/utility.bdsl
@@ -1,0 +1,46 @@
+; ============================================================
+; utility.bdsl — declared channel-parameter priors (Stage 1).
+;
+; DATA the operator sets, read by the typed Julia brain
+; (apps/answer-brain/brain/answer_brain.jl, the ChannelParams
+; struct) at wire time. The .bdsl declares the numbers a human
+; chooses; the Julia brain builds the (too-large-to-transcribe)
+; categorical posterior and runs EU-max. The brain's
+; CANONICAL_CHANNEL mirrors these defaults, so the file is
+; documentation as much as configuration.
+;
+; These mirror life-agent's lookup.py stated channel parameters
+; (§4.2 lineage temper, §4.1 covariates). Each is a PRIOR that
+; calibration moves — never fitted to the gate (frozen-blind).
+;
+; NOT declared here: the owner's utility posterior mean Ū
+; (u_correct / u_wrong / u_hedged / u_abstain / lambda_int).
+; Ū is the LEARNED preference, supplied per-decision by the
+; body from life-agent's utility posterior — it is not an
+; operator-set constant and does not live in this file.
+; ============================================================
+
+; Effective number of wrong values a misreport spreads over (the
+; noisy-channel's A). Larger ⇒ a single agreeing observation is
+; more decisive (a miss is spread thinner).
+(define a-alternatives 10.0)
+
+; §4.2 ancestry temper: within ONE source document, m observations
+; count as 1 + beta-ancestry·(m-1) effective (chunks of one doc
+; corroborate less than independent docs). 0 ⇒ full discount to 1.
+(define beta-ancestry 0.3)
+
+; §4.2 model temper: across the G source documents (one shared
+; extractor produced every observation), the groups count as
+; 1 + beta-model·(G-1). Tempers shared-instrument over-counting.
+(define beta-model 0.7)
+
+; Prior mass on none-of-the-retrieved (the NONE atom: "the truth
+; is not among the retrieved candidates"). The complement of an
+; unproven extraction channel; the rest is uniform over candidates.
+(define p-none-prior 0.5)
+
+; Owner-as-oracle reliability, pricing ask-user: EU(ask) =
+; oracle-p·u_correct − lambda_int. The oracle is infallible WHEN
+; it knows; this is P(it knows). Not a u_assert outcome.
+(define oracle-p 0.9)

--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -30,7 +30,8 @@ using Main.Credence: CategoricalMeasure, Finite, Kernel, PushOnly, condition, we
 import Main.Credence.Ontology: optimise, value, net_voi
 
 export Obs, ChannelParams, CANONICAL_CHANNEL,
-       candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather
+       candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather,
+       provisional_leader, gather_decide
 
 # ── Stated channel parameters (the §4.2/§4.1 priors; calibration moves them) ────────────
 # Mirror of life-agent's `lookup.py` constants and `bdsl/utility.bdsl`. A `ChannelParams`
@@ -206,6 +207,48 @@ function voi_gather(state::CategoricalMeasure, k::Int, u_bar::AbstractDict,
                     cp::ChannelParams = CANONICAL_CHANNEL)::Float64
     order, fpa = decision_fpa(k, u_bar; cp = cp)
     Float64(net_voi(state, probe_kernel, order, fpa, possible_obs, cost))
+end
+
+# ── The forward gather steer: an operator-set feature-policy (Move 4, move-4-design §2C) ──
+"""
+    provisional_leader(state, k, u_bar; cp=CANONICAL_CHANNEL) -> Int
+
+The 0-based candidate index the decision mechanism would report **if forced to report** —
+`optimise` over the K `report_j` actions ALONE. Invariant 1: the leader comes from the decision
+mechanism, never `argmax(weights)`. Used as the `gather` target when the terminal decision
+withholds, so the steer names the candidate whose support the probe will test.
+"""
+function provisional_leader(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
+                            cp::ChannelParams = CANONICAL_CHANNEL)::Int
+    order, fpa = decision_fpa(k, u_bar; cp = cp)
+    optimise(state, order[1:k], fpa) - 1        # report keys 1..k only; key j ⇒ index j-1
+end
+
+"""
+    gather_decide(state, k, u_bar; era_split=false, applied_probes=String[], cp=CANONICAL_CHANNEL)
+        -> (effector, report_index, probe, target, eu)
+
+The Move-4 feature-policy (move-4-design §2C, §5 Q2). If the terminal decision is a confident
+`report`, take it — the leader cleared the EU bar (the bar already integrates `u_wrong` under Ū).
+Otherwise, if a **class-valid discriminating probe** is available-and-unapplied, emit
+`gather(probe, target)` to defer a below-bar answer; else the terminal decision (hedge / ask /
+abstain) stands. v0's only class-valid probe is `recency` on an `era_split` — the validated lever
+(`master-plan.md` §"probe library": stale leader 0.605 → ~0.09). `applied_probes` (body-held,
+resent each step) guarantees termination. corroborate / subject / dispersion-gating are the
+declared-but-deferred refinements (§5 Q2 named successor); their thresholds are the §5 Q5 params.
+`report_index`/`probe`/`target` are `nothing` where inapplicable (a report carries no probe; a
+gather carries no report index).
+"""
+function gather_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
+                       era_split::Bool = false,
+                       applied_probes::AbstractVector{<:AbstractString} = String[],
+                       cp::ChannelParams = CANONICAL_CHANNEL)
+    action, report_index, eu = decide_full(state, k, u_bar; cp = cp)
+    action == "report" && return (action, report_index, nothing, nothing, eu)
+    if era_split && !("recency" in applied_probes)
+        return ("gather", nothing, "recency", provisional_leader(state, k, u_bar; cp = cp), eu)
+    end
+    (action, report_index, nothing, nothing, eu)
 end
 
 end # module AnswerBrain

--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -228,24 +228,30 @@ end
     gather_decide(state, k, u_bar; era_split=false, applied_probes=String[], cp=CANONICAL_CHANNEL)
         -> (effector, report_index, probe, target, eu)
 
-The Move-4 feature-policy (move-4-design §2C, §5 Q2). If the terminal decision is a confident
-`report`, take it — the leader cleared the EU bar (the bar already integrates `u_wrong` under Ū).
-Otherwise, if a **class-valid discriminating probe** is available-and-unapplied, emit
-`gather(probe, target)` to defer a below-bar answer; else the terminal decision (hedge / ask /
-abstain) stands. v0's only class-valid probe is `recency` on an `era_split` — the validated lever
-(`master-plan.md` §"probe library": stale leader 0.605 → ~0.09). `applied_probes` (body-held,
-resent each step) guarantees termination. corroborate / subject / dispersion-gating are the
-declared-but-deferred refinements (§5 Q2 named successor); their thresholds are the §5 Q5 params.
-`report_index`/`probe`/`target` are `nothing` where inapplicable (a report carries no probe; a
-gather carries no report index).
+The Move-4 feature-policy (move-4-design §2C, §5 Q2). A **cheap, class-valid re-weighting probe**
+is applied BEFORE the terminal report, not gated behind it: whenever `era_split` holds (the
+candidates span eras — the stale-vs-current precondition) and `recency` is unapplied, emit
+`gather(recency, leader)` so the body re-weights by recency and re-decides. A confident report must
+first rule out the staleness `era_split` signals — a count-led STALE value can sit ABOVE the EU
+bar, and reporting it without the recency check is a confident-wrong (`gather.py` applies recency
+pre-decision for exactly this reason; the daemon ports that). `applied_probes` (body-held, resent)
+makes recency fire at most once, so the loop terminates; afterwards the terminal decision (report /
+hedge / ask / abstain) stands. v0's only class-valid probe is `recency` on `era_split` (the
+validated lever — `master-plan.md` §"probe library": stale leader 0.605 → ~0.09). The EXPENSIVE
+gather — `corroborate` (fetch new documents), EU-gated on a below-bar leader — plus `subject` and
+dispersion-gating are the declared-but-deferred refinements (§5 Q2 named successor; their thresholds
+are the §5 Q5 params). `report_index`/`probe`/`target` are `nothing` where inapplicable (a report
+carries no probe; a gather carries no report index).
 """
 function gather_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
                        era_split::Bool = false,
                        applied_probes::AbstractVector{<:AbstractString} = String[],
                        cp::ChannelParams = CANONICAL_CHANNEL)
     action, report_index, eu = decide_full(state, k, u_bar; cp = cp)
-    action == "report" && return (action, report_index, nothing, nothing, eu)
     if era_split && !("recency" in applied_probes)
+        # Rule out staleness before any terminal report (even a confident one): the recency
+        # re-weight is cheap and class-valid here, so it precedes the decision rather than being
+        # gated by it — a count-led stale leader above the bar must be recency-checked first.
         return ("gather", nothing, "recency", provisional_leader(state, k, u_bar; cp = cp), eu)
     end
     (action, report_index, nothing, nothing, eu)

--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -30,7 +30,7 @@ using Main.Credence: CategoricalMeasure, Finite, Kernel, PushOnly, condition, we
 import Main.Credence.Ontology: optimise, value, net_voi
 
 export Obs, ChannelParams, CANONICAL_CHANNEL,
-       candidate_posterior, terminal_decide, decision_fpa, voi_gather
+       candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather
 
 # ── Stated channel parameters (the §4.2/§4.1 priors; calibration moves them) ────────────
 # Mirror of life-agent's `lookup.py` constants and `bdsl/utility.bdsl`. A `ChannelParams`
@@ -155,6 +155,15 @@ end
 _action_name(act::Int, k::Int)::String =
     act <= k ? "report" : act == k + 1 ? "hedge" : act == k + 2 ? "ask_clarify" : "abstain"
 
+# Shared decision: `optimise` over the terminal action set; returns the chosen action KEY + its EU.
+# The argmax is the single decision mechanism — no `weights` are read to select behaviour.
+function _decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict, cp::ChannelParams)
+    order, fpa = decision_fpa(k, u_bar; cp = cp)
+    act = optimise(state, order, fpa)          # argmax_a expect(state, fpa[a]) (single decision mech.)
+    eu  = value(state, order, fpa)             # = EU of the chosen action
+    (act, Float64(eu))
+end
+
 """
     terminal_decide(state, k, u_bar; cp=CANONICAL_CHANNEL) -> (action::String, eu::Float64)
 
@@ -163,10 +172,24 @@ _action_name(act::Int, k::Int)::String =
 """
 function terminal_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
                          cp::ChannelParams = CANONICAL_CHANNEL)
-    order, fpa = decision_fpa(k, u_bar; cp = cp)
-    act = optimise(state, order, fpa)          # argmax_a expect(state, fpa[a]) (single decision mech.)
-    eu  = value(state, order, fpa)             # = EU of the chosen action
-    (_action_name(act, k), Float64(eu))
+    act, eu = _decide(state, k, u_bar, cp)
+    (_action_name(act, k), eu)
+end
+
+"""
+    decide_full(state, k, u_bar; cp=CANONICAL_CHANNEL)
+        -> (action::String, report_index::Union{Int,Nothing}, eu::Float64)
+
+As `terminal_decide`, but also returns the **0-based candidate index** `optimise` chose when the
+action is a report (`report_{j*}` ⇒ index `j*−1`), `nothing` otherwise. That index is the decision
+mechanism's own choice, not an `argmax(weights)` — the wire surface (`daemon/server.jl`) needs the
+reported value while keeping the Invariant-1 promise that no caller reads `weights` to pick an action.
+"""
+function decide_full(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
+                     cp::ChannelParams = CANONICAL_CHANNEL)
+    act, eu = _decide(state, k, u_bar, cp)
+    report_index = act <= k ? act - 1 : nothing
+    (_action_name(act, k), report_index, eu)
 end
 
 # ── The forward capability: VOI-priced gather/ask (NEW; no Stage-0 parity counterpart) ──

--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -1,0 +1,188 @@
+# Role: brain
+"""
+    answer_brain.jl — the answer-brain's belief + decision core (Stage 1).
+
+A native-Julia port of `life-agent`'s validated Stage-0 answerer
+(`src/life_agent/core/lookup.py`, `core/gather.py`): the tempered candidate posterior and
+the EU decision over the terminal effectors, plus the `net_voi`-priced gather/ask gate. See
+`docs/answer-brain/master-plan.md` and `docs/answer-brain/move-1-design.md`.
+
+The parity boundary (move-1-design §1): the brain reasons over ABSTRACT candidates and
+evidence groups. Candidate identity (string canon) and covariate projection are the body's
+job; an `Obs` here is pure numbers — which candidate index it reports, which ancestry group
+it belongs to, and its already-projected reliability covariates (authority / subject / time).
+
+Belief: a `CategoricalMeasure` over K candidate atoms `0..K-1` plus an explicit NONE atom `K`
+("the truth is not among the retrieved candidates"). Each observation conditions the
+categorical through a tempered `tabular_log_density` (PushOnly) kernel — the same construction
+`life-agent` ships to the skin (`apps/skin/server.jl` `build_kernel`), now built natively.
+
+Invariant 1 (single reasoner): this module DECLARES data (the kernel's log-density matrix, the
+`Tabular` utility vectors) and CALLS the Tier-1 primitives (`condition`, `optimise`, `value`,
+`net_voi`). It never reads `weights` to select behaviour — the argmax over candidates lives in
+`optimise` via K explicit `report_j` actions (move-1-design Open-Q1), not a hand-coded
+`argmax(weights)`.
+"""
+module AnswerBrain
+
+using Main.Credence: CategoricalMeasure, Finite, Kernel, PushOnly, condition, weights,
+                     Tabular, Functional
+import Main.Credence.Ontology: optimise, value, net_voi
+
+export Obs, ChannelParams, CANONICAL_CHANNEL,
+       candidate_posterior, terminal_decide, decision_fpa, voi_gather
+
+# ── Stated channel parameters (the §4.2/§4.1 priors; calibration moves them) ────────────
+# Mirror of life-agent's `lookup.py` constants and `bdsl/utility.bdsl`. A `ChannelParams`
+# value travels with every call so the parity test can pin these against the fixture's
+# `channel_params` (drift guard) rather than trusting a silent default.
+struct ChannelParams
+    a_alternatives::Float64   # effective number of wrong values a misreport spreads over
+    beta_ancestry::Float64    # within-document ancestry temper exponent
+    beta_model::Float64       # across-document (shared extractor) temper exponent
+    p_none_prior::Float64     # prior mass on none-of-the-retrieved
+    oracle_p::Float64         # owner-as-oracle reliability, pricing ask_clarify
+    prob_eps::Float64         # log-domain floor
+end
+
+const CANONICAL_CHANNEL = ChannelParams(10.0, 0.3, 0.7, 0.5, 0.9, 1e-12)
+
+# ── One observation, abstracted to numbers (the parity boundary) ────────────────────────
+struct Obs
+    reports::Int          # candidate index in 0..K-1 this observation asserts
+    group::Int            # ancestry-group id (chunks of one document share a group)
+    authority::Float64    # §4.1 source-authority prior
+    subject_factor::Float64   # §4.1 doc_subject covariate on aᵢ (1.0 = no covariate)
+    time_factor::Float64      # §4.1 doc_date covariate on aᵢ (1.0 = no covariate)
+end
+
+# ── The §4.2 lineage temper (pure; mirrors lookup.temper_scales, keyed on group) ────────
+"""
+    temper_scales(obs, cp) -> Vector{Float64}
+
+Per observation: within an ancestry group of size m the group counts as
+`1 + β_anc·(m-1)` effective observations; across the G groups (one shared extractor) the
+groups count as `1 + β_mod·(G-1)`. A single observation ⇒ scale 1.
+"""
+function temper_scales(obs::Vector{Obs}, cp::ChannelParams)::Vector{Float64}
+    counts = Dict{Int, Int}()
+    for o in obs
+        counts[o.group] = get(counts, o.group, 0) + 1
+    end
+    n_groups = length(counts)
+    s_mod = n_groups == 0 ? 1.0 : (1.0 + cp.beta_model * (n_groups - 1)) / n_groups
+    [begin
+         m = counts[o.group]
+         s_anc = (1.0 + cp.beta_ancestry * (m - 1)) / m
+         s_anc * s_mod
+     end for o in obs]
+end
+
+# ── The tempered noisy-channel log-density matrix (pure; mirrors observation_densities) ──
+"""
+    observation_densities(o, k, rho, scale, cp) -> Vector{Vector{Float64}}
+
+Rows are the K candidate hypotheses + NONE (last); columns the K reported-candidate atoms.
+With reliability `r = rho · authority · subject · time`, a match carries
+`scale·log(r + (1-r)/A)` and any miss `scale·log((1-r)/A)`; NONE misses everything.
+"""
+function observation_densities(o::Obs, k::Int, rho::Float64, scale::Float64,
+                               cp::ChannelParams)::Vector{Vector{Float64}}
+    r = rho * o.authority * o.subject_factor * o.time_factor
+    log_match = scale * log(max(r + (1.0 - r) / cp.a_alternatives, cp.prob_eps))
+    log_miss  = scale * log(max((1.0 - r) / cp.a_alternatives, cp.prob_eps))
+    rows = [[t == j ? log_match : log_miss for t in 0:(k - 1)] for j in 0:(k - 1)]
+    push!(rows, fill(log_miss, k))   # NONE row: every report is a misreport
+    rows
+end
+
+# ── The posterior: condition the candidate+NONE categorical on every observation ────────
+"""
+    candidate_posterior(k, obs, rho; cp=CANONICAL_CHANNEL) -> CategoricalMeasure
+
+The tempered posterior over K candidates + NONE. Same construction life-agent ships to the
+skin: a `categorical` prior (`p_none` on NONE, the rest uniform over candidates) conditioned
+on each observation through a `tabular_log_density` PushOnly kernel, in observation order.
+"""
+function candidate_posterior(k::Int, obs::Vector{Obs}, rho::Float64;
+                             cp::ChannelParams = CANONICAL_CHANNEL)::CategoricalMeasure
+    atoms = collect(Float64, 0:k)                       # 0..k-1 candidates, k = NONE
+    prior = vcat(fill((1.0 - cp.p_none_prior) / k, k), [cp.p_none_prior])
+    state = CategoricalMeasure(Finite(atoms), log.(prior))
+    scales = temper_scales(obs, cp)
+    src, tgt = Finite(atoms), Finite(collect(Float64, 0:(k - 1)))
+    for (o, scale) in zip(obs, scales)
+        dens = observation_densities(o, k, rho, scale, cp)
+        kern = Kernel(src, tgt, _ -> error("generate not used"),
+                      (h, ob) -> dens[Int(round(h)) + 1][Int(round(ob)) + 1];
+                      likelihood_family = PushOnly())  # credence-lint: allow — precedent:declarative-construction — tabular_log_density kernel, mirrors apps/skin/server.jl build_kernel
+        state = condition(state, kern, Float64(o.reports))
+    end
+    state
+end
+
+# ── The decision: optimise over {report_j × K, hedge, ask_clarify, abstain} ──────────────
+# action keys (deterministic numeric order = the skin's _sorted_action_keys semantics):
+#   1..k       report_j        reward candidate (j-1), every other atom + NONE = u_wrong
+#   k+1        hedge           the named-set value; misleads only when the truth is NONE
+#   k+2        ask_clarify     the oracle price (NOT a u_assert outcome)
+#   k+3        abstain         the gauge zero
+"""
+    decision_fpa(k, u_bar; cp=CANONICAL_CHANNEL) -> (order, fpa)
+
+The terminal preference: an ordered action-key vector and a `Dict` of `Tabular` utility
+vectors over the K+1 atoms. Pure declarative construction of the §4.4 utility (the argmax
+over candidates is left to `optimise` via the K `report_j` actions — Invariant 1).
+`u_bar` is the owner's utility posterior mean Ū, supplied by the body.
+"""
+function decision_fpa(k::Int, u_bar::AbstractDict;
+                      cp::ChannelParams = CANONICAL_CHANNEL)
+    u_c = Float64(u_bar["u_correct"]); u_w = Float64(u_bar["u_wrong"])
+    u_h = Float64(u_bar["u_hedged"]);  u_ab = Float64(u_bar["u_abstain"])
+    lam = Float64(u_bar["lambda_int"])
+    order = Int[]
+    fpa = Dict{Int, Functional}()
+    for j in 1:k                                   # report_j: reward candidate (j-1)
+        vals = fill(u_w, k + 1); vals[j] = u_c
+        fpa[j] = Tabular(vals); push!(order, j)
+    end
+    fpa[k + 1] = Tabular(vcat(fill(u_h, k), [u_w]));           push!(order, k + 1)  # hedge
+    fpa[k + 2] = Tabular(fill(cp.oracle_p * u_c - lam, k + 1)); push!(order, k + 2)  # ask
+    fpa[k + 3] = Tabular(fill(u_ab, k + 1));                    push!(order, k + 3)  # abstain
+    (order, fpa)
+end
+
+_action_name(act::Int, k::Int)::String =
+    act <= k ? "report" : act == k + 1 ? "hedge" : act == k + 2 ? "ask_clarify" : "abstain"
+
+"""
+    terminal_decide(state, k, u_bar; cp=CANONICAL_CHANNEL) -> (action::String, eu::Float64)
+
+`optimise` over the terminal action set on the live posterior; the chosen `report_j` maps to
+`"report"`. Returns the Stage-0 action vocabulary so parity compares like-for-like.
+"""
+function terminal_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
+                         cp::ChannelParams = CANONICAL_CHANNEL)
+    order, fpa = decision_fpa(k, u_bar; cp = cp)
+    act = optimise(state, order, fpa)          # argmax_a expect(state, fpa[a]) (single decision mech.)
+    eu  = value(state, order, fpa)             # = EU of the chosen action
+    (_action_name(act, k), Float64(eu))
+end
+
+# ── The forward capability: VOI-priced gather/ask (NEW; no Stage-0 parity counterpart) ──
+"""
+    voi_gather(state, k, u_bar, probe_kernel, possible_obs, cost; cp=CANONICAL_CHANNEL)
+
+`net_voi` of one probe for the terminal decision: the expected gain in `value` from
+conditioning on the probe's observation, net of `cost`. Positive ⇒ the probe earns its
+keep. The forward gather/ask gate the Stage-0 loop lacked (it gathered unconditionally);
+priced against the SAME terminal preference, so gather competes with answer/abstain in one EU.
+"""
+function voi_gather(state::CategoricalMeasure, k::Int, u_bar::AbstractDict,
+                    probe_kernel::Kernel, possible_obs, cost::Float64;
+                    cp::ChannelParams = CANONICAL_CHANNEL)::Float64
+    order, fpa = decision_fpa(k, u_bar; cp = cp)
+    Float64(net_voi(state, probe_kernel, order, fpa, possible_obs, cost))
+end
+
+end # module AnswerBrain

--- a/apps/answer-brain/daemon/main.jl
+++ b/apps/answer-brain/daemon/main.jl
@@ -1,15 +1,15 @@
 # Role: brain
 """
-    main.jl — standalone entrypoint for the answer-brain daemon (Stage-1 skeleton).
+    main.jl — answer-brain daemon entrypoint (Stage 2a: the stateless decision wire).
 
-Loads Credence + the brain + the observation log, and reports ready. The HTTP/SSE wire
-surface (`server.jl`, the sensor→effector loop) is deferred to Stage 2, where the pi-mono
-body defines the sensor-event schema (move-1-design §0/§"Q2"). Until then this entrypoint
-exists to confirm the app loads under the repo project and to be the seam Stage 2 grows the
-server onto.
+Loads Credence + the brain + the HTTP server (`server.jl`) and serves `POST /decide` + `GET /ready`
+until interrupted. Stateless, so there is nothing to replay on boot (move-2-design §5 Resolution); the
+observation log / live-session wiring lands with the pi-mono body in Stage 2b (Move 3).
 
 Run:
     julia --project=<repo-root> apps/answer-brain/daemon/main.jl
+Env:
+    ANSWER_BRAIN_HOST (default 127.0.0.1), ANSWER_BRAIN_PORT (default 8799)
 """
 
 push!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..", "src")))
@@ -17,14 +17,23 @@ using Credence
 
 include(joinpath(@__DIR__, "..", "brain", "answer_brain.jl"))
 using .AnswerBrain
-include(joinpath(@__DIR__, "observation_log.jl"))
-using .ObservationLog
+include(joinpath(@__DIR__, "server.jl"))
+using .Server
 
-const BDSL_DIR = get(ENV, "ANSWER_BRAIN_BDSL_DIR",
-                     normpath(joinpath(@__DIR__, "..", "bdsl")))
-const LOG_PATH = get(ENV, "ANSWER_BRAIN_LOG",
-                     joinpath(homedir(), ".answer-brain", "observations.jsonl"))
+const HOST = get(ENV, "ANSWER_BRAIN_HOST", "127.0.0.1")
+const PORT = parse(Int, get(ENV, "ANSWER_BRAIN_PORT", "8799"))
 
-@info "answer-brain loaded (Stage 1: no wire surface — see move-1-design §Q2)" #=
-=#    channel = AnswerBrain.CANONICAL_CHANNEL bdsl_dir = BDSL_DIR log = LOG_PATH
-println(Dict("status" => "ready", "stage" => 1, "wire" => "deferred-to-stage-2"))
+function main()
+    server = start_daemon(; port = PORT, host = HOST)
+    @info "answer-brain daemon listening (Stage 2a: stateless /decide)" host = HOST port = PORT
+    try
+        wait(server)
+    catch e
+        e isa InterruptException || rethrow()
+    finally
+        stop_daemon(server)
+        @info "answer-brain daemon stopped"
+    end
+end
+
+main()

--- a/apps/answer-brain/daemon/main.jl
+++ b/apps/answer-brain/daemon/main.jl
@@ -26,6 +26,9 @@ const PORT = parse(Int, get(ENV, "ANSWER_BRAIN_PORT", "8799"))
 function main()
     server = start_daemon(; port = PORT, host = HOST)
     @info "answer-brain daemon listening (Stage 2a: stateless /decide)" host = HOST port = PORT
+    # SIGINT → catchable InterruptException (not a hard exit), so the finally below runs
+    # stop_daemon and releases the port cleanly on Ctrl-C (credence-pi daemon parity).
+    Base.exit_on_sigint(false)
     try
         wait(server)
     catch e

--- a/apps/answer-brain/daemon/main.jl
+++ b/apps/answer-brain/daemon/main.jl
@@ -1,0 +1,30 @@
+# Role: brain
+"""
+    main.jl — standalone entrypoint for the answer-brain daemon (Stage-1 skeleton).
+
+Loads Credence + the brain + the observation log, and reports ready. The HTTP/SSE wire
+surface (`server.jl`, the sensor→effector loop) is deferred to Stage 2, where the pi-mono
+body defines the sensor-event schema (move-1-design §0/§"Q2"). Until then this entrypoint
+exists to confirm the app loads under the repo project and to be the seam Stage 2 grows the
+server onto.
+
+Run:
+    julia --project=<repo-root> apps/answer-brain/daemon/main.jl
+"""
+
+push!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..", "src")))
+using Credence
+
+include(joinpath(@__DIR__, "..", "brain", "answer_brain.jl"))
+using .AnswerBrain
+include(joinpath(@__DIR__, "observation_log.jl"))
+using .ObservationLog
+
+const BDSL_DIR = get(ENV, "ANSWER_BRAIN_BDSL_DIR",
+                     normpath(joinpath(@__DIR__, "..", "bdsl")))
+const LOG_PATH = get(ENV, "ANSWER_BRAIN_LOG",
+                     joinpath(homedir(), ".answer-brain", "observations.jsonl"))
+
+@info "answer-brain loaded (Stage 1: no wire surface — see move-1-design §Q2)" #=
+=#    channel = AnswerBrain.CANONICAL_CHANNEL bdsl_dir = BDSL_DIR log = LOG_PATH
+println(Dict("status" => "ready", "stage" => 1, "wire" => "deferred-to-stage-2"))

--- a/apps/answer-brain/daemon/manifest.jl
+++ b/apps/answer-brain/daemon/manifest.jl
@@ -1,0 +1,108 @@
+# Role: brain
+"""
+    manifest.jl — serve the body's vocabulary from the bdsl, through the ONE library parser.
+
+The de-dup cut (move-4-design §0, §5 Q1): credence-pi parses its manifest a *second* time in
+TypeScript (`extension/src/manifest.ts`, 159 lines). The library already owns the single BDSL
+parser (`src/parse.jl`); so the answer-brain body has **no** parser — the daemon reads
+`bdsl/capabilities.bdsl` + `bdsl/features.bdsl` via `Credence.parse_all` and serves the effector /
+feature vocabulary as JSON (`GET /manifest`). The body fetches it and verifies every declared
+effector / feature has a registered impl.
+
+The served shape mirrors the `EffectorDecl` / `FeatureDecl` interfaces the TS body consumes:
+    {effectors:[{name, parameters:[{name,type}]}], features:[{name, spaceName}]}
+
+Read-only and stateless — parsing two small files per request; the body fetches once at startup.
+"""
+module Manifest
+
+using Credence: parse_all
+using Credence.Parse: SExpr, Atom, SList
+
+export manifest_dict
+
+# Walk the parsed forms, collecting every (head …) list. Like credence-pi's
+# manifest.ts `collect`: descend through nested lists, but do NOT recurse into a
+# form once its head matches (an (effector …) has no nested (effector …)).
+function _collect(exprs::Vector{SExpr}, head::Symbol)::Vector{SList}
+    out = SList[]
+    function visit(e::SExpr)
+        e isa SList || return
+        if !isempty(e.items) && e.items[1] isa Atom && (e.items[1]::Atom).value === head
+            push!(out, e)
+        else
+            for child in e.items
+                visit(child)
+            end
+        end
+    end
+    for e in exprs
+        visit(e)
+    end
+    out
+end
+
+_sym(e::SExpr)::String =
+    e isa Atom ? string((e::Atom).value) : error("manifest: expected an atom, got $(e)")
+
+# (effector NAME (parameters (p type) …)) → {name, parameters:[{name,type}]}
+function _effector(form::SList)::Dict{String, Any}
+    length(form.items) >= 2 || error("manifest: effector form missing name in $(form)")
+    name = _sym(form.items[2])
+    params = Dict{String, String}[]
+    for i in 3:length(form.items)
+        clause = form.items[i]
+        if !(clause isa SList && !isempty(clause.items) &&
+             clause.items[1] isa Atom && (clause.items[1]::Atom).value === :parameters)
+            error("manifest: effector $(name): expected (parameters …), got $(clause)")
+        end
+        for j in 2:length(clause.items)
+            p = clause.items[j]
+            (p isa SList && length((p::SList).items) == 2) ||
+                error("manifest: effector $(name): parameter must be (name type), got $(p)")
+            push!(params, Dict("name" => _sym((p::SList).items[1]),
+                               "type" => _sym((p::SList).items[2])))
+        end
+    end
+    Dict{String, Any}("name" => name, "parameters" => params)
+end
+
+# (feature NAME SPACE) → {name, spaceName}
+function _feature(form::SList)::Dict{String, String}
+    length(form.items) == 3 ||
+        error("manifest: feature form must be (feature NAME SPACE), got $(form)")
+    Dict("name" => _sym(form.items[2]), "spaceName" => _sym(form.items[3]))
+end
+
+# Scope features to the `(define features (list …))` form — a sibling
+# `(define safety-features …)` declares a different body's vocabulary and is
+# intentionally not served here (parity with manifest.ts's `parseFeatures`).
+function _features_scope(exprs::Vector{SExpr})::Vector{SExpr}
+    for e in exprs
+        if e isa SList && length((e::SList).items) >= 2 &&
+           (e::SList).items[1] isa Atom && ((e::SList).items[1]::Atom).value === :define &&
+           (e::SList).items[2] isa Atom && ((e::SList).items[2]::Atom).value === :features
+            return SExpr[e]
+        end
+    end
+    exprs
+end
+
+"""
+    manifest_dict(; capabilities_path, features_path) -> Dict
+
+Parse the two bdsl files through the library parser and return the served manifest. Throws (→ HTTP
+500 at the route) on a malformed manifest; the body's `verify` is the second gate (a declared
+effector with no impl fails the body closed).
+"""
+function manifest_dict(; capabilities_path::AbstractString,
+                         features_path::AbstractString)::Dict{String, Any}
+    caps = parse_all(read(capabilities_path, String))
+    feats = parse_all(read(features_path, String))
+    Dict{String, Any}(
+        "effectors" => [_effector(f) for f in _collect(caps, :effector)],
+        "features"  => [_feature(f) for f in _collect(_features_scope(feats), :feature)],
+    )
+end
+
+end # module Manifest

--- a/apps/answer-brain/daemon/observation_log.jl
+++ b/apps/answer-brain/daemon/observation_log.jl
@@ -1,0 +1,158 @@
+# Role: brain
+"""
+    observation_log.jl — append-only JSONL observation log for answer-brain.
+
+The canonical de Finetti record. Each line wraps one event:
+
+    { "schema": "answer-brain/v1",
+      "received_at": "2026-06-17T08:34:11.421Z",
+      "event": { ... } }
+
+`append_observation!` writes one grounded observation (the unit the brain conditions on —
+which candidate index it reports, its ancestry group, and its already-projected reliability
+covariates) and fsync's before returning, so a crash between an effector emission and the
+append never loses the observation that prompted it.
+
+`replay_observations` reconstructs the conditioning sequence per question in file order;
+feeding it back through `AnswerBrain.candidate_posterior` reproduces the posterior exactly
+(deterministic replay — the durability property in test_answer_brain.jl §3).
+
+This module is wire/IO only — it never calls `condition` or `expect`. The reasoner is the
+brain; the log is a record. Adapted from `apps/credence-pi/daemon/observation_log.jl`.
+"""
+module ObservationLog
+
+using Dates: now, UTC, format
+using JSON3
+
+export append_event!, append_observation!, read_log, replay_observations,
+       LogRecord, SCHEMA_VERSION
+
+const SCHEMA_VERSION = "answer-brain/v1"
+
+"""One parsed log line; `event` held as `Dict{String,Any}` (the live event shape)."""
+struct LogRecord
+    schema::String
+    received_at::String
+    event::Dict{String, Any}
+end
+
+# ── Append ──────────────────────────────────────────────────────────────
+
+"""
+    append_event!(path, event::AbstractDict) -> LogRecord
+
+Wrap `event` in `{schema, received_at, event}`, append one JSON line, fsync. The parent
+directory must exist (the daemon owns `~/.answer-brain/` lifecycle).
+"""
+function append_event!(path::AbstractString, event::AbstractDict)::LogRecord
+    received_at = format(now(UTC), "yyyy-mm-ddTHH:MM:SS.sssZ")
+    record = Dict{String, Any}("schema" => SCHEMA_VERSION,
+                               "received_at" => received_at, "event" => event)
+    line = JSON3.write(record)
+    open(path, "a") do io
+        write(io, line)
+        write(io, '\n')
+        flush(io)
+        ret = ccall(:fsync, Cint, (Cint,), Base.fd(io))
+        ret == 0 || error("fsync($path) failed: errno=$(Libc.errno())")
+    end
+    LogRecord(SCHEMA_VERSION, received_at,
+              Dict{String, Any}(string(k) => v for (k, v) in event))
+end
+
+"""
+    append_observation!(path; question_id, reports, group, authority,
+                        subject_factor, time_factor) -> LogRecord
+
+Append one grounded observation for `question_id`. The fields are exactly an
+`AnswerBrain.Obs` plus the question it belongs to — the integer/float belief inputs, no PII.
+"""
+function append_observation!(path::AbstractString; question_id,
+                             reports::Integer, group::Integer,
+                             authority::Real, subject_factor::Real,
+                             time_factor::Real)::LogRecord
+    append_event!(path, Dict{String, Any}(
+        "event_type" => "observation",
+        "question_id" => String(question_id),
+        "reports" => Int(reports),
+        "group" => Int(group),
+        "authority" => Float64(authority),
+        "subject_factor" => Float64(subject_factor),
+        "time_factor" => Float64(time_factor),
+    ))
+end
+
+# ── Read ────────────────────────────────────────────────────────────────
+
+"""
+    read_log(path) -> Vector{LogRecord}
+
+Every line, parsed in file order. Missing file ⇒ empty. Malformed / wrong-schema / no-event
+lines are skipped with `@warn` (forward-compatibility under schema bumps), never raised.
+"""
+function read_log(path::AbstractString)::Vector{LogRecord}
+    records = LogRecord[]
+    isfile(path) || return records
+    open(path, "r") do io
+        for (lineno, line) in enumerate(eachline(io))
+            isempty(strip(line)) && continue
+            record = _parse_line(line, path, lineno)
+            record === nothing && continue
+            push!(records, record)
+        end
+    end
+    records
+end
+
+function _parse_line(line::AbstractString, path::AbstractString,
+                     lineno::Integer)::Union{LogRecord, Nothing}
+    parsed = try
+        JSON3.read(line)
+    catch e
+        @warn "observation log: skipping malformed JSON line" path lineno error = e
+        return nothing
+    end
+    schema = get(parsed, :schema, nothing)
+    if schema === nothing
+        @warn "observation log: skipping line with no schema field" path lineno
+        return nothing
+    end
+    if schema != SCHEMA_VERSION
+        @warn "observation log: skipping line with unrecognised schema" path lineno schema
+        return nothing
+    end
+    event_obj = get(parsed, :event, nothing)
+    if event_obj === nothing
+        @warn "observation log: skipping line with no event field" path lineno
+        return nothing
+    end
+    LogRecord(String(schema), String(get(parsed, :received_at, "")),
+              Dict{String, Any}(string(k) => v for (k, v) in event_obj))
+end
+
+# ── Replay ──────────────────────────────────────────────────────────────
+
+"""
+    replay_observations(path) -> Vector{NamedTuple}
+
+The grounded observations in file order, each a NamedTuple
+`(question_id, reports, group, authority, subject_factor, time_factor)`. The caller groups by
+`question_id` and rebuilds `AnswerBrain.Obs` to reconstruct that question's posterior — the
+deterministic replay path. Raw tuples (not `Obs`) keep this module domain-free (wire/IO only).
+"""
+function replay_observations(path::AbstractString)
+    out = NamedTuple[]
+    for record in read_log(path)
+        get(record.event, "event_type", "") == "observation" || continue
+        e = record.event
+        push!(out, (question_id = String(get(e, "question_id", "")),
+                    reports = Int(e["reports"]), group = Int(e["group"]),
+                    authority = Float64(e["authority"]),
+                    subject_factor = Float64(e["subject_factor"]),
+                    time_factor = Float64(e["time_factor"])))
+    end
+    out
+end
+
+end # module ObservationLog

--- a/apps/answer-brain/daemon/server.jl
+++ b/apps/answer-brain/daemon/server.jl
@@ -15,10 +15,15 @@ probability. The effector and the reported candidate index both come from `Answe
 body to *display* the withheld leader, not to select an action.
 
 Routes:
-  POST /decide  {question_id?, observations[], candidates[], rho, u_bar, channel?,
-                 era_split?, owner_scoped?, applied_probes?}
-             →  {effector, report_index, value, probe, target, credences[], p_none, eu}
-  GET  /ready → "ok"
+  POST /decide   {question_id?, observations[], candidates[], rho, u_bar, channel?,
+                  era_split?, owner_scoped?, applied_probes?}
+             →   {effector, report_index, value, probe, target, credences[], p_none, eu}
+  GET  /manifest → {effectors:[{name,parameters:[{name,type}]}], features:[{name,spaceName}]}
+  GET  /ready    → "ok"
+
+`GET /manifest` serves the body's effector/feature vocabulary, parsed from `bdsl/*.bdsl` by the ONE
+library parser (`manifest.jl`); the body verifies its registered impls against it and has no parser
+of its own (move-4-design §0, §5 Q1).
 
 The `era_split?`/`owner_scoped?`/`applied_probes?` fields drive the Move-4 gather branch
 (`AnswerBrain.gather_decide`); absent ⇒ the Stage-2a terminal decision, unchanged. `effector` may
@@ -34,7 +39,16 @@ using Main.Credence: weights
 using HTTP
 using JSON3
 
-export decide_response, start_daemon, stop_daemon
+include(joinpath(@__DIR__, "manifest.jl"))
+using .Manifest: manifest_dict
+
+export decide_response, manifest_dict, start_daemon, stop_daemon
+
+# The bdsl the daemon serves at GET /manifest — the body's effector/feature vocabulary, parsed by
+# the ONE library parser (move-4-design §2C). Located relative to this file (daemon/ → ../bdsl).
+const _BDSL_DIR = abspath(joinpath(@__DIR__, "..", "bdsl"))
+const CAPABILITIES_PATH = joinpath(_BDSL_DIR, "capabilities.bdsl")
+const FEATURES_PATH = joinpath(_BDSL_DIR, "features.bdsl")
 
 # ── Request parsing (the wire → the brain's abstract types) ──────────────────────────────
 
@@ -126,6 +140,17 @@ function _handle_decide(stream::HTTP.Stream)
     _write_json_response(stream, 200, resp)
 end
 
+function _handle_manifest(stream::HTTP.Stream)
+    resp = try
+        manifest_dict(; capabilities_path = CAPABILITIES_PATH, features_path = FEATURES_PATH)
+    catch e
+        # A malformed/absent bdsl is an operator error, not a bad request → 500.
+        return _write_json_response(stream, 500,
+            Dict("error" => "manifest: $(sprint(showerror, e))"))
+    end
+    _write_json_response(stream, 200, resp)
+end
+
 """
     start_daemon(; port, host="127.0.0.1") -> server
 
@@ -139,6 +164,8 @@ function start_daemon(; port::Int, host::AbstractString = "127.0.0.1")
         target = stream.message.target
         if method == "POST" && target == "/decide"
             _handle_decide(stream)
+        elseif method == "GET" && target == "/manifest"
+            _handle_manifest(stream)
         elseif method == "GET" && target == "/ready"
             HTTP.setstatus(stream, 200)
             HTTP.setheader(stream, "Content-Type" => "text/plain")

--- a/apps/answer-brain/daemon/server.jl
+++ b/apps/answer-brain/daemon/server.jl
@@ -60,10 +60,11 @@ end
     decide_response(req) -> Dict
 
 The decision for one question, given the evidence so far: the terminal effector (report / hedge /
-ask_clarify / abstain), or — when the body supplies `era_split` and a class-valid discriminating
-probe is available below the report bar — a forward `gather(probe, target)` steer
-(`AnswerBrain.gather_decide`, move-4-design §2C). Pure: same inputs → same Dict. Throws on a
-malformed request (the HTTP layer turns that into a 400).
+ask_clarify / abstain), or — when the body supplies `era_split` (the candidates span eras) and
+`recency` is unapplied — a forward `gather(recency, target)` steer that re-weights by recency BEFORE
+any terminal report, ruling out a stale leader first (`AnswerBrain.gather_decide`, move-4-design
+§2C). Pure: same inputs → same Dict. Throws on a malformed request (the HTTP layer turns that into a
+400).
 
 Optional request fields (all absent ⇒ the Stage-2a terminal decision, unchanged):
   `era_split::Bool`           body-projected feature — candidates split across eras (recency discriminates)

--- a/apps/answer-brain/daemon/server.jl
+++ b/apps/answer-brain/daemon/server.jl
@@ -1,0 +1,140 @@
+# Role: brain
+"""
+    server.jl — the answer-brain daemon's HTTP decision surface (Stage 2a, move-2-design §2).
+
+A **stateless** request/response wire over the Stage-1 brain (`brain/answer_brain.jl`). The body
+(pi-mono, Stage 2b) gathers evidence, projects the parity-boundary covariates Python-side, and posts
+the accumulated *abstract* observations + the owner's Ū; the daemon rebuilds the candidate posterior
+and returns the chosen effector. It holds **no** per-question state — `candidate_posterior` is rebuilt
+from the request's full observation vector each call (a handful of `condition`s), so isolation is by
+construction and there is no belief to leak across questions (move-2-design §5 Resolution).
+
+Invariant 1 (single reasoner): this module **transports** the brain's outputs; it computes no
+probability. The effector and the reported candidate index both come from `AnswerBrain.decide_full`
+(i.e. from `optimise`), never from reading `weights` here. `credences`/`p_none` are returned for the
+body to *display* the withheld leader, not to select an action.
+
+Routes:
+  POST /decide  {question_id?, observations[], candidates[], rho, u_bar, channel?}
+             →  {effector, report_index, value, credences[], p_none, eu}
+  GET  /ready → "ok"
+
+`decide_response(req::AbstractDict) -> Dict` is the pure handler the tests drive directly (no socket);
+`start_daemon`/`stop_daemon` wrap it in HTTP for the body + a curl smoke.
+"""
+module Server
+
+using Main.AnswerBrain: Obs, ChannelParams, CANONICAL_CHANNEL, candidate_posterior, decide_full
+using Main.Credence: weights
+using HTTP
+using JSON3
+
+export decide_response, start_daemon, stop_daemon
+
+# ── Request parsing (the wire → the brain's abstract types) ──────────────────────────────
+
+_obs(o::AbstractDict)::Obs = Obs(
+    Int(round(Float64(o["reports"]))),
+    Int(round(Float64(o["group"]))),
+    Float64(o["authority"]),
+    Float64(o["subject_factor"]),
+    Float64(o["time_factor"]),
+)
+
+# Optional per-request channel override; defaults to the operator-set CANONICAL_CHANNEL. The body
+# ships the canonical params; the parity test relies on the default + a drift guard (move-1 §0).
+function _channel(req::AbstractDict)::ChannelParams
+    haskey(req, "channel") || return CANONICAL_CHANNEL
+    c = req["channel"]
+    ChannelParams(Float64(c["a_alternatives"]), Float64(c["beta_ancestry"]),
+                  Float64(c["beta_model"]), Float64(c["p_none_prior"]),
+                  Float64(c["oracle_p"]), Float64(c["prob_eps"]))
+end
+
+"""
+    decide_response(req) -> Dict
+
+The terminal decision for one question, given the evidence so far. Pure: same inputs → same Dict.
+Throws on a malformed request (the HTTP layer turns that into a 400).
+"""
+function decide_response(req::AbstractDict)::Dict{String, Any}
+    candidates = String.(req["candidates"])
+    k = length(candidates)
+    k >= 1 || error("`candidates` must be non-empty")
+    rho = Float64(req["rho"])
+    cp = _channel(req)
+    obs = Obs[_obs(o) for o in req["observations"]]
+    u_bar = Dict{String, Float64}(String(kk) => Float64(vv) for (kk, vv) in req["u_bar"])
+
+    post = candidate_posterior(k, obs, rho; cp = cp)
+    w = weights(post)                                  # length k+1: candidates then NONE
+    effector, report_index, eu = decide_full(post, k, u_bar; cp = cp)
+
+    Dict{String, Any}(
+        "effector"     => effector,                    # report | hedge | ask_clarify | abstain
+        "report_index" => report_index,                # 0-based candidate idx, or nothing → null
+        "value"        => report_index === nothing ? nothing : candidates[report_index + 1],
+        "credences"    => w[1:k],                       # candidate weights (NONE excluded)
+        "p_none"       => w[k + 1],
+        "eu"           => eu,
+    )
+end
+
+# ── HTTP transport (adapted from apps/credence-pi/daemon/server.jl) ──────────────────────
+
+function _write_json_response(stream::HTTP.Stream, status::Int, payload::AbstractDict)
+    body = JSON3.write(payload)
+    HTTP.setstatus(stream, status)
+    HTTP.setheader(stream, "Content-Type" => "application/json")
+    HTTP.setheader(stream, "Content-Length" => string(sizeof(body)))
+    HTTP.startwrite(stream)
+    write(stream, body)
+end
+
+function _handle_decide(stream::HTTP.Stream)
+    req = try
+        JSON3.read(String(read(stream)), Dict{String, Any})
+    catch e
+        return _write_json_response(stream, 400,
+            Dict("error" => "malformed JSON: $(sprint(showerror, e))"))
+    end
+    resp = try
+        decide_response(req)
+    catch e
+        return _write_json_response(stream, 400,
+            Dict("error" => sprint(showerror, e)))
+    end
+    _write_json_response(stream, 200, resp)
+end
+
+"""
+    start_daemon(; port, host="127.0.0.1") -> server
+
+Serve the decision surface. Stateless, so there is nothing to initialise or replay — unlike
+credence-pi's daemon this takes no `log_path`/`bdsl_dir` (the brain's params are compiled-in
+`CANONICAL_CHANNEL`; Ū is per-request). `stop_daemon(server)` closes the listener.
+"""
+function start_daemon(; port::Int, host::AbstractString = "127.0.0.1")
+    function dispatch(stream::HTTP.Stream)
+        method = stream.message.method
+        target = stream.message.target
+        if method == "POST" && target == "/decide"
+            _handle_decide(stream)
+        elseif method == "GET" && target == "/ready"
+            HTTP.setstatus(stream, 200)
+            HTTP.setheader(stream, "Content-Type" => "text/plain")
+            HTTP.startwrite(stream)
+            write(stream, "ok\n")
+        else
+            HTTP.setstatus(stream, 404)
+            HTTP.startwrite(stream)
+            write(stream, "Not Found\n")
+        end
+    end
+    # `stream=true` requires HTTP 1.11.x (pinned in Project.toml [compat]) — same as credence-pi.
+    HTTP.serve!(dispatch, host, port; stream = true)
+end
+
+stop_daemon(server) = close(server)
+
+end # module Server

--- a/apps/answer-brain/daemon/server.jl
+++ b/apps/answer-brain/daemon/server.jl
@@ -15,16 +15,21 @@ probability. The effector and the reported candidate index both come from `Answe
 body to *display* the withheld leader, not to select an action.
 
 Routes:
-  POST /decide  {question_id?, observations[], candidates[], rho, u_bar, channel?}
-             →  {effector, report_index, value, credences[], p_none, eu}
+  POST /decide  {question_id?, observations[], candidates[], rho, u_bar, channel?,
+                 era_split?, owner_scoped?, applied_probes?}
+             →  {effector, report_index, value, probe, target, credences[], p_none, eu}
   GET  /ready → "ok"
+
+The `era_split?`/`owner_scoped?`/`applied_probes?` fields drive the Move-4 gather branch
+(`AnswerBrain.gather_decide`); absent ⇒ the Stage-2a terminal decision, unchanged. `effector` may
+now be `gather`, with `probe`/`target` naming the forward steer (null on a terminal decision).
 
 `decide_response(req::AbstractDict) -> Dict` is the pure handler the tests drive directly (no socket);
 `start_daemon`/`stop_daemon` wrap it in HTTP for the body + a curl smoke.
 """
 module Server
 
-using Main.AnswerBrain: Obs, ChannelParams, CANONICAL_CHANNEL, candidate_posterior, decide_full
+using Main.AnswerBrain: Obs, ChannelParams, CANONICAL_CHANNEL, candidate_posterior, gather_decide
 using Main.Credence: weights
 using HTTP
 using JSON3
@@ -54,8 +59,16 @@ end
 """
     decide_response(req) -> Dict
 
-The terminal decision for one question, given the evidence so far. Pure: same inputs → same Dict.
-Throws on a malformed request (the HTTP layer turns that into a 400).
+The decision for one question, given the evidence so far: the terminal effector (report / hedge /
+ask_clarify / abstain), or — when the body supplies `era_split` and a class-valid discriminating
+probe is available below the report bar — a forward `gather(probe, target)` steer
+(`AnswerBrain.gather_decide`, move-4-design §2C). Pure: same inputs → same Dict. Throws on a
+malformed request (the HTTP layer turns that into a 400).
+
+Optional request fields (all absent ⇒ the Stage-2a terminal decision, unchanged):
+  `era_split::Bool`           body-projected feature — candidates split across eras (recency discriminates)
+  `owner_scoped::Bool`        body-projected feature — reserved for the subject refinement (§5 Q2); v0 ignores it
+  `applied_probes::[String]`  probes already applied this question (body-held, resent) — guarantees termination
 """
 function decide_response(req::AbstractDict)::Dict{String, Any}
     candidates = String.(req["candidates"])
@@ -65,15 +78,20 @@ function decide_response(req::AbstractDict)::Dict{String, Any}
     cp = _channel(req)
     obs = Obs[_obs(o) for o in req["observations"]]
     u_bar = Dict{String, Float64}(String(kk) => Float64(vv) for (kk, vv) in req["u_bar"])
+    era_split = Bool(get(req, "era_split", false))
+    applied = String[String(p) for p in get(req, "applied_probes", String[])]
 
     post = candidate_posterior(k, obs, rho; cp = cp)
     w = weights(post)                                  # length k+1: candidates then NONE
-    effector, report_index, eu = decide_full(post, k, u_bar; cp = cp)
+    effector, report_index, probe, target, eu =
+        gather_decide(post, k, u_bar; era_split = era_split, applied_probes = applied, cp = cp)
 
     Dict{String, Any}(
-        "effector"     => effector,                    # report | hedge | ask_clarify | abstain
-        "report_index" => report_index,                # 0-based candidate idx, or nothing → null
+        "effector"     => effector,                    # report | hedge | ask_clarify | abstain | gather
+        "report_index" => report_index,                # 0-based candidate idx (report), or nothing → null
         "value"        => report_index === nothing ? nothing : candidates[report_index + 1],
+        "probe"        => probe,                        # the gather probe (e.g. "recency"), or null
+        "target"       => target === nothing ? nothing : candidates[target + 1],  # candidate to test, or null
         "credences"    => w[1:k],                       # candidate weights (NONE excluded)
         "p_none"       => w[k + 1],
         "eu"           => eu,

--- a/apps/answer-brain/extension/README.md
+++ b/apps/answer-brain/extension/README.md
@@ -1,0 +1,50 @@
+# answer-brain extension (the body)
+
+The pi-mono **body** for the answer-brain: the TS extension that runs the govern+steer
+loop over the two HTTP backends — the **daemon** (`POST /decide`, the single reasoner)
+and the life-agent **bridge** (`/route`/`/retrieve`/`/extract`/`/probe/*`/`/utility`, the
+evidence). It stands on the shared `@credence/brain-body` governor lib (move-4-design §2A);
+only the transport (`decideWithGather`) and the effector/feature impls are answer-brain's.
+
+## Shape
+
+The LLM drives three tools (pi-mono is reactive — the brain governs, it does not drive):
+
+```
+retrieve_documents(question) → bridge /route + /retrieve + /probe/recency   (accumulate)
+extract_candidates()         → bridge /extract → candidates + era_split      (accumulate)
+answer(value)                → GOVERNED on tool_call:
+      compose evidence + Ū → POST /decide → effector:
+        report/hedge → ALLOW, rewrite the answer to the brain's value
+        gather(recency) → enact INTERNALLY (re-extract with recency, re-decide)
+        ask_clarify  → BLOCK, steer to ask the owner
+        abstain      → BLOCK, name the withheld leader (never a confident wrong)
+```
+
+The daemon decides every step; the body transports its inputs and enacts its outputs. No
+posterior or EU is computed here. The body has **no BDSL parser** — it fetches the
+effector/feature vocabulary from the daemon's `GET /manifest` and verifies it implements
+it (fail closed at startup). On an unreachable daemon the governor **fails closed** (it
+withholds rather than emit an ungoverned answer).
+
+## Files
+
+- `src/tools.ts` — register the tools, accumulate evidence, install the governor (`govern`).
+- `src/daemon.ts` — `decideWithGather` (the injected `askBrain`): `/decide` + the internal
+  recency-gather loop; the daemon-action→effector mapping + human-facing param composition.
+- `src/bridge.ts` — the life-agent capability-bridge client.
+- `src/effectors.ts` — answer / ask-user / abstain / gather (the `tool_call` outcomes).
+- `src/features.ts` — the four posterior-shape extractors (era-split + owner-scoped are the
+  body's to project; dispersion + leader-band are daemon-authoritative display proxies).
+- `src/index.ts` — the factory: manifest verify + wiring.
+- `src/pi.ts` — the minimal `PiLike` slice of the pi API (so the body tests without pi-mono).
+
+## Develop
+
+```bash
+npm install
+npm run build   # tsc --noEmit
+npm test        # node --test against a fake daemon + fake bridge (no pi-mono, no corpus)
+```
+
+The end-to-end run (a real local-Ollama agent over the real corpus) lives in `../app`.

--- a/apps/answer-brain/extension/package-lock.json
+++ b/apps/answer-brain/extension/package-lock.json
@@ -1,0 +1,595 @@
+{
+  "name": "answer-brain-extension",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "answer-brain-extension",
+      "version": "0.1.0",
+      "dependencies": {
+        "@credence/brain-body": "file:../../../packages/brain-body",
+        "typebox": "1.1.38"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "../../../packages/brain-body": {
+      "name": "@credence/brain-body",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@credence/brain-body": {
+      "resolved": "../../../packages/brain-body",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/answer-brain/extension/package.json
+++ b/apps/answer-brain/extension/package.json
@@ -4,6 +4,9 @@
   "version": "0.1.0",
   "type": "module",
   "description": "answer-brain pi-mono body: retrieve/extract/answer tools + the VOI governor over the daemon (/decide) and the life-agent bridge.",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "build": "tsc --noEmit",
     "test": "node --import tsx --test tests/*.test.ts"

--- a/apps/answer-brain/extension/package.json
+++ b/apps/answer-brain/extension/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "answer-brain-extension",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "answer-brain pi-mono body: retrieve/extract/answer tools + the VOI governor over the daemon (/decide) and the life-agent bridge.",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "node --import tsx --test tests/*.test.ts"
+  },
+  "dependencies": {
+    "@credence/brain-body": "file:../../../packages/brain-body",
+    "typebox": "1.1.38"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/apps/answer-brain/extension/src/bridge.ts
+++ b/apps/answer-brain/extension/src/bridge.ts
@@ -1,0 +1,80 @@
+// bridge.ts — the body's client for the life-agent capability bridge (move-3).
+// Each method is a thin POST/GET to one bridge endpoint; the bridge gathers and
+// shapes evidence, the body composes it. Errors throw (the governor fail-opens
+// around the whole loop); these calls are loopback and fast.
+
+import type { ExtractResult, Hit, RouteResult } from "./types.js";
+
+export interface BridgeClient {
+	route(question: string): Promise<RouteResult | null>;
+	retrieve(question: string, terms: string, k: number): Promise<Hit[]>;
+	probeRecency(hitKeys: string[]): Promise<Record<string, string | null>>;
+	extract(
+		question: string,
+		hits: Hit[],
+		covariates: { doc_date?: Record<string, string | null>; subject_state?: Record<string, string> },
+		timeIndexed: boolean,
+	): Promise<ExtractResult>;
+	utility(): Promise<Record<string, number>>;
+}
+
+export interface BridgeOptions {
+	timeoutMs?: number;
+	fetchImpl?: typeof fetch;
+}
+
+export function createBridgeClient(baseUrl: string, opts: BridgeOptions = {}): BridgeClient {
+	const base = baseUrl.replace(/\/+$/, "");
+	const timeoutMs = opts.timeoutMs ?? 60_000;
+	const fetchImpl = opts.fetchImpl ?? fetch;
+
+	async function call<T>(method: "GET" | "POST", path: string, body?: unknown): Promise<T> {
+		const ctrl = new AbortController();
+		const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+		try {
+			const resp = await fetchImpl(`${base}${path}`, {
+				method,
+				headers: body === undefined ? undefined : { "Content-Type": "application/json" },
+				body: body === undefined ? undefined : JSON.stringify(body),
+				signal: ctrl.signal,
+			});
+			if (!resp.ok) {
+				throw new Error(`bridge ${method} ${path} → ${resp.status}`);
+			}
+			return (await resp.json()) as T;
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	return {
+		async route(question) {
+			// /route returns JSON null for the narrative path (not a typed lookup).
+			return await call<RouteResult | null>("POST", "/route", { question });
+		},
+		async retrieve(question, terms, k) {
+			const { hits } = await call<{ hits: Hit[] }>("POST", "/retrieve", { question, terms, k });
+			return hits;
+		},
+		async probeRecency(hitKeys) {
+			const { doc_date } = await call<{ doc_date: Record<string, string | null> }>(
+				"POST",
+				"/probe/recency",
+				{ hit_keys: hitKeys },
+			);
+			return doc_date;
+		},
+		async extract(question, hits, covariates, timeIndexed) {
+			return await call<ExtractResult>("POST", "/extract", {
+				question,
+				hits,
+				covariates,
+				time_indexed: timeIndexed,
+			});
+		},
+		async utility() {
+			const { u_bar } = await call<{ u_bar: Record<string, number> }>("GET", "/utility");
+			return u_bar;
+		},
+	};
+}

--- a/apps/answer-brain/extension/src/daemon.ts
+++ b/apps/answer-brain/extension/src/daemon.ts
@@ -1,0 +1,156 @@
+// daemon.ts — the body's transport to the brain (POST /decide) AND the injected
+// `askBrain` the lib's `govern` calls. `decideWithGather` posts the accumulated
+// evidence, and when the daemon steers `gather(recency)` it enacts it INTERNALLY —
+// re-extract with recency applied, re-decide — until a terminal effector (the §4
+// worked example, steps 2-4). The brain decides every step; the body only enacts
+// and re-asks. `applied_probes` (resent) makes recency fire at most once → it
+// terminates. No posterior/EU is computed here (single-reasoner invariant); the
+// daemon-action→manifest-effector mapping and the human-facing param composition
+// (the withheld leader, the ask text) are the body's render job.
+
+import type { EffectorSignal } from "@credence/brain-body";
+
+import type { BridgeClient } from "./bridge.js";
+import type { AbstractObs, DecideResponse, Evidence } from "./types.js";
+
+export interface DecideRequest {
+	candidates: string[];
+	observations: AbstractObs[];
+	rho: number;
+	u_bar: Record<string, number>;
+	era_split: boolean;
+	owner_scoped: boolean; // daemon v0 ignores it (reserved for the subject refinement)
+	applied_probes: string[];
+}
+
+export interface DecideOptions {
+	daemonUrl: string;
+	timeoutMs: number;
+	fetchImpl?: typeof fetch;
+	onStep?: (msg: string) => void;
+}
+
+const MAX_GATHER_STEPS = 4; // recency fires at most once; this is a runaway backstop
+
+function composeDecide(ev: Evidence, uBar: Record<string, number>): DecideRequest {
+	return {
+		candidates: ev.candidates,
+		observations: ev.observations,
+		rho: ev.rho,
+		u_bar: uBar,
+		era_split: ev.eraSplit,
+		owner_scoped: ev.ownerScoped,
+		applied_probes: ev.appliedProbes,
+	};
+}
+
+async function postDecide(req: DecideRequest, opts: DecideOptions): Promise<DecideResponse> {
+	const fetchImpl = opts.fetchImpl ?? fetch;
+	const ctrl = new AbortController();
+	const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs);
+	try {
+		const resp = await fetchImpl(`${opts.daemonUrl.replace(/\/+$/, "")}/decide`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(req),
+			signal: ctrl.signal,
+		});
+		if (!resp.ok) {
+			throw new Error(`daemon POST /decide → ${resp.status}`);
+		}
+		return (await resp.json()) as DecideResponse;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function leaderIndex(credences: number[]): number {
+	let best = 0;
+	for (let i = 1; i < credences.length; i++) {
+		if ((credences[i] ?? 0) > (credences[best] ?? 0)) best = i;
+	}
+	return best;
+}
+
+function pct(credences: number[], index: number | null): string {
+	const i = index ?? (credences.length ? leaderIndex(credences) : 0);
+	return `${((credences[i] ?? 0) * 100).toFixed(0)}%`;
+}
+
+// The abstain-show-withheld contract: name the leader the brain declined to assert,
+// without asserting it (move-3/foundations).
+function abstainReason(ev: Evidence, resp: DecideResponse): string {
+	if (!ev.candidates.length || !resp.credences.length) {
+		return "no grounded candidate to assert";
+	}
+	const i = leaderIndex(resp.credences);
+	const leader = ev.candidates[i] ?? "(unknown)";
+	return `evidence too uncertain to assert — leading candidate "${leader}" at ${pct(resp.credences, i)} (below the report bar)`;
+}
+
+function askText(ev: Evidence): string {
+	const what = ev.route?.construct ?? "the value";
+	return `I could not settle ${what} from the documents. Can you tell me?`;
+}
+
+// A terminal /decide response → the manifest effector + the body-composed params.
+// (report|hedge → answer; ask_clarify → ask-user; abstain → abstain.)
+function terminalSignal(resp: DecideResponse, ev: Evidence): EffectorSignal {
+	const credence = pct(resp.credences, resp.report_index);
+	switch (resp.effector) {
+		case "report":
+			return { effector: "answer", parameters: { value: resp.value ?? "", credence, hedged: false } };
+		case "hedge":
+			return {
+				effector: "answer",
+				parameters: { value: ev.candidates.join(" · "), credence, hedged: true },
+			};
+		case "ask_clarify":
+			return { effector: "ask-user", parameters: { text: askText(ev) } };
+		case "abstain":
+			return { effector: "abstain", parameters: { reason: abstainReason(ev, resp) } };
+		default:
+			return {
+				effector: "abstain",
+				parameters: { reason: `unexpected terminal effector "${resp.effector}"` },
+			};
+	}
+}
+
+/**
+ * The injected `askBrain`: decide, enacting any `gather(recency)` steer internally,
+ * and return the terminal effector signal. Mutates `ev` (the accumulator) in place —
+ * appliedProbes, the re-extracted candidates/observations, and the last credences for
+ * the display features. Throws on a daemon/bridge failure → `govern` fail-opens.
+ */
+export async function decideWithGather(
+	ev: Evidence,
+	uBar: Record<string, number>,
+	bridge: BridgeClient,
+	opts: DecideOptions,
+): Promise<EffectorSignal> {
+	for (let step = 0; step < MAX_GATHER_STEPS; step++) {
+		const resp = await postDecide(composeDecide(ev, uBar), opts);
+		ev.lastCredences = resp.credences;
+		ev.lastPNone = resp.p_none;
+
+		const steerRecency =
+			resp.effector === "gather" &&
+			resp.probe === "recency" &&
+			!ev.appliedProbes.includes("recency");
+		if (!steerRecency) {
+			return terminalSignal(resp, ev);
+		}
+
+		opts.onStep?.(
+			`brain steers gather(recency) on "${resp.target ?? "?"}" — re-extracting with recency applied`,
+		);
+		ev.appliedProbes = [...ev.appliedProbes, "recency"];
+		const re = await bridge.extract(ev.question, ev.hits, { doc_date: ev.docDate }, true);
+		ev.candidates = re.candidates;
+		ev.observations = re.observations;
+		ev.rho = re.rho;
+		ev.eraSplit = re.era_split;
+	}
+	return { effector: "abstain", parameters: { reason: "gather did not converge" } };
+}

--- a/apps/answer-brain/extension/src/effectors.ts
+++ b/apps/answer-brain/extension/src/effectors.ts
@@ -1,0 +1,59 @@
+// effectors.ts — the body's tentacles. Each enacts ONE terminal brain decision as
+// a pi-mono tool_call outcome over the governed `answer` call:
+//
+//   answer   → ALLOW (return undefined): rewrite event.input in place to the brain's
+//              decided value + credence, so the answer tool emits the BRAIN's answer,
+//              not the LLM's draft (move-4-design §4 step 4).
+//   ask-user → BLOCK with a reason that tells the agent to put the question to the owner.
+//   abstain  → BLOCK with the withheld-leader reason (the abstain-show-withheld contract).
+//   gather   → not a terminal (the daemon's gather is enacted inside decideWithGather); a
+//              safe fallback block if one ever reaches here.
+//
+// The registry keys are the manifest effector names (capabilities.bdsl); the daemon's
+// action→effector mapping (report|hedge → answer, …) already happened in daemon.ts.
+
+import type { EffectorRegistry } from "@credence/brain-body";
+
+/** A pi-mono tool_call result: undefined = allow, {block} = stop + steer. */
+export type ToolCallResultLike = { block: true; reason: string } | undefined;
+
+/** The mutable tool_call event the body governs (its `input` is the live args object the
+ *  tool will execute with — agent-loop.ts passes the same reference, so a mutation here
+ *  reaches execute). */
+export interface GovernedEvent {
+	input: Record<string, unknown>;
+}
+
+export type Effector = (params: Record<string, unknown>, event: GovernedEvent) => ToolCallResultLike;
+
+const answer: Effector = (params, event) => {
+	// Rewrite the answer in place to the brain's decision; execute emits this.
+	event.input.value = params.value;
+	event.input.credence = params.credence;
+	event.input.hedged = params.hedged ?? false;
+	return undefined; // allow
+};
+
+const askUser: Effector = (params) => ({
+	block: true,
+	reason: `Put this question to the owner (the oracle): ${String(params.text ?? "")}`,
+});
+
+const abstain: Effector = (params) => ({
+	block: true,
+	reason: `Do not answer — ${String(params.reason ?? "the evidence does not settle it")}.`,
+});
+
+const gather: Effector = (params) => ({
+	// Defensive: the recency gather is enacted inside decideWithGather and should never
+	// surface as a terminal. If a future probe does, steer rather than silently answer.
+	block: true,
+	reason: `Gather more evidence first: ${String(params.probe ?? "probe")} on "${String(params.target ?? "")}".`,
+});
+
+export const effectors: EffectorRegistry<Effector> = {
+	answer,
+	"ask-user": askUser,
+	abstain,
+	gather,
+};

--- a/apps/answer-brain/extension/src/features.ts
+++ b/apps/answer-brain/extension/src/features.ts
@@ -1,0 +1,42 @@
+// features.ts — the four posterior-shape feature extractors (features.bdsl). They
+// read the accumulated evidence and return a kebab-case space member. Two are the
+// body's to PROJECT (the daemon cannot see them):
+//
+//   candidates-era-split  the bridge projected it (raw obs + doc_date); the body forwards it
+//   owner-scoped          a "my X" question (sent to /decide; daemon v0 reserves it)
+//
+// The other two the daemon computes authoritatively from the posterior it builds; the body's
+// versions here are DISPLAY proxies off the daemon's last returned credences (move-4-design
+// §2C). All four are registered so the manifest `verify` passes (an extractor per declared
+// feature); only era-split + owner-scoped cross the wire to /decide.
+
+import type { FeatureExtractor } from "@credence/brain-body";
+
+import type { Evidence } from "./types.js";
+
+const dispersion: FeatureExtractor<Evidence> = (ev) => {
+	if (!ev.lastCredences.length) return "moderate";
+	const max = Math.max(...ev.lastCredences);
+	if (max >= 0.7) return "sharp";
+	if (max >= 0.4) return "moderate";
+	return "dispersed";
+};
+
+const leaderBand: FeatureExtractor<Evidence> = (ev) => {
+	if (!ev.lastCredences.length) return "near-bar";
+	const max = Math.max(...ev.lastCredences);
+	if (max >= 0.8) return "above-bar";
+	if (max >= 0.5) return "near-bar";
+	return "below-bar";
+};
+
+const eraSplit: FeatureExtractor<Evidence> = (ev) => (ev.eraSplit ? "yes" : "no");
+
+const ownerScoped: FeatureExtractor<Evidence> = (ev) => (ev.ownerScoped ? "yes" : "no");
+
+export const extractors: Record<string, FeatureExtractor<Evidence>> = {
+	"posterior-dispersion": dispersion,
+	"leader-credence-band": leaderBand,
+	"candidates-era-split": eraSplit,
+	"owner-scoped": ownerScoped,
+};

--- a/apps/answer-brain/extension/src/index.ts
+++ b/apps/answer-brain/extension/src/index.ts
@@ -1,0 +1,67 @@
+// index.ts — the answer-brain extension factory. Verifies the body against the
+// daemon-served manifest (fail closed), then installs the tools + governor. Stays
+// typed on `PiLike` so the extension typechecks + tests without pi-mono; the demo
+// app (apps/answer-brain/app) adapts the real ExtensionAPI to it.
+
+import { fetchManifest, verify } from "@credence/brain-body";
+
+import { type BridgeClient, createBridgeClient } from "./bridge.js";
+import { extractors } from "./features.js";
+import { effectors } from "./effectors.js";
+import type { PiLike } from "./pi.js";
+import { installAnswerBrain } from "./tools.js";
+
+export interface ExtensionOptions {
+	/** Daemon base URL (GET /manifest, POST /decide). Default $ANSWER_BRAIN_DAEMON_URL or :8799. */
+	daemonUrl?: string;
+	/** Bridge base URL. Default $LIFE_AGENT_BRIDGE_URL or :8798. */
+	bridgeUrl?: string;
+	/** Injected fetch (tests fake /manifest + /decide). */
+	fetchImpl?: typeof fetch;
+	/** Injected bridge (tests fake it); built from bridgeUrl otherwise. */
+	bridge?: BridgeClient;
+	log?: (msg: string) => void;
+	retrieveK?: number;
+}
+
+const DEFAULT_DAEMON_URL = "http://127.0.0.1:8799";
+const DEFAULT_BRIDGE_URL = "http://127.0.0.1:8798";
+
+/**
+ * Verify the body against the daemon's manifest (the body has no parser — it fetches
+ * + checks), then register the tools + governor on `pi`. Throws if the manifest is
+ * unreachable or a declared effector/feature lacks an impl (fail closed at startup).
+ */
+export async function createAnswerBrainExtension(pi: PiLike, opts: ExtensionOptions = {}): Promise<void> {
+	const env = (k: string): string | undefined => globalThis.process?.env?.[k];
+	const daemonUrl = opts.daemonUrl ?? env("ANSWER_BRAIN_DAEMON_URL") ?? DEFAULT_DAEMON_URL;
+	const bridgeUrl = opts.bridgeUrl ?? env("LIFE_AGENT_BRIDGE_URL") ?? DEFAULT_BRIDGE_URL;
+	const log = opts.log ?? ((m: string) => console.warn(`[answer-brain] ${m}`));
+	const bridge = opts.bridge ?? createBridgeClient(bridgeUrl, { fetchImpl: opts.fetchImpl });
+
+	const manifest = await fetchManifest(daemonUrl, { fetchImpl: opts.fetchImpl });
+	verify(manifest, { effectors, features: extractors });
+	log(`manifest verified — ${manifest.effectors.length} effectors, ${manifest.features.length} features`);
+
+	installAnswerBrain(pi, {
+		bridge,
+		daemonUrl,
+		fetchImpl: opts.fetchImpl,
+		log,
+		retrieveK: opts.retrieveK,
+	});
+}
+
+/** Default ExtensionFactory shape: `(pi) => Promise<void>` (move-1 examples). The demo
+ *  app passes the real pi adapted to PiLike. */
+export default function answerBrainExtension(pi: PiLike): Promise<void> {
+	return createAnswerBrainExtension(pi);
+}
+
+export { installAnswerBrain } from "./tools.js";
+export { effectors } from "./effectors.js";
+export { extractors } from "./features.js";
+export { createBridgeClient } from "./bridge.js";
+export type { BridgeClient } from "./bridge.js";
+export * from "./pi.js";
+export * from "./types.js";

--- a/apps/answer-brain/extension/src/pi.ts
+++ b/apps/answer-brain/extension/src/pi.ts
@@ -1,0 +1,49 @@
+// pi.ts — the minimal slice of the pi-mono extension API the body uses, so the
+// extension is unit-testable WITHOUT pi-mono (a fake `PiLike` in the tests). The
+// real `ExtensionAPI` (@earendil-works/pi-coding-agent) satisfies this shape; the
+// demo app (apps/answer-brain/app) adapts the real `pi` to it at its boundary.
+// Tool parameter schemas are real TypeBox (what pi validates LLM args against).
+
+import type { TSchema } from "typebox";
+
+/** A pi tool result: text content + structured details (move-1 examples). */
+export interface PiToolResult {
+	content: Array<{ type: "text"; text: string }>;
+	details: unknown;
+}
+
+export interface PiToolDefinition {
+	name: string;
+	label: string;
+	description: string;
+	parameters: TSchema;
+	promptGuidelines?: string[];
+	execute(
+		toolCallId: string,
+		params: Record<string, unknown>,
+		signal?: AbortSignal,
+		onUpdate?: unknown,
+		ctx?: unknown,
+	): Promise<PiToolResult>;
+}
+
+/** The tool_call event the governor intercepts. `input` is the live args object the
+ *  tool will execute with (agent-loop passes the same reference), so a mutation here
+ *  reaches execute. */
+export interface PiToolCallEvent {
+	toolName: string;
+	input: Record<string, unknown>;
+}
+
+/** undefined = allow; {block} = stop + steer (createErrorToolResult(reason) feeds the LLM). */
+export type ToolCallOutcome = { block: true; reason: string } | undefined;
+
+export type ToolCallHandler = (
+	event: PiToolCallEvent,
+	ctx?: unknown,
+) => Promise<ToolCallOutcome> | ToolCallOutcome;
+
+export interface PiLike {
+	registerTool(tool: PiToolDefinition): void;
+	on(event: "tool_call", handler: ToolCallHandler): void;
+}

--- a/apps/answer-brain/extension/src/tools.ts
+++ b/apps/answer-brain/extension/src/tools.ts
@@ -1,0 +1,169 @@
+// tools.ts — wire the body: register the tools the LLM proposes (retrieve →
+// extract → answer), accumulate the evidence across them, and GOVERN the answer
+// tool. The govern loop, manifest harness, and dispatch come from
+// @credence/brain-body; the transport (decideWithGather) and effectors are injected.
+//
+// The LLM drives the surface (pi-mono is reactive — the plan's key finding); the
+// brain governs the one call that asserts. retrieve/extract are bridge proxies that
+// grow the accumulator; answer is intercepted on tool_call, its evidence posted to
+// /decide, and the returned effector enacted (allow+rewrite / block+steer).
+
+import { dispatchEffector, govern } from "@credence/brain-body";
+import { Type } from "typebox";
+
+import type { BridgeClient } from "./bridge.js";
+import { decideWithGather } from "./daemon.js";
+import { effectors } from "./effectors.js";
+import type { PiLike, PiToolCallEvent, PiToolResult, ToolCallOutcome } from "./pi.js";
+import { type Evidence, freshEvidence } from "./types.js";
+
+export interface InstallDeps {
+	bridge: BridgeClient;
+	daemonUrl: string;
+	/** Injected for tests (fakes /decide); production uses the global fetch. */
+	fetchImpl?: typeof fetch;
+	log?: (msg: string) => void;
+	retrieveK?: number;
+}
+
+const ANSWER_TOOL = "answer";
+const GOVERN_TIMEOUT_MS = 120_000; // backstop around the whole govern loop
+
+// demo-grade owner-scope proxy: the gate uses ask.owner_question; here a lexical
+// "my X" test. owner_scoped is daemon-ignored in v0, so this is non-load-bearing.
+function ownerScopedHeuristic(q: string): boolean {
+	return /\b(my|mine|i|me|i'm|im|myself|our)\b/i.test(q);
+}
+
+function text(t: string): PiToolResult {
+	return { content: [{ type: "text", text: t }], details: {} };
+}
+
+function dedupeKeys(hits: { artifact_cache_key: string }[]): string[] {
+	return [...new Set(hits.map((h) => h.artifact_cache_key))];
+}
+
+export function installAnswerBrain(pi: PiLike, deps: InstallDeps): void {
+	const log = deps.log ?? (() => {});
+	const k = deps.retrieveK ?? 20;
+	const bridge = deps.bridge;
+	const perCallTimeout = deps.fetchImpl ? 5_000 : 60_000;
+
+	// One evidence accumulator per question; replaced wholesale on a new retrieve
+	// (statelessness across questions — the daemon/bridge hold none).
+	let evidence: Evidence = freshEvidence("");
+	let uBar: Record<string, number> | null = null;
+	const getUBar = async (): Promise<Record<string, number>> => {
+		if (uBar === null) uBar = await bridge.utility();
+		return uBar;
+	};
+
+	pi.registerTool({
+		name: "retrieve_documents",
+		label: "Retrieve documents",
+		description:
+			"Retrieve documents from the personal corpus for a point-fact question and route it. " +
+			"Call this FIRST, passing the user's question verbatim.",
+		parameters: Type.Object({
+			question: Type.String({ description: "the user's question, verbatim" }),
+		}),
+		async execute(_id, params) {
+			const question = String(params.question ?? "");
+			evidence = freshEvidence(question);
+			evidence.ownerScoped = ownerScopedHeuristic(question);
+			const route = await bridge.route(question);
+			evidence.route = route;
+			if (route === null) {
+				return text(
+					`"${question}" is not a single point-fact lookup. Answer it from general reading; ` +
+						`the answer tool will not gather typed evidence for it.`,
+				);
+			}
+			const hits = await bridge.retrieve(question, "", k);
+			evidence.hits = hits;
+			evidence.hitKeys = dedupeKeys(hits);
+			evidence.docDate = await bridge.probeRecency(evidence.hitKeys);
+			return text(
+				`Routed as "${route.construct}" (time-indexed: ${route.time_indexed}). ` +
+					`Retrieved ${hits.length} document(s). Now call extract_candidates.`,
+			);
+		},
+	});
+
+	pi.registerTool({
+		name: "extract_candidates",
+		label: "Extract candidates",
+		description:
+			"Extract the candidate values for the question from the retrieved documents. " +
+			"Call after retrieve_documents and before answer.",
+		parameters: Type.Object({}),
+		async execute() {
+			if (!evidence.route) return text("No typed lookup in progress — call retrieve_documents first.");
+			if (!evidence.hits.length) return text("No documents retrieved — call retrieve_documents first.");
+			const timeIndexed = evidence.route.time_indexed;
+			const re = await bridge.extract(
+				evidence.question,
+				evidence.hits,
+				{ doc_date: evidence.docDate },
+				timeIndexed,
+			);
+			evidence.candidates = re.candidates;
+			evidence.observations = re.observations;
+			evidence.rho = re.rho;
+			evidence.eraSplit = re.era_split;
+			// mirror gather.py: recency is pre-applied iff the router time-indexed the value.
+			evidence.appliedProbes = timeIndexed ? ["recency"] : [];
+			evidence.extracted = true;
+			return text(
+				`Extracted ${re.candidates.length} candidate value(s)` +
+					(re.era_split ? " — their documents span eras, so recency may discriminate" : "") +
+					`. Now call answer with your best value.`,
+			);
+		},
+	});
+
+	pi.registerTool({
+		name: ANSWER_TOOL,
+		label: "Answer",
+		description:
+			"Answer the question. The answer brain governs this call: it may rewrite your value to the " +
+			"evidence-backed one, send you to gather more, or withhold if the evidence is too uncertain.",
+		parameters: Type.Object({
+			value: Type.String({ description: "your best answer to the question" }),
+			credence: Type.Optional(Type.String()),
+			hedged: Type.Optional(Type.Boolean()),
+		}),
+		async execute(_id, params) {
+			// Reached only when the governor ALLOWED (report/hedge), or for a narrative
+			// question with no typed governance. `value` is the brain's by then (rewritten).
+			const value = String(params.value ?? "");
+			const credence = params.credence ? ` (credence ${String(params.credence)})` : "";
+			const hedged = params.hedged ? " [candidate set]" : "";
+			return text(`${value}${credence}${hedged}`);
+		},
+	});
+
+	pi.on("tool_call", (event: PiToolCallEvent) => {
+		if (event.toolName !== ANSWER_TOOL) return undefined;
+		// Narrative path / nothing extracted ⇒ no typed candidates to govern ⇒ let the
+		// LLM's answer through (the daemon would have nothing to decide over).
+		if (!evidence.extracted || !evidence.candidates.length) return undefined;
+
+		return govern<{ ev: Evidence; u: Record<string, number> }, ToolCallOutcome>({
+			buildRequest: async () => ({ ev: evidence, u: await getUBar() }),
+			askBrain: ({ ev, u }) =>
+				decideWithGather(ev, u, bridge, {
+					daemonUrl: deps.daemonUrl,
+					timeoutMs: perCallTimeout,
+					fetchImpl: deps.fetchImpl,
+					onStep: log,
+				}),
+			dispatch: (signal) => dispatchEffector(effectors, signal, (impl, p) => impl(p, event)),
+			// Fail CLOSED for an answer agent: a brain-unreachable failure must NOT leak an
+			// ungoverned (possibly confident-wrong) answer — withhold and say why.
+			failOpen: { block: true, reason: "The answer brain is unavailable; not answering ungoverned." },
+			timeoutMs: GOVERN_TIMEOUT_MS,
+			onError: (m, e) => log(`${m}${e === undefined ? "" : `: ${String(e)}`}`),
+		});
+	});
+}

--- a/apps/answer-brain/extension/src/types.ts
+++ b/apps/answer-brain/extension/src/types.ts
@@ -1,0 +1,87 @@
+// types.ts — the shapes the answer-brain body holds and moves. The brain↔body
+// wire types (EffectorSignal, Manifest) come from @credence/brain-body; these are
+// the answer-brain-specific ones: the two backends' responses and the per-question
+// evidence accumulator the body grows and resends (the daemon + bridge are both
+// stateless — move-3/move-4-design).
+
+/** One abstract observation — the string-blind tuple the bridge's /extract emits and
+ *  the daemon's /decide consumes verbatim (the parity boundary). The body forwards
+ *  these; it never reads the fields. */
+export interface AbstractObs {
+	reports: number;
+	group: number;
+	authority: number;
+	subject_factor: number;
+	time_factor: number;
+}
+
+export interface Hit {
+	artifact_cache_key: string;
+	[k: string]: unknown;
+}
+
+export interface RouteResult {
+	construct: string;
+	time_indexed: boolean;
+}
+
+export interface ExtractResult {
+	candidates: string[];
+	observations: AbstractObs[];
+	rho: number;
+	indeterminate: number;
+	era_split: boolean;
+}
+
+/** The daemon's POST /decide response (apps/answer-brain/daemon/server.jl). */
+export interface DecideResponse {
+	effector: string; // report | hedge | ask_clarify | abstain | gather
+	report_index: number | null;
+	value: string | null;
+	probe: string | null; // the gather probe (e.g. "recency"), or null
+	target: string | null; // the candidate to test, or null
+	credences: number[];
+	p_none: number;
+	eu: number;
+}
+
+/**
+ * The per-question evidence the body accumulates across its tool calls and resends
+ * each refinement (the daemon + bridge hold no per-question state). One of these per
+ * pi session; replaced wholesale on a new question (statelessness by construction).
+ */
+export interface Evidence {
+	question: string;
+	hits: Hit[];
+	hitKeys: string[];
+	docDate: Record<string, string | null>;
+	route: RouteResult | null;
+	ownerScoped: boolean;
+	candidates: string[];
+	observations: AbstractObs[];
+	rho: number;
+	eraSplit: boolean;
+	appliedProbes: string[]; // grows [] → ["recency"]; guarantees termination
+	extracted: boolean; // has /extract run at least once?
+	lastCredences: number[]; // from the last /decide — feeds the display features
+	lastPNone: number;
+}
+
+export function freshEvidence(question: string): Evidence {
+	return {
+		question,
+		hits: [],
+		hitKeys: [],
+		docDate: {},
+		route: null,
+		ownerScoped: false,
+		candidates: [],
+		observations: [],
+		rho: 0,
+		eraSplit: false,
+		appliedProbes: [],
+		extracted: false,
+		lastCredences: [],
+		lastPNone: 1,
+	};
+}

--- a/apps/answer-brain/extension/tests/governor.test.ts
+++ b/apps/answer-brain/extension/tests/governor.test.ts
@@ -1,0 +1,217 @@
+// Transport-free body tests: a fake pi + a fake bridge + a fake daemon (scripted
+// /decide). The §1b proof obligation — gather-then-report on the mobile class, an
+// abstain that withholds its leader, statelessness across questions — plus
+// fail-closed on an unreachable daemon and manifest verify.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import type { BridgeClient } from "../src/bridge.js";
+import { createAnswerBrainExtension } from "../src/index.js";
+import type { PiLike, PiToolCallEvent, PiToolDefinition, ToolCallHandler, ToolCallOutcome } from "../src/pi.js";
+import type { DecideResponse, ExtractResult, Hit, RouteResult } from "../src/types.js";
+
+const MANIFEST = {
+	effectors: [
+		{ name: "answer", parameters: [{ name: "value", type: "string" }] },
+		{ name: "ask-user", parameters: [{ name: "text", type: "string" }] },
+		{ name: "abstain", parameters: [{ name: "reason", type: "string" }] },
+		{ name: "gather", parameters: [{ name: "target", type: "string" }] },
+	],
+	features: [
+		{ name: "posterior-dispersion", spaceName: "dispersion-space" },
+		{ name: "leader-credence-band", spaceName: "leader-band-space" },
+		{ name: "candidates-era-split", spaceName: "era-split-space" },
+		{ name: "owner-scoped", spaceName: "owner-scoped-space" },
+	],
+};
+
+interface Harness {
+	pi: PiLike;
+	tool(name: string): PiToolDefinition;
+	govern(event: PiToolCallEvent): Promise<ToolCallOutcome>;
+}
+
+function fakePi(): Harness {
+	const tools = new Map<string, PiToolDefinition>();
+	let handler: ToolCallHandler | undefined;
+	const pi: PiLike = {
+		registerTool: (t) => void tools.set(t.name, t),
+		on: (_e, h) => void (handler = h),
+	};
+	return {
+		pi,
+		tool: (n) => {
+			const t = tools.get(n);
+			if (!t) throw new Error(`no tool ${n}`);
+			return t;
+		},
+		govern: async (event) => {
+			if (!handler) throw new Error("no tool_call handler registered");
+			return handler(event);
+		},
+	};
+}
+
+function extractResult(over: Partial<ExtractResult> = {}): ExtractResult {
+	return {
+		candidates: ["Vstale", "Vcur"],
+		observations: [{ reports: 1, group: 1, authority: 0.9, subject_factor: 1, time_factor: 1 }],
+		rho: 0.7,
+		indeterminate: 0,
+		era_split: true,
+		...over,
+	};
+}
+
+function decide(over: Partial<DecideResponse>): DecideResponse {
+	return {
+		effector: "abstain",
+		report_index: null,
+		value: null,
+		probe: null,
+		target: null,
+		credences: [],
+		p_none: 1,
+		eu: 0,
+		...over,
+	};
+}
+
+interface FakeBridgeOpts {
+	route?: RouteResult | null;
+	hits?: Hit[];
+	extractBaseline?: ExtractResult;
+	extractRecency?: ExtractResult;
+}
+
+function fakeBridge(opts: FakeBridgeOpts = {}): { bridge: BridgeClient; extractCalls: boolean[] } {
+	const extractCalls: boolean[] = [];
+	const bridge: BridgeClient = {
+		route: async () => (opts.route === undefined ? { construct: "mobile number", time_indexed: false } : opts.route),
+		retrieve: async () => opts.hits ?? [{ artifact_cache_key: "d1" }, { artifact_cache_key: "d2" }],
+		probeRecency: async () => ({ d1: "2026-01-01", d2: "2015-01-01" }),
+		extract: async (_q, _h, _cov, timeIndexed) => {
+			extractCalls.push(timeIndexed);
+			return timeIndexed && opts.extractRecency
+				? opts.extractRecency
+				: (opts.extractBaseline ?? extractResult());
+		},
+		utility: async () => ({ u_correct: 1, u_wrong: -4, u_hedged: -0.5, u_abstain: 0, lambda_int: 1 }),
+	};
+	return { bridge, extractCalls };
+}
+
+// GET /manifest → MANIFEST; POST /decide → the next scripted response.
+function fakeFetch(decideQueue: DecideResponse[], manifest: unknown = MANIFEST): typeof fetch {
+	const queue = [...decideQueue];
+	return (async (url: string) => {
+		const u = String(url);
+		if (u.endsWith("/manifest")) return { ok: true, status: 200, json: async () => manifest };
+		if (u.endsWith("/decide")) {
+			const r = queue.shift();
+			if (!r) throw new Error("fakeFetch: /decide queue exhausted");
+			return { ok: true, status: 200, json: async () => r };
+		}
+		throw new Error(`fakeFetch: unexpected url ${u}`);
+	}) as unknown as typeof fetch;
+}
+
+test("gather-then-report: the daemon steers recency, the body re-extracts and reports the current value", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult(), extractRecency: extractResult() });
+	const ff = fakeFetch([
+		decide({ effector: "gather", probe: "recency", target: "Vstale", credences: [0.55, 0.3], p_none: 0.15 }),
+		decide({ effector: "report", value: "Vcur", report_index: 1, credences: [0.1, 0.85], p_none: 0.05 }),
+	]);
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, { bridge: fb.bridge, fetchImpl: ff, log: () => {} });
+
+	await h.tool("retrieve_documents").execute("1", { question: "what is my mobile number?" });
+	await h.tool("extract_candidates").execute("2", {});
+	const event: PiToolCallEvent = { toolName: "answer", input: { value: "Vstale" } };
+	const outcome = await h.govern(event);
+
+	assert.equal(outcome, undefined, "allowed (report)");
+	assert.equal(event.input.value, "Vcur", "rewritten to the brain's current value");
+	assert.deepEqual(fb.extractCalls, [false, true], "baseline extract, then recency-applied re-extract");
+});
+
+test("abstain withholds and names the leader (abstain-show-withheld)", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult({ era_split: false }) });
+	const ff = fakeFetch([decide({ effector: "abstain", credences: [0.3, 0.25], p_none: 0.45 })]);
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, { bridge: fb.bridge, fetchImpl: ff, log: () => {} });
+
+	await h.tool("retrieve_documents").execute("1", { question: "what is my X?" });
+	await h.tool("extract_candidates").execute("2", {});
+	const event: PiToolCallEvent = { toolName: "answer", input: { value: "Vstale" } };
+	const outcome = await h.govern(event);
+
+	assert.ok(outcome?.block, "blocked");
+	assert.match(outcome.reason, /Vstale/, "names the withheld leader");
+	assert.equal(event.input.value, "Vstale", "input not rewritten (no assertion)");
+});
+
+test("statelessness: a new narrative question does not reuse the prior question's candidates", async () => {
+	let routeCall = 0;
+	const bridge: BridgeClient = {
+		route: async () => (++routeCall === 1 ? { construct: "c", time_indexed: false } : null),
+		retrieve: async () => [{ artifact_cache_key: "d1" }],
+		probeRecency: async () => ({ d1: "2026-01-01" }),
+		extract: async () => extractResult({ candidates: ["A"], era_split: false }),
+		utility: async () => ({ u_correct: 1, u_wrong: -4, u_hedged: -0.5, u_abstain: 0, lambda_int: 1 }),
+	};
+	// Only ONE /decide is scripted (q1). If q2's evidence leaked, q2 would decide → throw.
+	const ff = fakeFetch([decide({ effector: "report", value: "A", report_index: 0, credences: [0.9], p_none: 0.1 })]);
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, { bridge, fetchImpl: ff, log: () => {} });
+
+	await h.tool("retrieve_documents").execute("1", { question: "what is my id?" });
+	await h.tool("extract_candidates").execute("2", {});
+	const e1: PiToolCallEvent = { toolName: "answer", input: { value: "x" } };
+	assert.equal(await h.govern(e1), undefined);
+	assert.equal(e1.input.value, "A");
+
+	// q2 routes narrative → retrieve resets the accumulator → governor must not reuse q1's candidates.
+	await h.tool("retrieve_documents").execute("3", { question: "tell me about my week" });
+	const e2: PiToolCallEvent = { toolName: "answer", input: { value: "my own answer" } };
+	assert.equal(await h.govern(e2), undefined, "not governed (evidence reset, nothing extracted)");
+	assert.equal(e2.input.value, "my own answer", "left untouched");
+});
+
+test("fails CLOSED (withholds) when the daemon is unreachable", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult({ era_split: false }) });
+	const ff = ((url: string) => {
+		if (String(url).endsWith("/manifest")) return Promise.resolve({ ok: true, status: 200, json: async () => MANIFEST });
+		return Promise.reject(new Error("ECONNREFUSED"));
+	}) as unknown as typeof fetch;
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, { bridge: fb.bridge, fetchImpl: ff, log: () => {} });
+
+	await h.tool("retrieve_documents").execute("1", { question: "my id?" });
+	await h.tool("extract_candidates").execute("2", {});
+	const event: PiToolCallEvent = { toolName: "answer", input: { value: "draft" } };
+	const outcome = await h.govern(event);
+
+	assert.ok(outcome?.block, "fail-closed → blocked");
+	assert.match(outcome.reason, /unavailable/i);
+	assert.equal(event.input.value, "draft", "no ungoverned answer emitted");
+});
+
+test("createAnswerBrainExtension fails closed when the manifest declares an unimplemented effector", async () => {
+	const bad = { effectors: [...MANIFEST.effectors, { name: "teleport", parameters: [] }], features: MANIFEST.features };
+	const ff = fakeFetch([], bad);
+	const h = fakePi();
+	await assert.rejects(
+		() => createAnswerBrainExtension(h.pi, { bridge: fakeBridge().bridge, fetchImpl: ff, log: () => {} }),
+		/no impl for declared effector\(s\): teleport/,
+	);
+});
+
+test("registers retrieve / extract / answer tools", async () => {
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, { bridge: fakeBridge().bridge, fetchImpl: fakeFetch([]), log: () => {} });
+	assert.ok(h.tool("retrieve_documents"));
+	assert.ok(h.tool("extract_candidates"));
+	assert.ok(h.tool("answer"));
+});

--- a/apps/answer-brain/extension/tsconfig.json
+++ b/apps/answer-brain/extension/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/apps/answer-brain/tests/fixtures/README.md
+++ b/apps/answer-brain/tests/fixtures/README.md
@@ -1,0 +1,20 @@
+# answer-brain test fixtures
+
+Per the repo CLAUDE.md ("Test fixtures are commit-pinned"): regenerate only by re-running
+the named generator at a recorded SHA and updating this note. Never hand-edit a fixture to
+fix a loading bug — fix the loader / the brain.
+
+## `stage0_parity.json` — schema `answer-brain/parity/v1`
+
+The Stage-1 parity oracle (`move-1-design.md` §3). The reference `(weights, p_none, action,
+eu)` per case is the **Stage-0 lookup answerer's** output — `life_agent.core.lookup`'s
+`lookup_posterior` + `decide`, run through the credence skin.
+
+- **Generator:** `scripts/dump_parity_fixtures.py` in the **life-agent** repo.
+- **Provenance SHA:** life-agent `c1a781f` (branch `capability-sprint-extraction`).
+- **Regenerate:** `uv run python scripts/dump_parity_fixtures.py --out <path>` in life-agent,
+  then copy here and update the SHA above.
+- **Content:** 10 synthetic cases (no PII — every value is a synthetic label) covering
+  ancestry/model tempering, the subject/time covariates, and each terminal action
+  (report / hedge / ask_clarify / abstain) as a winner. Observations are integer-indexed:
+  the brain reasons over abstract candidates/groups, so candidate identity stays Python-side.

--- a/apps/answer-brain/tests/fixtures/stage0_parity.json
+++ b/apps/answer-brain/tests/fixtures/stage0_parity.json
@@ -1,0 +1,427 @@
+{
+  "schema": "answer-brain/parity/v1",
+  "channel_params": {
+    "A_alternatives": 10.0,
+    "beta_ancestry": 0.3,
+    "beta_model": 0.7,
+    "p_none_prior": 0.5,
+    "oracle_p": 0.9,
+    "prob_eps": 1e-12
+  },
+  "action_order": [
+    "report",
+    "hedge",
+    "ask_clarify",
+    "abstain"
+  ],
+  "cases": [
+    {
+      "name": "single-observation",
+      "k": 1,
+      "rho": 0.5,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -4.0,
+        "u_hedged": -0.5,
+        "lambda_int": 0.05,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.9,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.9017857142857142,
+          0.0982142857142857
+        ],
+        "p_none": 0.0982142857142857,
+        "action": "ask_clarify",
+        "eu": 0.8499999999999999
+      }
+    },
+    {
+      "name": "ancestry-temper-two-chunks-one-doc",
+      "k": 1,
+      "rho": 0.6,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -4.0,
+        "u_hedged": -0.5,
+        "lambda_int": 0.05,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.95,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.95,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.9693595411508403,
+          0.030640458849159634
+        ],
+        "p_none": 0.030640458849159634,
+        "action": "ask_clarify",
+        "eu": 0.85
+      }
+    },
+    {
+      "name": "model-temper-two-docs-agree",
+      "k": 1,
+      "rho": 0.6,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -4.0,
+        "u_hedged": -0.5,
+        "lambda_int": 0.05,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.95,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 0,
+          "group": 1,
+          "authority": 0.95,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.9891981814648106,
+          0.010801818535189347
+        ],
+        "p_none": 0.010801818535189347,
+        "action": "report",
+        "eu": 0.9459909073240532
+      }
+    },
+    {
+      "name": "covariates-subject-and-time-attenuate",
+      "k": 2,
+      "rho": 0.6,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -4.0,
+        "u_hedged": -0.5,
+        "lambda_int": 0.05,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.95,
+          "subject_factor": 0.05,
+          "time_factor": 0.3
+        },
+        {
+          "reports": 1,
+          "group": 1,
+          "authority": 0.9,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.09115192448547944,
+          0.7389220799623116,
+          0.16992599555220886
+        ],
+        "p_none": 0.16992599555220886,
+        "action": "ask_clarify",
+        "eu": 0.8499999999999999
+      }
+    },
+    {
+      "name": "none-dominant-weak-single",
+      "k": 1,
+      "rho": 0.3,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -6.0,
+        "u_hedged": -0.5,
+        "lambda_int": 0.2,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.8,
+          "subject_factor": 1.0,
+          "time_factor": 0.1
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.5547445255474452,
+          0.44525547445255476
+        ],
+        "p_none": 0.44525547445255476,
+        "action": "ask_clarify",
+        "eu": 0.7
+      }
+    },
+    {
+      "name": "dispersed-three-docs-disagree",
+      "k": 3,
+      "rho": 0.5,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -4.0,
+        "u_hedged": -0.5,
+        "lambda_int": 0.4,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.9,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 1,
+          "group": 1,
+          "authority": 0.9,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 2,
+          "group": 2,
+          "authority": 0.9,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.2849757152053079,
+          0.284975715205308,
+          0.284975715205308,
+          0.14507285438407613
+        ],
+        "p_none": 0.14507285438407613,
+        "action": "ask_clarify",
+        "eu": 0.5
+      }
+    },
+    {
+      "name": "clear-leader-ask-attractive",
+      "k": 2,
+      "rho": 0.55,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -9.0,
+        "u_hedged": -0.5,
+        "lambda_int": 0.02,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.95,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 0,
+          "group": 1,
+          "authority": 0.95,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 1,
+          "group": 2,
+          "authority": 0.9,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.8585792193502649,
+          0.10895220032996458,
+          0.03246858031977043
+        ],
+        "p_none": 0.03246858031977043,
+        "action": "ask_clarify",
+        "eu": 0.8799999999999999
+      }
+    },
+    {
+      "name": "hedge-wins-two-way-tie-costly-ask",
+      "k": 2,
+      "rho": 0.7,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -4.0,
+        "u_hedged": 0.7,
+        "lambda_int": 1.0,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.95,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 1,
+          "group": 1,
+          "authority": 0.95,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.4648399049231899,
+          0.4648399049231901,
+          0.07032019015361993
+        ],
+        "p_none": 0.07032019015361993,
+        "action": "hedge",
+        "eu": 0.3694951062779862
+      }
+    },
+    {
+      "name": "abstain-wins-dispersed-costly-ask",
+      "k": 3,
+      "rho": 0.5,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -4.0,
+        "u_hedged": -0.5,
+        "lambda_int": 1.0,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.9,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 1,
+          "group": 1,
+          "authority": 0.9,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 2,
+          "group": 2,
+          "authority": 0.9,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.2849757152053079,
+          0.284975715205308,
+          0.284975715205308,
+          0.14507285438407613
+        ],
+        "p_none": 0.14507285438407613,
+        "action": "abstain",
+        "eu": 0.0
+      }
+    },
+    {
+      "name": "report-wins-sharp-posterior",
+      "k": 1,
+      "rho": 0.9,
+      "u_bar": {
+        "u_correct": 1.0,
+        "u_abstain": 0.0,
+        "u_wrong": -1.0,
+        "u_hedged": -0.5,
+        "lambda_int": 0.5,
+        "kappa_att": 0.0
+      },
+      "observations": [
+        {
+          "reports": 0,
+          "group": 0,
+          "authority": 0.98,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 0,
+          "group": 1,
+          "authority": 0.98,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 0,
+          "group": 2,
+          "authority": 0.98,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        },
+        {
+          "reports": 0,
+          "group": 3,
+          "authority": 0.98,
+          "subject_factor": 1.0,
+          "time_factor": 1.0
+        }
+      ],
+      "expected": {
+        "weights": [
+          0.9999985072451588,
+          1.4927548412608937e-06
+        ],
+        "p_none": 1.4927548412608937e-06,
+        "action": "report",
+        "eu": 0.9999970144903175
+      }
+    }
+  ]
+}

--- a/apps/answer-brain/tests/julia/test_answer_brain.jl
+++ b/apps/answer-brain/tests/julia/test_answer_brain.jl
@@ -1,0 +1,152 @@
+#!/usr/bin/env julia
+# Role: tests
+"""
+    test_answer_brain.jl — Stage-1 parity + the net_voi forward capability.
+
+Parity: on each fixture case the native brain reproduces the Stage-0 lookup answerer's
+posterior weights, chosen effector, and EU (move-1-design §3). The reference is
+`apps/answer-brain/tests/fixtures/stage0_parity.json` (life-agent `c1a781f`). Both sides call
+the same Credence `condition`/`optimise`, so a mismatch is a porting bug in the density /
+utility construction — exactly what these cases pin.
+
+net_voi: a correctness (not parity) check of the forward gather/ask gate — a perfect probe
+prices above a useless one; cost subtracts (move-1-design §5 Open-Q3).
+
+Run from the credence repo root:
+    julia --project=. apps/answer-brain/tests/julia/test_answer_brain.jl
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "..", "src"))
+using Credence
+using Credence: weights, Kernel, Finite, PushOnly
+using JSON3
+
+include(joinpath(@__DIR__, "..", "..", "brain", "answer_brain.jl"))
+using .AnswerBrain
+include(joinpath(@__DIR__, "..", "..", "daemon", "observation_log.jl"))
+using .ObservationLog
+
+const FIXTURE = joinpath(@__DIR__, "..", "fixtures", "stage0_parity.json")
+const ATOL = 1e-9
+
+const PASSED = String[]
+function check(name::AbstractString, cond::Bool; detail::AbstractString = "")
+    if cond
+        push!(PASSED, name)
+        println("PASSED: ", name)
+    else
+        println("FAILED: ", name, " — ", detail)
+        error("assertion failed: $name")
+    end
+end
+approx(a, b; atol = ATOL) = abs(a - b) <= atol
+
+println("="^64)
+println("answer-brain Stage-1 — parity vs Stage 0 + net_voi")
+println("="^64)
+
+data = JSON3.read(read(FIXTURE, String))
+
+# ── 0. Channel-param drift guard: the fixture's params == the brain's constants ──────────
+let ch = data.channel_params
+    cp = ChannelParams(Float64(ch.A_alternatives), Float64(ch.beta_ancestry),
+                       Float64(ch.beta_model), Float64(ch.p_none_prior),
+                       Float64(ch.oracle_p), Float64(ch.prob_eps))
+    check("channel params match brain CANONICAL_CHANNEL",
+          cp.a_alternatives == CANONICAL_CHANNEL.a_alternatives &&
+          cp.beta_ancestry  == CANONICAL_CHANNEL.beta_ancestry &&
+          cp.beta_model     == CANONICAL_CHANNEL.beta_model &&
+          cp.p_none_prior   == CANONICAL_CHANNEL.p_none_prior &&
+          cp.oracle_p       == CANONICAL_CHANNEL.oracle_p &&
+          cp.prob_eps       == CANONICAL_CHANNEL.prob_eps;
+          detail = "fixture $(cp) vs brain $(CANONICAL_CHANNEL)")
+end
+
+# ── 1. Per-case parity: posterior weights, chosen effector, EU ──────────────────────────
+for case in data.cases
+    name = String(case.name)
+    k = Int(case.k)
+    rho = Float64(case.rho)
+    ubar = Dict{String, Float64}(String(kk) => Float64(vv) for (kk, vv) in case.u_bar)
+    obs = Obs[Obs(Int(o.reports), Int(o.group), Float64(o.authority),
+                  Float64(o.subject_factor), Float64(o.time_factor))
+              for o in case.observations]
+
+    post = candidate_posterior(k, obs, rho)
+    w = weights(post)
+    exp_w = [Float64(x) for x in case.expected.weights]
+    check("[$name] weight-vector length", length(w) == length(exp_w);
+          detail = "got $(length(w)) want $(length(exp_w))")
+    check("[$name] posterior weights match Stage-0",
+          all(approx(w[i], exp_w[i]) for i in eachindex(w));
+          detail = "got $w want $exp_w")
+    check("[$name] p_none matches", approx(w[end], Float64(case.expected.p_none)))
+
+    act, eu = terminal_decide(post, k, ubar)
+    check("[$name] chosen effector matches Stage-0", act == String(case.expected.action);
+          detail = "got $act want $(case.expected.action)")
+    check("[$name] EU matches Stage-0", approx(eu, Float64(case.expected.eu));
+          detail = "got $eu want $(case.expected.eu)")
+end
+
+# ── 2. net_voi forward gate (correctness, not parity) ───────────────────────────────────
+let k = 2,
+    ubar = Dict("u_correct" => 1.0, "u_wrong" => -4.0, "u_hedged" => -0.5,
+                "u_abstain" => 0.0, "lambda_int" => 1.0),
+    obs = Obs[Obs(0, 0, 0.9, 1.0, 1.0), Obs(1, 1, 0.9, 1.0, 1.0)]   # dispersed two-way
+
+    post = candidate_posterior(k, obs, 0.7)
+    atoms = collect(Float64, 0:k)
+    reveal = Finite(collect(Float64, 0:(k - 1)))
+    # perfect probe: the observation reveals which candidate is true
+    perfect = Kernel(Finite(atoms), reveal, _ -> error("gen"),
+                     (h, o) -> Int(round(h)) == Int(round(o)) ? 0.0 : -Inf;
+                     likelihood_family = PushOnly())
+    # useless probe: flat — every observation equally likely under every hypothesis
+    useless = Kernel(Finite(atoms), reveal, _ -> error("gen"),
+                     (_h, _o) -> 0.0; likelihood_family = PushOnly())
+    possible = [0.0, 1.0]
+
+    vp = voi_gather(post, k, ubar, perfect, possible, 0.0)
+    vu = voi_gather(post, k, ubar, useless, possible, 0.0)
+    check("net_voi: perfect probe is valued above a useless one", vp > vu + 1e-6;
+          detail = "perfect=$vp useless=$vu")
+    check("net_voi: a useless probe carries ~zero gross VOI", approx(vu, 0.0);
+          detail = "got $vu")
+    check("net_voi: cost subtracts pointwise",
+          approx(voi_gather(post, k, ubar, useless, possible, 0.05), -0.05))
+    check("net_voi: a perfect probe earns positive net value at small cost",
+          voi_gather(post, k, ubar, perfect, possible, 0.01) > 0.0)
+end
+
+# ── 3. Observation-log replay reconstructs the posterior exactly ────────────────────────
+let case = first(data.cases),
+    k = Int(case.k), rho = Float64(case.rho)
+
+    obs = Obs[Obs(Int(o.reports), Int(o.group), Float64(o.authority),
+                  Float64(o.subject_factor), Float64(o.time_factor))
+              for o in case.observations]
+    direct = weights(candidate_posterior(k, obs, rho))
+
+    path = tempname() * ".jsonl"
+    for o in obs
+        ObservationLog.append_observation!(path; question_id = "q", reports = o.reports,
+            group = o.group, authority = o.authority,
+            subject_factor = o.subject_factor, time_factor = o.time_factor)
+    end
+    replayed = [Obs(r.reports, r.group, r.authority, r.subject_factor, r.time_factor)
+                for r in ObservationLog.replay_observations(path)]
+    rm(path; force = true)
+
+    check("replay: same observation count", length(replayed) == length(obs);
+          detail = "got $(length(replayed)) want $(length(obs))")
+    rebuilt = weights(candidate_posterior(k, replayed, rho))
+    check("replay reconstructs the posterior exactly",
+          length(rebuilt) == length(direct) &&
+          all(approx(direct[i], rebuilt[i]) for i in eachindex(direct));
+          detail = "got $rebuilt want $direct")
+end
+
+println("\n", "="^64)
+println("answer-brain Stage-1: $(length(PASSED)) checks PASSED · $(length(data.cases)) parity cases")
+println("="^64)

--- a/apps/answer-brain/tests/julia/test_gather.jl
+++ b/apps/answer-brain/tests/julia/test_gather.jl
@@ -1,0 +1,115 @@
+#!/usr/bin/env julia
+# Role: tests
+"""
+    test_gather.jl — the daemon's gather branch (Move 4: the feature-policy).
+
+The forward gather steer as an operator-set feature-policy (move-4-design §2C, §5 Q2): when the
+terminal decision is NOT a confident report and a class-valid discriminating probe is
+available-and-unapplied, the brain emits `gather(probe, target)` instead of withholding; else the
+terminal decision stands. v0's class-valid probe is `recency` on an `era_split` (the validated
+lever, `master-plan.md` §"probe library"). `applied_probes` (body-held, resent) guarantees
+termination. `provisional_leader` names the candidate the decision mechanism would report — via
+`optimise` over the report actions, NOT `argmax(weights)` (Invariant 1). A correctness check, not a
+parity check; the scenarios are synthetic (no PII).
+
+Run from the credence repo root:
+    julia --project=. apps/answer-brain/tests/julia/test_gather.jl
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "..", "src"))
+using Credence
+
+include(joinpath(@__DIR__, "..", "..", "brain", "answer_brain.jl"))
+using .AnswerBrain
+
+const PASSED = String[]
+function check(name::AbstractString, cond::Bool; detail::AbstractString = "")
+    if cond
+        push!(PASSED, name); println("PASSED: ", name)
+    else
+        println("FAILED: ", name, " — ", detail); error("assertion failed: $name")
+    end
+end
+
+# The owner's Ū with a harsh wrong-answer cost — reporting a below-bar leader is EU-negative,
+# so a led-but-dispersed posterior withholds and the gather policy can fire.
+const UBAR = Dict("u_correct" => 1.0, "u_wrong" => -4.0, "u_hedged" => -0.5,
+                  "u_abstain" => 0.0, "lambda_int" => 1.0)
+
+println("="^64)
+println("answer-brain Move 4 — the gather feature-policy")
+println("="^64)
+
+# ── 0. Preconditions: a sharp posterior reports; a dispersed one withholds ───────────────
+sharp     = candidate_posterior(2, Obs[Obs(0, 0, 0.95, 1.0, 1.0), Obs(0, 1, 0.95, 1.0, 1.0)], 0.7)
+dispersed = candidate_posterior(2, Obs[Obs(0, 0, 0.9, 1.0, 1.0),  Obs(1, 1, 0.9, 1.0, 1.0)],  0.7)
+let (a, _, _) = decide_full(sharp, 2, UBAR)
+    check("precondition: sharp posterior → report", a == "report"; detail = "got $a")
+end
+let (a, _, _) = decide_full(dispersed, 2, UBAR)
+    check("precondition: dispersed posterior → withhold (not report)", a != "report"; detail = "got $a")
+end
+
+# ── 1. provisional_leader = the EU-leader (optimise over reports, not argmax weights) ────
+check("provisional_leader picks the dominant candidate",
+      provisional_leader(sharp, 2, UBAR) == 0;
+      detail = "got $(provisional_leader(sharp, 2, UBAR))")
+
+# ── 2. a confident report is never deflected to gather (even with era_split) ──────────────
+let (eff, idx, probe, _, _) = gather_decide(sharp, 2, UBAR; era_split = true)
+    check("report is not deflected to gather",
+          eff == "report" && idx == 0 && probe === nothing;
+          detail = "got eff=$eff idx=$idx probe=$probe")
+end
+
+# ── 3. below-bar + era-split + recency unapplied ⇒ gather(recency, leader) ────────────────
+let (eff, idx, probe, tgt, _) = gather_decide(dispersed, 2, UBAR; era_split = true)
+    check("below-bar era-split ⇒ gather(recency)", eff == "gather" && probe == "recency";
+          detail = "got eff=$eff probe=$probe")
+    check("gather names the provisional leader as target",
+          tgt == provisional_leader(dispersed, 2, UBAR); detail = "got tgt=$tgt")
+    check("a gather carries no report index", idx === nothing)
+end
+
+# ── 4. no era-split ⇒ no gather (the discriminating probe's precondition is absent) ───────
+let (eff, _, _, _, _) = gather_decide(dispersed, 2, UBAR; era_split = false)
+    check("no era-split ⇒ terminal stands (no gather)", eff != "gather"; detail = "got $eff")
+end
+
+# ── 5. recency already applied ⇒ no re-gather (termination guard) ─────────────────────────
+let (eff, _, _, _, _) = gather_decide(dispersed, 2, UBAR; era_split = true,
+                                      applied_probes = ["recency"])
+    check("recency applied ⇒ terminal stands (terminates)", eff != "gather"; detail = "got $eff")
+end
+
+# ── 6. the loop closes: stale-led ⇒ gather(recency); recency-decayed ⇒ report(current) ───
+# candidate 0 = current (2 obs); candidate 1 = stale (2 obs, slightly higher source authority,
+# so it leads modestly — below the report bar). The mobile-number class in miniature.
+let stale_obs = Obs[Obs(0, 0, 0.9, 1.0, 1.0),  Obs(0, 1, 0.9, 1.0, 1.0),
+                    Obs(1, 2, 0.95, 1.0, 1.0), Obs(1, 3, 0.95, 1.0, 1.0)]
+    stale_led = candidate_posterior(2, stale_obs, 0.7)
+    let (a, _, _) = decide_full(stale_led, 2, UBAR)
+        check("precondition: stale-led posterior is below bar (withholds)", a != "report";
+              detail = "got $a — stale leader cleared the bar; make it less corroborated")
+    end
+    let (eff, _, probe, tgt, _) = gather_decide(stale_led, 2, UBAR; era_split = true)
+        check("stale-led, below bar ⇒ gather(recency) on the stale leader",
+              eff == "gather" && probe == "recency" && tgt == 1;
+              detail = "got eff=$eff probe=$probe tgt=$tgt")
+    end
+
+    # recency applied: the stale candidate's (old) observations decay (time_factor 0.02);
+    # the current candidate's observations keep time_factor 1.0, and now clear the bar.
+    recency_obs = Obs[Obs(0, 0, 0.9, 1.0, 1.0),  Obs(0, 1, 0.9, 1.0, 1.0),
+                      Obs(1, 2, 0.95, 1.0, 0.02), Obs(1, 3, 0.95, 1.0, 0.02)]
+    after = candidate_posterior(2, recency_obs, 0.7)
+    let (eff, idx, _, _, _) = gather_decide(after, 2, UBAR; era_split = true,
+                                            applied_probes = ["recency"])
+        check("after recency ⇒ report the current candidate (loop closed)",
+              eff == "report" && idx == 0; detail = "got eff=$eff idx=$idx")
+    end
+end
+
+println("\n", "="^64)
+println("answer-brain Move 4 gather-policy: $(length(PASSED)) checks PASSED")
+println("="^64)

--- a/apps/answer-brain/tests/julia/test_gather.jl
+++ b/apps/answer-brain/tests/julia/test_gather.jl
@@ -3,11 +3,11 @@
 """
     test_gather.jl — the daemon's gather branch (Move 4: the feature-policy).
 
-The forward gather steer as an operator-set feature-policy (move-4-design §2C, §5 Q2): when the
-terminal decision is NOT a confident report and a class-valid discriminating probe is
-available-and-unapplied, the brain emits `gather(probe, target)` instead of withholding; else the
-terminal decision stands. v0's class-valid probe is `recency` on an `era_split` (the validated
-lever, `master-plan.md` §"probe library"). `applied_probes` (body-held, resent) guarantees
+The forward gather steer as an operator-set feature-policy (move-4-design §2C, §5 Q2). v0's
+class-valid probe is `recency` on an `era_split` — a **cheap re-weighting** probe, so it is applied
+BEFORE the terminal report, not gated behind it: a count-led STALE value can sit ABOVE the EU bar,
+and a confident report must rule out that staleness first (`gather.py` applies recency pre-decision;
+the daemon ports that). `applied_probes` (body-held, resent) makes it fire at most once →
 termination. `provisional_leader` names the candidate the decision mechanism would report — via
 `optimise` over the report actions, NOT `argmax(weights)` (Invariant 1). A correctness check, not a
 parity check; the scenarios are synthetic (no PII).
@@ -31,8 +31,7 @@ function check(name::AbstractString, cond::Bool; detail::AbstractString = "")
     end
 end
 
-# The owner's Ū with a harsh wrong-answer cost — reporting a below-bar leader is EU-negative,
-# so a led-but-dispersed posterior withholds and the gather policy can fire.
+# The owner's Ū with a harsh wrong-answer cost.
 const UBAR = Dict("u_correct" => 1.0, "u_wrong" => -4.0, "u_hedged" => -0.5,
                   "u_abstain" => 0.0, "lambda_int" => 1.0)
 
@@ -40,7 +39,7 @@ println("="^64)
 println("answer-brain Move 4 — the gather feature-policy")
 println("="^64)
 
-# ── 0. Preconditions: a sharp posterior reports; a dispersed one withholds ───────────────
+# ── 0. Preconditions: a sharp posterior reports; a dispersed one withholds (no era_split) ─
 sharp     = candidate_posterior(2, Obs[Obs(0, 0, 0.95, 1.0, 1.0), Obs(0, 1, 0.95, 1.0, 1.0)], 0.7)
 dispersed = candidate_posterior(2, Obs[Obs(0, 0, 0.9, 1.0, 1.0),  Obs(1, 1, 0.9, 1.0, 1.0)],  0.7)
 let (a, _, _) = decide_full(sharp, 2, UBAR)
@@ -55,11 +54,18 @@ check("provisional_leader picks the dominant candidate",
       provisional_leader(sharp, 2, UBAR) == 0;
       detail = "got $(provisional_leader(sharp, 2, UBAR))")
 
-# ── 2. a confident report is never deflected to gather (even with era_split) ──────────────
-let (eff, idx, probe, _, _) = gather_decide(sharp, 2, UBAR; era_split = true)
-    check("report is not deflected to gather",
-          eff == "report" && idx == 0 && probe === nothing;
-          detail = "got eff=$eff idx=$idx probe=$probe")
+# ── 2. era_split forces a recency-check BEFORE the report (even a sharp/confident posterior) ─
+let (eff, _, probe, _, _) = gather_decide(sharp, 2, UBAR; era_split = true)
+    check("era_split ⇒ recency-check precedes the report (even when sharp)",
+          eff == "gather" && probe == "recency"; detail = "got eff=$eff probe=$probe")
+end
+let (eff, idx, _, _, _) = gather_decide(sharp, 2, UBAR; era_split = true, applied_probes = ["recency"])
+    check("recency checked ⇒ the sharp report stands", eff == "report" && idx == 0;
+          detail = "got eff=$eff idx=$idx")
+end
+let (eff, idx, _, _, _) = gather_decide(sharp, 2, UBAR; era_split = false)
+    check("no era_split ⇒ report directly (no confound to rule out)", eff == "report" && idx == 0;
+          detail = "got eff=$eff idx=$idx")
 end
 
 # ── 3. below-bar + era-split + recency unapplied ⇒ gather(recency, leader) ────────────────
@@ -82,30 +88,31 @@ let (eff, _, _, _, _) = gather_decide(dispersed, 2, UBAR; era_split = true,
     check("recency applied ⇒ terminal stands (terminates)", eff != "gather"; detail = "got $eff")
 end
 
-# ── 6. the loop closes: stale-led ⇒ gather(recency); recency-decayed ⇒ report(current) ───
-# candidate 0 = current (2 obs); candidate 1 = stale (2 obs, slightly higher source authority,
-# so it leads modestly — below the report bar). The mobile-number class in miniature.
+# ── 6. confident-stale safety: a STALE value above the bar is recency-checked, not reported ─
+# candidate 0 = current (2 obs); candidate 1 = stale (3 obs — out-documents the current, so it
+# confidently leads ABOVE the bar at baseline). The exact trap the below-bar gate would have sprung.
 let stale_obs = Obs[Obs(0, 0, 0.9, 1.0, 1.0),  Obs(0, 1, 0.9, 1.0, 1.0),
-                    Obs(1, 2, 0.95, 1.0, 1.0), Obs(1, 3, 0.95, 1.0, 1.0)]
+                    Obs(1, 2, 0.9, 1.0, 1.0),  Obs(1, 3, 0.9, 1.0, 1.0), Obs(1, 4, 0.9, 1.0, 1.0)]
     stale_led = candidate_posterior(2, stale_obs, 0.7)
-    let (a, _, _) = decide_full(stale_led, 2, UBAR)
-        check("precondition: stale-led posterior is below bar (withholds)", a != "report";
-              detail = "got $a — stale leader cleared the bar; make it less corroborated")
+    let (a, idx, _) = decide_full(stale_led, 2, UBAR)
+        check("precondition: stale value leads CONFIDENTLY (reports the stale at baseline)",
+              a == "report" && idx == 1;
+              detail = "got act=$a idx=$idx — make the stale leader more corroborated")
     end
     let (eff, _, probe, tgt, _) = gather_decide(stale_led, 2, UBAR; era_split = true)
-        check("stale-led, below bar ⇒ gather(recency) on the stale leader",
+        check("confident-stale + era_split ⇒ gather(recency), NOT a confident-wrong report",
               eff == "gather" && probe == "recency" && tgt == 1;
               detail = "got eff=$eff probe=$probe tgt=$tgt")
     end
 
     # recency applied: the stale candidate's (old) observations decay (time_factor 0.02);
-    # the current candidate's observations keep time_factor 1.0, and now clear the bar.
+    # the current candidate's observations keep time_factor 1.0, and now lead.
     recency_obs = Obs[Obs(0, 0, 0.9, 1.0, 1.0),  Obs(0, 1, 0.9, 1.0, 1.0),
-                      Obs(1, 2, 0.95, 1.0, 0.02), Obs(1, 3, 0.95, 1.0, 0.02)]
+                      Obs(1, 2, 0.9, 1.0, 0.02), Obs(1, 3, 0.9, 1.0, 0.02), Obs(1, 4, 0.9, 1.0, 0.02)]
     after = candidate_posterior(2, recency_obs, 0.7)
     let (eff, idx, _, _, _) = gather_decide(after, 2, UBAR; era_split = true,
                                             applied_probes = ["recency"])
-        check("after recency ⇒ report the current candidate (loop closed)",
+        check("after recency ⇒ report the current candidate (loop closed, correct value)",
               eff == "report" && idx == 0; detail = "got eff=$eff idx=$idx")
     end
 end

--- a/apps/answer-brain/tests/julia/test_manifest.jl
+++ b/apps/answer-brain/tests/julia/test_manifest.jl
@@ -1,0 +1,130 @@
+#!/usr/bin/env julia
+# Role: tests
+"""
+    test_manifest.jl — GET /manifest serves the bdsl vocabulary through the ONE library parser.
+
+The de-dup proof (move-4-design §0, §5 Q1): the body has no BDSL parser; the daemon parses
+`bdsl/capabilities.bdsl` + `bdsl/features.bdsl` via `Credence.parse_all` and serves the effector /
+feature vocabulary the TS body verifies against. Checks: `manifest_dict` round-trips every declared
+effector (with its parameter (name,type)s) and every declared feature (with its space); a live HTTP
+`GET /manifest` returns the same JSON; and the served effectors are exactly the brain's action-space.
+
+Run from the credence repo root:
+    julia --project=. apps/answer-brain/tests/julia/test_manifest.jl
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "..", "src"))
+using Credence
+using JSON3
+using HTTP
+
+include(joinpath(@__DIR__, "..", "..", "brain", "answer_brain.jl"))
+using .AnswerBrain
+include(joinpath(@__DIR__, "..", "..", "daemon", "server.jl"))
+using .Server
+
+const PASSED = String[]
+function check(name::AbstractString, cond::Bool; detail::AbstractString = "")
+    if cond
+        push!(PASSED, name)
+        println("PASSED: ", name)
+    else
+        println("FAILED: ", name, " — ", detail)
+        error("assertion failed: $name")
+    end
+end
+
+# Look up a served effector / feature by name in the manifest's vectors.
+_find(items, name) = (i = findfirst(x -> x["name"] == name, items); i === nothing ? nothing : items[i])
+_has_param(eff, pname, ptype) = any(p -> p["name"] == pname && p["type"] == ptype, eff["parameters"])
+
+# ── 1. The pure function: parse the real bdsl ────────────────────────────────────────────
+man = Server.Manifest.manifest_dict(
+    capabilities_path = Server.CAPABILITIES_PATH,
+    features_path = Server.FEATURES_PATH,
+)
+
+effs = man["effectors"]
+feats = man["features"]
+
+# The served effectors are EXACTLY the brain's declared action-space (capabilities.bdsl).
+eff_names = sort([e["name"] for e in effs])
+check("effectors are {answer, ask-user, abstain, gather}",
+      eff_names == ["abstain", "answer", "ask-user", "gather"];
+      detail = "got $(eff_names)")
+
+answer = _find(effs, "answer")
+check("answer effector present", answer !== nothing)
+check("answer params = value/credence/citations (all string)",
+      _has_param(answer, "value", "string") &&
+      _has_param(answer, "credence", "string") &&
+      _has_param(answer, "citations", "string") &&
+      length(answer["parameters"]) == 3;
+      detail = "got $(answer["parameters"])")
+
+check("ask-user takes (text string)",
+      (a = _find(effs, "ask-user"); a !== nothing && _has_param(a, "text", "string") &&
+       length(a["parameters"]) == 1))
+check("abstain takes (reason string)",
+      (a = _find(effs, "abstain"); a !== nothing && _has_param(a, "reason", "string") &&
+       length(a["parameters"]) == 1))
+check("gather takes (target string)",
+      (a = _find(effs, "gather"); a !== nothing && _has_param(a, "target", "string") &&
+       length(a["parameters"]) == 1))
+
+# The four posterior-shape features, each with its declared space (features.bdsl).
+expected_features = Dict(
+    "posterior-dispersion" => "dispersion-space",
+    "leader-credence-band" => "leader-band-space",
+    "candidates-era-split" => "era-split-space",
+    "owner-scoped"         => "owner-scoped-space",
+)
+feat_names = sort([f["name"] for f in feats])
+check("features are the four posterior-shape signals",
+      feat_names == sort(collect(keys(expected_features)));
+      detail = "got $(feat_names)")
+for (fname, space) in expected_features
+    f = _find(feats, fname)
+    check("feature $(fname) → $(space)",
+          f !== nothing && f["spaceName"] == space;
+          detail = f === nothing ? "absent" : "got $(f["spaceName"])")
+end
+
+# ── 2. Live HTTP: GET /manifest serves the same JSON ─────────────────────────────────────
+const PORT = 8801
+server = start_daemon(; port = PORT)
+try
+    # Give the listener a moment to bind.
+    local ok = false
+    for _ in 1:50
+        try
+            r = HTTP.get("http://127.0.0.1:$(PORT)/ready"; retry = false, connect_timeout = 1)
+            ok = (r.status == 200); break
+        catch
+            sleep(0.1)
+        end
+    end
+    check("daemon /ready up", ok)
+
+    resp = HTTP.get("http://127.0.0.1:$(PORT)/manifest"; retry = false)
+    check("GET /manifest → 200", resp.status == 200)
+    body = JSON3.read(String(resp.body))
+    wire_effs = sort([String(e["name"]) for e in body["effectors"]])
+    wire_feats = sort([String(f["name"]) for f in body["features"]])
+    check("HTTP effectors match the pure function",
+          wire_effs == ["abstain", "answer", "ask-user", "gather"];
+          detail = "got $(wire_effs)")
+    check("HTTP features match the pure function",
+          wire_feats == sort(collect(keys(expected_features)));
+          detail = "got $(wire_feats)")
+    # Spot-check a nested parameter survives the JSON round-trip.
+    wire_answer = body["effectors"][findfirst(e -> e["name"] == "answer", body["effectors"])]
+    check("HTTP answer carries (value string)",
+          any(p -> String(p["name"]) == "value" && String(p["type"]) == "string",
+              wire_answer["parameters"]))
+finally
+    stop_daemon(server)
+end
+
+println("\n", repeat("─", 60))
+println("test_manifest.jl: ", length(PASSED), " checks passed.")

--- a/apps/answer-brain/tests/julia/test_manifest.jl
+++ b/apps/answer-brain/tests/julia/test_manifest.jl
@@ -68,9 +68,10 @@ check("ask-user takes (text string)",
 check("abstain takes (reason string)",
       (a = _find(effs, "abstain"); a !== nothing && _has_param(a, "reason", "string") &&
        length(a["parameters"]) == 1))
-check("gather takes (target string)",
-      (a = _find(effs, "gather"); a !== nothing && _has_param(a, "target", "string") &&
-       length(a["parameters"]) == 1))
+check("gather takes (probe string) (target string)",
+      (a = _find(effs, "gather"); a !== nothing &&
+       _has_param(a, "probe", "string") && _has_param(a, "target", "string") &&
+       length(a["parameters"]) == 2))
 
 # The four posterior-shape features, each with its declared space (features.bdsl).
 expected_features = Dict(

--- a/apps/answer-brain/tests/julia/test_server.jl
+++ b/apps/answer-brain/tests/julia/test_server.jl
@@ -63,6 +63,25 @@ function request_for(case)
     )
 end
 
+# A synthetic below-bar two-candidate request (dispersed, harsh u_wrong) — the Move-4 gather inputs
+# ride on the same wire. `current`/`stale` are display labels only; era_split drives the gather branch.
+function gather_request(; era_split::Bool, applied::Vector{String} = String[])
+    Dict{String, Any}(
+        "question_id"    => "wire-gather",
+        "candidates"     => ["current", "stale"],
+        "rho"            => 0.7,
+        "u_bar"          => Dict{String, Any}("u_correct" => 1.0, "u_wrong" => -4.0,
+                            "u_hedged" => -0.5, "u_abstain" => 0.0, "lambda_int" => 1.0),
+        "observations"   => [
+            Dict{String, Any}("reports" => 0, "group" => 0, "authority" => 0.9,
+                              "subject_factor" => 1.0, "time_factor" => 1.0),
+            Dict{String, Any}("reports" => 1, "group" => 1, "authority" => 0.9,
+                              "subject_factor" => 1.0, "time_factor" => 1.0)],
+        "era_split"      => era_split,
+        "applied_probes" => applied,
+    )
+end
+
 # ── 0. Drift guard: the handler's default channel == the fixture's params (move-1 §0) ────
 let ch = data.channel_params
     cp = CANONICAL_CHANNEL
@@ -143,9 +162,37 @@ let port = 8791
                         "{not json"; status_exception = false, retry = false, readtimeout = 5)
         check("HTTP /decide rejects malformed JSON with 400", bad.status == 400;
               detail = "status=$(bad.status)")
+
+        # Move 4: a gather request over live HTTP returns the forward steer.
+        ghttp = HTTP.post("http://127.0.0.1:$port/decide", ["Content-Type" => "application/json"],
+                          JSON3.write(gather_request(; era_split = true)); retry = false, readtimeout = 5)
+        gresp = JSON3.read(String(ghttp.body))
+        check("HTTP /decide gather: era_split ⇒ gather(recency)",
+              ghttp.status == 200 && String(gresp.effector) == "gather" &&
+              String(gresp.probe) == "recency";
+              detail = "status=$(ghttp.status) effector=$(get(gresp, :effector, "∅"))")
     finally
         stop_daemon(server)
     end
+end
+
+# ── 4. The gather branch over the wire (Move 4): the forward steer + backward compatibility ──
+let r = Server.decide_response(gather_request(; era_split = true))
+    check("wire gather: below-bar + era_split ⇒ gather(recency)",
+          r["effector"] == "gather" && r["probe"] == "recency";
+          detail = "got effector=$(r["effector"]) probe=$(get(r, "probe", "∅"))")
+    check("wire gather: target is a candidate string, report_index null",
+          r["target"] in ("current", "stale") && r["report_index"] === nothing;
+          detail = "target=$(r["target"]) report_index=$(r["report_index"])")
+end
+let r = Server.decide_response(gather_request(; era_split = false))
+    check("wire gather: era_split absent ⇒ no gather (Stage-2a terminal, additive fields null)",
+          r["effector"] != "gather" && r["probe"] === nothing && r["target"] === nothing;
+          detail = "got $(r["effector"])")
+end
+let r = Server.decide_response(gather_request(; era_split = true, applied = ["recency"]))
+    check("wire gather: recency applied ⇒ no re-gather (terminates)",
+          r["effector"] != "gather"; detail = "got $(r["effector"])")
 end
 
 println("\n", "="^64)

--- a/apps/answer-brain/tests/julia/test_server.jl
+++ b/apps/answer-brain/tests/julia/test_server.jl
@@ -1,0 +1,153 @@
+#!/usr/bin/env julia
+# Role: tests
+"""
+    test_server.jl — Stage-2a wire parity: the daemon's `/decide` ≡ the Stage-1 brain.
+
+The decision must survive the wire. On each Stage-0 parity fixture, `Server.decide_response` (the
+request→response handler) must reproduce the chosen effector + EU + posterior the native brain does —
+same oracle as `test_answer_brain.jl` (`tests/fixtures/stage0_parity.json`, life-agent `c1a781f`),
+now exercised through the JSON request shape. Also checks: the report index `optimise` returned agrees
+with the weight leader (Invariant-1 consistency), the handler is stateless (no cross-question bleed),
+and a live HTTP round-trip serves `/decide` + `/ready`.
+
+Run from the credence repo root:
+    julia --project=. apps/answer-brain/tests/julia/test_server.jl
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "..", "src"))
+using Credence
+using JSON3
+using HTTP
+
+include(joinpath(@__DIR__, "..", "..", "brain", "answer_brain.jl"))
+using .AnswerBrain
+include(joinpath(@__DIR__, "..", "..", "daemon", "server.jl"))
+using .Server
+
+const FIXTURE = joinpath(@__DIR__, "..", "fixtures", "stage0_parity.json")
+const ATOL = 1e-9
+
+const PASSED = String[]
+function check(name::AbstractString, cond::Bool; detail::AbstractString = "")
+    if cond
+        push!(PASSED, name)
+        println("PASSED: ", name)
+    else
+        println("FAILED: ", name, " — ", detail)
+        error("assertion failed: $name")
+    end
+end
+approx(a, b; atol = ATOL) = abs(a - b) <= atol
+
+println("="^64)
+println("answer-brain Stage-2a — daemon /decide wire parity")
+println("="^64)
+
+data = JSON3.read(read(FIXTURE, String))
+
+# Build the wire request for a fixture case. The fixtures carry abstract observations + `k` but no
+# candidate display strings (the brain is string-blind), so synthesise k labels — parity is over
+# effector/EU/weights, which don't depend on the labels.
+function request_for(case)
+    k = Int(case.k)
+    Dict{String, Any}(
+        "question_id" => "wire-$(String(case.name))",
+        "candidates"  => ["c$(j)" for j in 0:(k - 1)],
+        "rho"         => Float64(case.rho),
+        "u_bar"       => Dict{String, Any}(String(kk) => Float64(vv) for (kk, vv) in case.u_bar),
+        "observations" => [Dict{String, Any}(
+            "reports" => Int(o.reports), "group" => Int(o.group),
+            "authority" => Float64(o.authority),
+            "subject_factor" => Float64(o.subject_factor),
+            "time_factor" => Float64(o.time_factor)) for o in case.observations],
+    )
+end
+
+# ── 0. Drift guard: the handler's default channel == the fixture's params (move-1 §0) ────
+let ch = data.channel_params
+    cp = CANONICAL_CHANNEL
+    check("default channel == fixture channel_params",
+          cp.a_alternatives == Float64(ch.A_alternatives) &&
+          cp.beta_ancestry  == Float64(ch.beta_ancestry) &&
+          cp.beta_model     == Float64(ch.beta_model) &&
+          cp.p_none_prior   == Float64(ch.p_none_prior) &&
+          cp.oracle_p       == Float64(ch.oracle_p) &&
+          cp.prob_eps       == Float64(ch.prob_eps);
+          detail = "brain $(cp) vs fixture $(ch)")
+end
+
+# ── 1. Per-case wire parity: effector, EU, posterior ─────────────────────────────────────
+for case in data.cases
+    name = String(case.name)
+    k = Int(case.k)
+    resp = Server.decide_response(request_for(case))
+
+    check("[$name] wire effector == Stage-0", resp["effector"] == String(case.expected.action);
+          detail = "got $(resp["effector"]) want $(case.expected.action)")
+    check("[$name] wire EU == Stage-0", approx(Float64(resp["eu"]), Float64(case.expected.eu));
+          detail = "got $(resp["eu"]) want $(case.expected.eu)")
+
+    exp_w = [Float64(x) for x in case.expected.weights]          # candidates then NONE
+    got_w = vcat([Float64(x) for x in resp["credences"]], [Float64(resp["p_none"])])
+    check("[$name] wire posterior == Stage-0 (credences ⧺ p_none)",
+          length(got_w) == length(exp_w) &&
+          all(approx(got_w[i], exp_w[i]) for i in eachindex(exp_w));
+          detail = "got $got_w want $exp_w")
+
+    # report_index: present iff a report, and it is the weight leader (optimise ≡ argmax wₖ for the
+    # symmetric report utility — the property that lets the body display the leader without deciding).
+    if resp["effector"] == "report"
+        idx = resp["report_index"]
+        leader = argmax([Float64(x) for x in resp["credences"]]) - 1   # 0-based
+        check("[$name] report_index is the weight leader", idx == leader;
+              detail = "report_index=$idx leader=$leader")
+        check("[$name] value == candidates[report_index]",
+              resp["value"] == request_for(case)["candidates"][idx + 1])
+    else
+        check("[$name] non-report ⇒ report_index/value are null",
+              resp["report_index"] === nothing && resp["value"] === nothing)
+    end
+end
+
+# ── 2. Stateless: deciding another question between two decides of the same one changes nothing ──
+let a = first(data.cases), b = last(data.cases)
+    r1 = Server.decide_response(request_for(a))
+    _ = Server.decide_response(request_for(b))            # interleave a different question
+    r2 = Server.decide_response(request_for(a))
+    check("stateless: same request decides identically across an interleaved one",
+          r1["effector"] == r2["effector"] && approx(Float64(r1["eu"]), Float64(r2["eu"])) &&
+          all(approx(Float64(r1["credences"][i]), Float64(r2["credences"][i]))
+              for i in eachindex(r1["credences"]));
+          detail = "r1=$(r1["effector"])/$(r1["eu"]) r2=$(r2["effector"])/$(r2["eu"])")
+end
+
+# ── 3. Live HTTP round-trip: the plumbing serves /decide + /ready ────────────────────────
+let port = 8791
+    server = start_daemon(; port = port, host = "127.0.0.1")
+    try
+        ready = HTTP.get("http://127.0.0.1:$port/ready"; retry = false, readtimeout = 5)
+        check("HTTP /ready returns 200 ok",
+              ready.status == 200 && strip(String(ready.body)) == "ok")
+
+        case = first(data.cases)
+        body = JSON3.write(request_for(case))
+        http = HTTP.post("http://127.0.0.1:$port/decide", ["Content-Type" => "application/json"],
+                         body; retry = false, readtimeout = 5)
+        resp = JSON3.read(String(http.body))
+        check("HTTP /decide returns 200 + Stage-0 effector",
+              http.status == 200 && String(resp.effector) == String(case.expected.action);
+              detail = "status=$(http.status) effector=$(get(resp, :effector, "∅"))")
+        check("HTTP /decide EU matches", approx(Float64(resp.eu), Float64(case.expected.eu)))
+
+        bad = HTTP.post("http://127.0.0.1:$port/decide", ["Content-Type" => "application/json"],
+                        "{not json"; status_exception = false, retry = false, readtimeout = 5)
+        check("HTTP /decide rejects malformed JSON with 400", bad.status == 400;
+              detail = "status=$(bad.status)")
+    finally
+        stop_daemon(server)
+    end
+end
+
+println("\n", "="^64)
+println("answer-brain Stage-2a: $(length(PASSED)) checks PASSED · $(length(data.cases)) wire-parity cases")
+println("="^64)

--- a/docs/answer-brain/master-plan.md
+++ b/docs/answer-brain/master-plan.md
@@ -1,0 +1,107 @@
+# answer-brain — master plan
+
+A new credence "brain" that governs **answering** the way `credence-pi` governs tool-call
+safety. It is a `credence-pi` sibling under `apps/answer-brain` (Julia daemon on `src/Credence`;
+a pi-mono TS body arrives in Stage 2). This file is the durable in-repo record; the originating
+session plan lives at the author's `~/.claude/plans/this-repo-is-supposed-mutable-taco.md`, which
+is session-external and not guaranteed available to future sessions (CLAUDE.md §"Session memory").
+
+## Why
+
+The consumer (the `life-agent` repo) has a single-pass lookup answerer — a static
+`threshold(pool(extract(retrieve(q))))` with no feedback. Every failure was met by hand-coding one
+more covariate, with the author as the gradient (the "patch-treadmill"). The canonical failure: a
+current-state point fact (e.g. a mobile number) whose true value **is** retrieved and **is**
+extracted cleanly, but loses at low credence to a superseded value, because the posterior pools
+candidates by *corroboration count* and the owner out-documents his current life with his old one.
+No retrieval/extraction knob fixes a *semantic* current-vs-stale problem; recency/whose-document
+are decision-theoretic covariates, not ranking heuristics.
+
+The fix is to make answering a **governed, multi-step** decision: gather the discriminating
+evidence the question's words missed, value it under one posterior, and choose answer / ask / abstain
+by EU — `condition`/`optimise`/`net_voi`, no magic thresholds. That is exactly what this repo's
+axioms already are; the brain *is* credence.
+
+## Relationship to the existing skin
+
+`life-agent`'s live ask path **already** runs its candidate posterior + EU decision through this
+repo's **skin** (`apps/skin/server.jl`) over JSON-RPC: it builds a `categorical` state
+(`build_prevision`, server.jl:153), conditions a `tabular_log_density` PushOnly kernel per
+observation (`build_kernel`, server.jl:295; `condition(::CategoricalMeasure, …)`, ontology.jl:861),
+and decides via `functional_per_action` `optimise` over `Tabular` utility vectors (server.jl:870;
+`expect(::CategoricalMeasure, ::Tabular)`, ontology.jl:690).
+
+The skin is a **stateless RPC evaluator** — the Python body builds every spec and ships it; the
+skin holds no belief between calls and makes no decision of its own. The answer-brain is the
+**stateful governor**: it *holds* the candidate posterior, receives evidence as it arrives
+(observations from probes), and emits the effector (answer/ask/abstain/gather). **Same Credence
+primitives, different control flow.** The math the body currently constructs in Python ports into
+native Julia in the brain; the skin remains the in-process evaluator life-agent keeps using until
+the body cuts over (Stage 2).
+
+## Architecture (three parts; pi-mono is reactive)
+
+pi-mono's loop is LLM-driven: the model proposes every tool call; extensions can only gate, rewrite
+a result, or inject a steering message. So the brain **governs + steers**, it does not drive.
+
+1. **pi-mono answering agent (TS, Stage 2).** Proposes `retrieve` / `extract` / `probe-*` / `answer`.
+2. **answer-brain (this app).** Belief = posterior over K candidate values + an explicit NONE atom
+   (the ported `lookup_posterior` + tempered observation kernels). Effectors = `answer` / `ask-user`
+   / `abstain` / `gather`. Decide = one EU comparison; `gather`/`ask-user` priced by `net_voi − cost`
+   against the terminal payoffs, the terminal payoffs evaluated under the owner's **utility
+   posterior** (supplied by the body as Ū). Learn = `condition` on probe-result observations + owner
+   verdicts; the observation log replays the posterior on restart.
+3. **life-agent capabilities (Python).** pkm retrieval + grounded extraction + the **probe library**
+   (`core/probes.py`: recency / authority / subject / corroborate). Each probe gathers a
+   discriminating signal the brain selects by VOI. These stay in life-agent; the brain never derives.
+
+## The parity boundary (what the brain owns)
+
+Once a grounded `Observation` exists, its covariate factors (`authority`, `subject_factor`,
+`time_factor`) and its ancestry-group key are **fixed numbers**. From there the math is pure and
+deterministic:
+
+    observations + rho + Ū  ──►  candidates, posterior weights, chosen action, EU
+
+Retrieval, extraction, gather-retrieval, and covariate *projection* are the body's job (Ollama +
+DuckDB); they are **not** ported. The brain owns the boxed function — and that is exactly what
+Stage-1 parity tests pin against the validated Stage-0 Python.
+
+## Staging
+
+- **Stage 0 — DONE (in `life-agent`, committed `4b336db`).** The probe library
+  (`core/probes.py`) + the gather-augmented loop (`core/gather.py`) + the shared
+  `lookup.decide_and_record` tail, wired behind `ask --gather` and the adoption gate. Gate result:
+  monotonic improvement on every axis with **zero confident-wrong** (the hard gate held), still
+  FAIL on the 0.90 bar — the dominant blocker is the width of the owner's `u_wrong` prior, not the
+  mechanism. The owner-scoped guard (gather augments only what whose-document can protect) removed
+  the one confident-wrong gather introduced.
+- **Stage 1 — NOW (this app).** Port the Stage-0 posterior + the `net_voi` decide to native Julia
+  (`answer_brain.jl`); declare effectors/utility in `bdsl/*`; adapt the observation log + replay.
+  **Parity tests vs Stage 0 on shared fixtures (same posterior, same chosen effector); replay
+  reconstructs the posterior.** See `move-1-design.md`.
+- **Stage 2 — pi-mono body + app.** Update the upstream pi-mono checkout first; build the TS body
+  extension (effectors + feature extractors), the HTTP/SSE daemon surface (`server.jl`, deferred
+  from Stage 1 because its sensor-event schema is defined by the body), and a minimal pi-mono
+  answering app on the life-agent retrieval/extraction/probe tools. End-to-end on the eval;
+  gate-measured.
+- **Stage 3 — learning + breadth.** Owner-verdict folding via the observation log (replayable);
+  widen the eval (frozen-blind).
+
+## Final-state architecture
+
+A standing `answer-brain` daemon (Tailscale-only) that the pi-mono answering app steers: the app
+proposes retrieve/extract/probe/answer; the brain holds one candidate posterior, gathers by VOI
+until a terminal effector wins under Ū, and emits answer/ask/abstain. Owner verdicts and probe
+outcomes condition the brain through its replayable observation log. The skin stays the in-process
+evaluator for any caller that wants stateless RPC; the brain is the stateful governor for answering.
+
+## Discipline (non-negotiable)
+
+Frozen-blind at every stage (never tune utility priors / eval golds to the gate); **zero new
+confident-wrong is a hard gate** (revert any increment that adds one); the three credence invariants
+bind every decision-causing computation (Invariant 1: apps declare data and call Tier-1 primitives —
+no arithmetic on weights to select an action; Invariant 2: typed kernels/functionals; Invariant 3:
+one role per representation); never fabricate owner verdicts; PII stays in `$LIFE_AGENT_KB`, never in
+this repo; the brain **reuses** life-agent retrieval/extraction, it does not rebuild them; pi-mono is
+upstream (update before building on it, contribute changes upstream).

--- a/docs/answer-brain/move-1-design.md
+++ b/docs/answer-brain/move-1-design.md
@@ -147,6 +147,13 @@ the terminal {report/hedge/ask/abstain} decide**. Stating this honestly keeps th
 clean (no fabricated Python oracle for a path Python never ran). Push back if you'd rather defer
 `net_voi` entirely to Stage 2 and make Stage 1 pure terminal-decide parity.
 
+**Resolution (author-approved, in conversation).** Q1 → **(a)** K `report_j` actions; the
+argmax lives in `optimise`, no compute-on-weights in the app. Q2 → **defer `server.jl` to
+Stage 2**; build only the observation log + replay + a `main.jl` skeleton. Q3 → **build
+`voi_gather` + correctness-test it**, with parity scoped strictly to the posterior + terminal
+decide. All three are implemented as resolved; the parity + net_voi + replay tests are green
+(57 checks, 10 cases, `atol=1e-9`) and `tools/credence-lint check apps/answer-brain` is clean.
+
 ## 6. Risk + mitigation
 
 - **Silent port drift** in `observation_densities`/`temper_scales` (the only hand-translated

--- a/docs/answer-brain/move-1-design.md
+++ b/docs/answer-brain/move-1-design.md
@@ -1,0 +1,195 @@
+# answer-brain — Move 1 design (Stage 1: the brain daemon, native port + parity)
+
+Follows `docs/posture-4/DESIGN-DOC-TEMPLATE.md`. Strategy is settled in `master-plan.md`; this doc
+wrestles the tactics of porting the Stage-0 decision math to native Julia/Credence with parity.
+
+## 0. Final-state alignment
+
+This move converges the tip toward `master-plan.md` §"Final-state architecture" by moving the
+candidate-posterior + EU decision from Python-builds-spec / skin-evaluates into a **native Julia
+brain** that owns the belief. It deliberately leaves transient state: (a) the **HTTP/SSE daemon
+surface** (`server.jl`) is *not* built here — its sensor-event schema is defined by the pi-mono body
+(Stage 2), so building it now would be speculative and require rework; only the brain math + the
+replayable observation log land. (b) life-agent keeps driving the **skin** in production — the brain
+is exercised by tests this move, not yet by the body. Both are explicit, not drift: the brain's
+public function (observations → posterior/decision) is the Stage-2 cut-over seam and is frozen here.
+
+## 1. Purpose
+
+Port the validated Stage-0 answerer's *decision core* — the tempered candidate posterior
+(`lookup_posterior`) and the EU decision (`decide`, plus the new `net_voi`-priced gather/ask gate) —
+from `life-agent`'s Python (`src/life_agent/core/lookup.py`, `core/gather.py`) into native Julia
+(`apps/answer-brain/brain/answer_brain.jl`) on `src/Credence`, declare its effectors/utility in
+`bdsl/*`, and prove **parity**: on shared fixtures the Julia brain produces the same posterior
+weights and the same chosen effector as Stage 0, and the observation-log replay reconstructs the
+posterior exactly.
+
+## 2. Files touched
+
+Created (this app):
+- `apps/answer-brain/brain/answer_brain.jl` — the port. Pure builders (`temper_scales`,
+  `observation_densities`, `action_utilities`) + `candidate_posterior` (CategoricalMeasure + tabular
+  PushOnly kernels + `condition`) + `terminal_decide` (`optimise` over the action set) + `voi_gather`
+  (Credence `net_voi`). ~220 lines.
+- `apps/answer-brain/bdsl/capabilities.bdsl` — effectors `answer` / `ask-user` / `abstain` /
+  `gather`.
+- `apps/answer-brain/bdsl/utility.bdsl` — the stated channel parameters as declared constants
+  (`_A_ALTERNATIVES`, `_BETA_ANCESTRY`, `_BETA_MODEL`, `_P_NONE_PRIOR`, `_ORACLE_P`, the §4.1
+  covariate priors). The owner's Ū is *input* (from the body), not declared here.
+- `apps/answer-brain/bdsl/features.bdsl` — the candidate-set state vocabulary (dispersion band,
+  leader credence, era-split, owner-scoped) — declared minimal; extractors are Stage 2.
+- `apps/answer-brain/daemon/observation_log.jl` — adapted from `apps/credence-pi/daemon/`: an
+  append-only JSONL log of *grounded observations*, with a replay that reconstructs the posterior.
+- `apps/answer-brain/daemon/main.jl` — skeleton entrypoint (loads Credence; no HTTP yet).
+- `apps/answer-brain/tests/julia/test_answer_brain.jl` — parity + replay tests.
+- `apps/answer-brain/tests/fixtures/stage0_parity.json` — generated from `life-agent@4b336db`.
+- `apps/answer-brain/tests/fixtures/README.md` — fixture provenance (SHA-pinned).
+- `apps/answer-brain/README.md`.
+
+Created (in `life-agent`, the fixture generator — separate repo, separate commit):
+- `scripts/dump_parity_fixtures.py` — runs `lookup_posterior` + `decide` on synthetic observation
+  sets and dumps `(observations, rho, u_bar) → (candidates, weights, action, eu)`.
+
+Deferred to Stage 2 (named so this move does not silently drop them): `apps/answer-brain/daemon/
+server.jl` (HTTP/SSE), `apps/answer-brain/extension/*` (pi-mono TS body), the pi-mono app shell.
+
+No file in `src/` is modified — the port consumes the existing Credence surface only.
+
+## 3. Behaviour preserved
+
+The reference is Stage-0 Python at `life-agent@4b336db`. The fixtures capture, per case,
+`(candidates, weights, p_none, action, eu)` from `lookup.lookup_posterior` + `lookup.decide`. The
+Julia brain must match:
+- **Posterior weights** — to `atol=1e-9` (both call the same `condition(::CategoricalMeasure, …)`,
+  ontology.jl:861; the only port surface is the density-matrix construction, so a mismatch is a
+  porting bug in `observation_densities` or `temper_scales`).
+- **Chosen effector** — exact. With the `report_j` action formulation (Open Q1), `report_{j*}` maps
+  to Stage-0 `report`; `hedge`/`ask_clarify`/`abstain` map directly.
+- **EU of the chosen action** — to `atol=1e-9`.
+
+Cases (each a fixture): single observation; two observations same document (ancestry temper); two
+documents (model temper); covariate `subject_factor`/`time_factor` ≠ 1; NONE-dominant (junk
+agreement); dispersed (→ abstain/hedge); clear-leader-below-bar (→ ask_clarify or abstain). Any
+divergence is a bug, not a benign reassociation — there is no RNG and no quadrature on this path
+(CategoricalMeasure expectations are exact sums, ontology.jl:690).
+
+## 4. Worked end-to-end example
+
+One observation reporting candidate-0; `k=2` candidates + NONE; `rho=0.5`, `authority=0.9`,
+`subject_factor=time_factor=1.0`, single obs ⇒ `scale=1.0`, `A=10`, `P_NONE=0.5`. Copy-pasteable
+against `src/Credence` (`push!(LOAD_PATH, "…/src"); using Credence`):
+
+```julia
+atoms = Float64.(0:2)                       # cand0, cand1, NONE
+prior = CategoricalMeasure(Finite(atoms), log.([0.25, 0.25, 0.5]))
+r = 0.5 * 0.9                               # = 0.45  (rho · authority · subject · time)
+lm = log(r + (1-r)/10)                      # log_match  ≈ -0.6833
+lo = log((1-r)/10)                          # log_miss   ≈ -2.9004
+dens = [[lm, lo], [lo, lm], [lo, lo]]       # rows: V=cand0, V=cand1, V=NONE ; cols: reported t
+src, tgt = Finite(atoms), Finite(Float64.(0:1))
+kern = Kernel(src, tgt, _->error("gen"),
+              (h,o)->dens[Int(h)+1][Int(o)+1]; likelihood_family = PushOnly())
+post = condition(prior, kern, 0.0)          # observation reports candidate 0
+weights(post)                               # ≈ [0.754, 0.082, 0.164]  (cand0, cand1, NONE)
+```
+
+Decision (illustrative Ū: `u_correct=1, u_wrong=-5, u_hedged=-0.5, u_abstain=0, oracle_p=0.9,
+lambda_int=0.05` — NOT the frozen priors, a trace):
+
+```julia
+report0 = Tabular([1.0, -5.0, -5.0])        # u_c at cand0, u_w else
+report1 = Tabular([-5.0, 1.0, -5.0])
+hedge   = Tabular([-0.5, -0.5, -5.0])       # misleads only when truth is NONE
+ask     = Tabular(fill(0.9*1.0 - 0.05, 3))  # oracle price, candidate-agnostic
+abstain = Tabular([0.0, 0.0, 0.0])
+fpa = Dict("0"=>report0, "1"=>report1, "2"=>hedge, "3"=>ask, "4"=>abstain)
+optimise(post, ["0","1","2","3","4"], fpa)  # EU(report0)=0.754-5·0.246=-0.476 < EU(abstain)=0 ⇒ "4"
+```
+
+`expect(post, report0)` (ontology.jl:690) = `0.754·1 + 0.082·(-5) + 0.164·(-5) = -0.476`; abstain
+EU `0` wins — credence 0.754 sits below the `u_wrong`-implied report bar, so the brain abstains
+(holding cand0 as the named, withheld leader). This is the Stage-0 behaviour, reproduced natively.
+The argmax over `report_j` is done by `optimise` (the single decision mechanism), never by reading
+`weights` in the app — see Open Q1.
+
+## 5. Open design questions
+
+**Q1 — `report` formulation under Invariant 1.** Stage-0 Python builds one `report` action whose
+utility vector bakes in `j* = argmax(weights)` (`lookup.action_utilities`, lookup.py:606). Porting
+that literally puts an *argmax-over-weights to select behaviour* inside the constitution's
+jurisdiction — the `compute-on-weights` / `sort-for-display` precedents say comparing weights to
+branch action selection is the violation `optimise` exists to absorb. **Recommend (a):** declare K
+`report_j` actions, each a `Tabular` rewarding atom `j`; `optimise` over
+`{report_0…report_{k-1}, hedge, ask-user, abstain}` picks `report_{j*}` *because* it maximises EU —
+provably the same value as Stage-0's `report` EU (`weights[j*]·u_c + (1−weights[j*])·u_w`), so parity
+holds, and the argmax lives in the single decision mechanism. The parity test maps `report_j →
+report`. Alternative (b): keep one `report` action + an explicit `compute-on-weights` pragma. (a) is
+more de Finettian *and* arguably more correct — the action space genuinely contains "report value
+j". I propose (a). Push back if the K-way action space is judged to muddy the Stage-2 effector
+manifest (the body emits a single `answer` effector regardless).
+
+**Q2 — daemon scope this move.** The plan text says "copy credence-pi's `daemon/*`". `credence-pi`'s
+`server.jl` (673 lines) is an HTTP/SSE sensor→signal loop whose event schema (`tool-proposed`,
+`user-responded`, `tool-completed`) is the *pi-mono body's*, undefined until Stage 2.
+**Recommend:** build only `observation_log.jl` (the replay is a Stage-1 success criterion) + a
+`main.jl` skeleton this move; **defer `server.jl` to Stage 2**, where the body fixes the schema. This
+is YAGNI-correct and avoids building-then-reworking a wire surface against a guessed schema (the
+template's reviewer checklist rejects a move that needs a later move to retract it). Push back if you
+want the HTTP surface stubbed now for an earlier end-to-end smoke.
+
+**Q3 — `net_voi` decide: parity-bound or new?** Stage-0's gather loop is *unconditional* — it always
+gathers on the top candidates, then decides among the terminal actions; there is no VOI gate in the
+Python, so **`net_voi` has no Stage-0 parity counterpart**. The plan names "the `net_voi` decide" as
+a Stage-1 deliverable. **Recommend:** build `voi_gather` (Credence `net_voi`, stdlib.jl:156) as the
+brain's native forward capability and unit-test it for *correctness* (it prices a discriminating
+probe above cost, a non-discriminating one below), but scope **parity strictly to the posterior +
+the terminal {report/hedge/ask/abstain} decide**. Stating this honestly keeps the parity claim
+clean (no fabricated Python oracle for a path Python never ran). Push back if you'd rather defer
+`net_voi` entirely to Stage 2 and make Stage 1 pure terminal-decide parity.
+
+## 6. Risk + mitigation
+
+- **Silent port drift** in `observation_densities`/`temper_scales` (the only hand-translated
+  arithmetic). *Caught by:* the weights-parity fixtures at `atol=1e-9` across the 7 cases incl.
+  ancestry/model tempering and covariates — a transposed index or wrong exponent fails immediately.
+- **Tie-break divergence.** Stage-0 routes through the skin's `_sorted_action_keys` numeric sort +
+  strict `>` (server.jl:854). *Mitigation:* the brain iterates the action keys in the same
+  numeric-sorted order with the stdlib `optimise`'s strict `>` (stdlib.jl:112); a fixture with a
+  near-tie pins it.
+- **Invariant 1 violation** by computing on weights in the app. *Mitigation:* Q1's `report_j`
+  formulation removes the only argmax-on-weights; `tools/credence-lint` `check apps/answer-brain`
+  runs at end-of-move; any residual grey-zone gets a named precedent pragma, not silent passage.
+- **Float path difference** Python↔Julia. *Mitigation:* both reduce to the same log-sum + exp-
+  normalise; `atol=1e-9` is comfortably above FP noise for K≤~20 candidates. If a case ever needs a
+  looser tol, that is reported (CLAUDE.md §"Performance problems" discipline), not silently widened.
+
+## 7. Verification cadence
+
+End-of-move: `julia apps/answer-brain/tests/julia/test_answer_brain.jl` (parity + replay) green;
+`python tools/credence-lint/credence_lint.py check apps/answer-brain` clean; the life-agent fixture
+generator's own unit check green in that repo. Julia core tests are not CI-gated (CLAUDE.md), so the
+brain test runs locally and its result is reported with the actual pass count.
+
+## 8. de Finettian discipline self-audit
+
+1. **Every numerical query routed through `expect`?** Yes. Posterior weights come from `condition` +
+   `weights`; every action EU is `expect(::CategoricalMeasure, ::Tabular)`; VOI is `net_voi` →
+   `value` → `expect`. The builders (`observation_densities`, `action_utilities`) return *declared
+   data* (a `Kernel`'s log-density matrix, a `Tabular`'s values) — `declarative-construction`
+   precedent — not probabilistic properties of a prevision. No function returns a `Float64`
+   describing the posterior without `expect`.
+2. **Prevision inside a Measure or vice-versa?** No. The brain holds a `CategoricalMeasure` and
+   conditions it; no Prevision is wrapped or unwrapped by the app.
+3. **Opaque closure where declared structure fits?** The per-observation kernel uses the same
+   closed-over log-density-matrix `Kernel` the skin uses for `tabular_log_density` (server.jl:307) —
+   a `PushOnly` leaf, declared, not an `OpaqueClosure`. Utilities are `Tabular`, the declared finite-
+   space functional. No `OpaqueClosure` is introduced.
+4. **`getproperty` override on a Prevision subtype?** No — the app adds no methods to `src/` types.
+
+## Reviewer checklist
+
+- [x] §0 names transient state explicitly (deferred `server.jl`; skin still drives production).
+- [x] §5 holds three non-trivial questions Claude argues a position on.
+- [x] §8 returns "yes" on all four with the declarative-construction justification named.
+- [x] file:line citations present for every current-state reference.
+- [x] The move needs no subsequent move to retract it (deferred files are additive, not rework).

--- a/docs/answer-brain/move-2-design.md
+++ b/docs/answer-brain/move-2-design.md
@@ -1,0 +1,241 @@
+# answer-brain — Move 2 design (Stage 2a: the wire surface + the capability bridge)
+
+Follows `docs/posture-4/DESIGN-DOC-TEMPLATE.md`. Strategy is settled in `master-plan.md`; Stage 1
+(`move-1-design.md`) landed the native brain with parity. This move stands up the two **backends** the
+pi-mono body will drive — the daemon's decision wire and the life-agent capability bridge — and proves
+the wire preserves Stage-1 parity. The pi-mono app + governor extension (the body that consumes both)
+is the named successor, Move 3.
+
+## 0. Final-state alignment
+
+`master-plan.md` §"Target architecture" is three processes: a pi-mono answering agent (TS) that
+proposes `retrieve`/`extract`/`probe`/`answer`; the **answer-brain daemon** (Julia) that holds the
+candidate posterior and governs answer/gather/ask/abstain by EU; and **life-agent capabilities**
+(Python) the agent's tools call. Stage 1 built the brain's *math*; this move gives it and the Python
+capabilities a **wire**, so Move 3's body has two live, independently-tested backends to drive.
+
+Transient state, named so it is not drift:
+- **The pi-mono app + governor extension are deferred to Move 3.** They need both backends live to
+  test end-to-end; building them now would be against an unproven wire. What freezes here is the
+  body's contract — the daemon's `decide` request/response schema and the bridge's tool schema — so
+  Move 3 is additive (write the body against a frozen seam), never a retraction of this move.
+- **life-agent keeps driving the skin in production** (`core/gather.py`); this move adds a *bridge*
+  process beside it, it does not reroute the live ask path. The bridge reuses life-agent's existing
+  reads (`_retrieve_set`, `observe_hits`, `probes.*`); it rebuilds nothing.
+
+## 1. Purpose
+
+Stand up and parity-test two backends:
+
+1. **The answer-brain daemon's decision wire** (`apps/answer-brain/daemon/server.jl`): a stateless
+   HTTP surface over Stage-1's `candidate_posterior` + the `optimise`/`value` terminal decide
+   (`decide_full`). Each `POST /decide` rebuilds the posterior from the request's full observation
+   vector and returns the chosen effector + the reported candidate index. The brain math is
+   unchanged — the wire only transports its inputs (abstract observations + Ū + channel params) and
+   its outputs (effector, report index, credences). (`voi_gather`, the forward gather gate, exists
+   from Stage 1; its answer-vs-gather arbitration wires in Move 3 with the body's probe set.)
+
+2. **The life-agent parity boundary** (`src/life_agent/bridge/observations.py`): the **Python side**
+   of the parity cut (`move-1-design.md` §"parity boundary") — `to_abstract_observations` maps
+   grounded observations to **abstract integer observations** + the candidate display strings, the
+   exact shape Stage 1's fixtures encode, so the brain stays string-blind. The HTTP bridge *service*
+   wrapping this (with `retrieve`/`extract`/`probe_*` over a live corpus, pi-mono having **no MCP
+   client** — §5 Q1) is deferred to Move 3, built and validated end-to-end with its pi-mono consumer:
+   it cannot be hermetically tested without a model, and its endpoint shapes are fixed by the body's
+   needs — building it now is plumbing against an unproven consumer (the reason Stage 1 likewise
+   deferred `server.jl`).
+
+**Proof obligation:** posting Stage-1's `stage0_parity.json` cases as `decide` *wire requests*
+reproduces the native effector + EU + posterior to `atol=1e-9` (parity survives the wire); and
+`to_abstract_observations`, on synthetic observations, reproduces the candidate-indexing /
+ancestry-grouping / identity-collapse / covariate pass-through the fixtures were generated through.
+
+## 2. Files touched
+
+Created — `credence` (`apps/answer-brain/`):
+- `daemon/server.jl` — HTTP, **stateless** (§5 Resolution). `POST /decide` `{question_id,
+  observations[], candidates[], rho, u_bar, channel?} → {effector, report_index, value, credences[],
+  p_none, eu}`; `GET /ready`. Each call rebuilds the posterior from the full observation vector, so
+  no per-question state is kept server-side — isolation is by construction. Wraps
+  `AnswerBrain.candidate_posterior` + the `optimise`/`value` decide (the report value is `optimise`'s
+  action key, not an `argmax(weights)`); **adds no inference** — every numerical result is the
+  brain's. Adapts `apps/credence-pi/daemon/server.jl` (the HTTP/JSON3 plumbing, the `/ready` probe),
+  shedding the SSE machinery (§5 Q2) and the stateful posterior.
+- `daemon/main.jl` — grow the Stage-1 skeleton to `start_daemon(; port, host)` and block;
+  env-configurable (`ANSWER_BRAIN_HOST`/`ANSWER_BRAIN_PORT`). Stateless ⇒ nothing to load/replay on
+  boot, unlike credence-pi's.
+- `tests/julia/test_server.jl` — wire-parity: each `stage0_parity.json` case through
+  `decide_response` reproduces the effector + EU + posterior (≡ Stage-1 native); the report index is
+  the weight leader; statelessness (an interleaved question doesn't perturb a repeat); plus a live
+  HTTP round-trip (`/ready`, `/decide`, malformed→400). **48 checks.**
+
+Created — `life-agent` (separate repo + commit):
+- `src/life_agent/bridge/observations.py` — `to_abstract_observations`: the **observation →
+  abstract-obs** mapping (candidate canon via the existing `_candidate_key`, ancestry-group keying,
+  covariate floats → the integer obs records). The **single source** of the parity boundary — the
+  fixture oracle (`scripts/dump_parity_fixtures.py`, refactored to call it) and the Move-3 bridge
+  both use it, so the brain's input shape is provably the fixtures'.
+- `src/life_agent/bridge/__init__.py` — package docstring naming the Move-3 service deferral.
+- `tests/test_bridge.py` — **7 hermetic cases** pinning the mapping (distinct→indexed, same-doc→one
+  group, first-seen group order, date/format identity collapse, distinct-stay-separate, covariate
+  pass-through, empty). No model, no corpus.
+
+No `src/Credence` change; no `src/pkm` change; no edit to a landed migration or to `core/lookup.py`'s
+math (the mapping *calls* it).
+
+Deferred to Move 3 (named): the **life-agent bridge HTTP service** (`src/life_agent/bridge/server.py`
+— `retrieve`/`extract`/`probe_*` over the live corpus, stdlib `http.server`); `apps/answer-brain/
+extension/*` (the pi-mono TS body — `tool_call` governor + `tool_result` observer + the bridge-tool
+registrations); the minimal pi-mono answering app/harness; the end-to-end eval run + gate.
+
+## 3. Behaviour preserved
+
+The reference is Stage-1's native brain (itself parity-locked to Stage-0 Python `@4b336db`). The wire
+must not perturb it:
+- **Effector + EU** from `POST /decide` == `AnswerBrain.terminal_decide` on the same inputs, exact
+  effector / `atol=1e-9` EU. The fixtures are reused verbatim as request bodies; any divergence is a
+  serialisation or state-keying bug, not a benign reassociation (no RNG on this path).
+- **The parity boundary holds:** the daemon receives only integers + floats (reports, group,
+  authority, subject_factor, time_factor) + Ū; it never sees a candidate string.
+  `to_abstract_observations` owns all string-canon and group keying, Python-side — the single-source
+  mapping the fixture oracle also uses.
+- **Per-question isolation:** stateless ⇒ independent by construction — two `question_id`s decided in
+  one process yield independent results; a decide on one cannot be perturbed by another's
+  observations.
+
+## 4. Worked end-to-end example
+
+The `move-1-design.md` §4 case (one obs reporting candidate-0, `k=2`+NONE, Ū with `u_wrong=-5`) as a
+wire round-trip:
+
+```
+POST /decide
+{ "question_id": "q-demo",
+  "observations": [ {"reports": 0, "group": 0, "authority": 0.9,
+                     "subject_factor": 1.0, "time_factor": 1.0} ],
+  "candidates": ["alpha", "bravo"],
+  "u_bar": {"u_correct":1.0,"u_wrong":-5.0,"u_hedged":-0.5,"u_abstain":0.0,
+            "oracle_p":0.9,"lambda_int":0.05,"kappa_att":0.0} }
+→ 200
+{ "effector": "abstain", "report_index": null, "value": null,
+  "credences": [0.754, 0.082], "p_none": 0.164, "eu": 0.0 }
+```
+
+Server-side this is verbatim Stage 1: `candidate_posterior` builds the `CategoricalMeasure`, conditions
+the PushOnly kernel (weights `≈[0.754,0.082,0.164]`), `decide_full` runs `optimise` over
+`{report_0,report_1,hedge,ask,abstain}` and returns `abstain` because EU(report_0)=`0.754−5·0.246=
+−0.476` < EU(abstain)=`0`. The `report_j` argmax stays inside `optimise` (Invariant 1); on a report,
+`decide_full` returns `report_index = j*` (the action key `optimise` chose, not an `argmax(weights)`)
+and the wire fills `value = candidates[j*]`. The leading candidate is *named in the response*
+(`credences` aligned to `candidates`) so an abstain still surfaces the withheld leader — the body
+renders it.
+
+## 5. Open design questions
+
+**Q1 — TS→Python transport.** The plan said "exposed via the dormant `src/pkm/mcp_server.py`
+bridge", but pi-mono ships **no MCP client** (verified `pi-mono@12bb8dd2`: the only
+`modelcontextprotocol` references are a package name in test files; the tool surface is
+`pi.registerTool(ToolDefinition)` with a TS `execute`). So MCP-as-written is out, and a bridge
+tool's `execute` must reach Python another way. Options: **(a) an HTTP service** (life-agent runs a
+small JSON server; the pi-mono tools `fetch` it) — standard, debuggable, warm DuckDB/skin, a port to
+manage; **(b) a stdio JSON-RPC subprocess** the app spawns (mirrors how life-agent already spawns the
+Julia skin, `core/brain.py`) — no port, but the app owns a Python process lifecycle in TS. Both keep
+Python warm (a per-call `uv run` cold-start — seconds of DuckDB+model init — is rejected for an agent
+loop). **I recommend (a) HTTP:** the daemon is already HTTP, so the body talks to two uniform HTTP
+backends; lifecycle is "start two services", trivially scriptable for the eval harness; and it keeps
+pkm **frozen** (a *new* `life_agent` bridge, not life-agent tools bolted into pkm's MCP server, which
+would violate the freeze). Push back if you'd rather the app own the Python lifecycle (b) for a
+single-process-to-launch story.
+
+**Q2 — daemon wire: synchronous request/response vs. the credence-pi SSE governor.** credence-pi's
+`server.jl` is `POST /sensor` (fire-and-forget) + `GET /signals` (SSE push), because *its* decision
+can defer across a user round-trip. The answer-brain's decision is **synchronous**: given the
+observations gathered so far, decide *now*. The reactive loop is driven by the LLM's tool calls — the
+governor's `tool_call` hook blocks the `answer` call and awaits one decision — so the brain never
+needs to *push* a signal absent a tool call. **I recommend request/response** (`POST /decide`
+returns the effector in the response body): it is YAGNI-correct, ~half the server code, and the
+`ask-user` effector is realised by the body's own `ctx.ui.confirm` (pi-mono exposes it) rather than a
+second async signal. The SSE governor is the faithful-to-credence-pi alternative and the right shape
+*if* a future §16 always-on governor must push unprompted — but that is out of scope until the
+answering brain is gate-certified (`master-plan.md` §"Out of scope"). Push back if you want the SSE
+surface now for template symmetry.
+
+**Q3 — Stage 2 as one move or two.** Stage 2 is a Julia daemon + a Python bridge + a TS app +
+extension + an e2e eval — large, and the novel risk (does the wire preserve parity; does the bridge
+reproduce the mapping) is **independent of pi-mono**. **I recommend this two-move split:** Move 2
+(this doc) lands + tests both backends with no pi-mono dependency; Move 3 writes the body against the
+frozen seam and runs the gate. This de-risks the wire before the agent-loop plumbing and gives a
+green checkpoint that doesn't need a model in the loop. Alternative: one move, but then the first
+green light requires the whole stack standing — more to debug at once, against the template's
+"a move needs no later move to retract it" preference. Push back if you'd rather one move for a single
+end-to-end milestone.
+
+**Resolution (author-approved, in conversation).** Q1 → **(a) HTTP service** — a new `life_agent`
+JSON-over-HTTP bridge (stdlib `http.server`, no new dependency); `pkm` is untouched. Q2 →
+**request/response** (`POST /decide` returns the effector in the response body); the SSE governor is
+deferred with the §16 always-on governor. Q3 → **two moves** — this move lands both backends +
+wire-parity with no pi-mono dependency; Move 3 writes the body against the frozen seam and runs the
+gate. All three are the recommended options; this move is scoped accordingly.
+
+A build-time refinement (recorded here, not a re-decision, surfaced when reading the Stage-1 brain
+surface): **`/decide` is stateless.** `candidate_posterior` rebuilds the posterior from the full
+observation vector each call — a handful of `condition` calls, cheap — so no per-question posterior is
+kept server-side. The body holds the accumulated evidence and resends it each decision; the daemon
+holds the decision *policy*, not the belief state. This makes §3's per-question isolation hold *by
+construction* and voids §6's state-leak risk. The chosen report *value* comes from `optimise`'s
+returned action key (`act ≤ k ⇒ report candidate act−1`), never an `argmax(weights)` in the daemon —
+Invariant-1-pure; the body uses `credences` only to *display* the withheld leader. The observation log
+stays append-only for audit/replay and is wired to a live session in Move 3.
+
+## 6. Risk + mitigation
+
+- **Wire serialisation drift** (a float rounded, a field renamed). *Caught by:* the fixture
+  wire-parity test at `atol=1e-9` — the same oracle Stage 1 used, now exercised through JSON3.
+- **Per-question cross-talk.** *Voided by design (§5 Resolution):* `/decide` is stateless — each call
+  rebuilds the posterior from the request's full observation vector, so there is no shared mutable
+  state to leak across `question_id`s. The isolation test still pins it (two `question_id`s decided in
+  one process yield independent results).
+- **Bridge mapping divergence** from the parity oracle. *Mitigation:* there is **one** mapping
+  function (`bridge/observations.py`), called by both the fixture oracle
+  (`scripts/dump_parity_fixtures.py`) and the Move-3 bridge — divergence is impossible by
+  construction; the 7 hermetic cases pin its output.
+- **pkm-freeze violation** by extending its MCP server. *Mitigation:* Q1(a) puts the bridge in
+  `life_agent`, not `pkm`; pkm is untouched.
+- **Python cold-start** making the loop slow. *Mitigation:* the bridge is a warm long-lived process
+  (Q1); DuckDB read-only handle + `shared_brain()` initialised once at boot, as `core/lookup.py`
+  already does per ask-session.
+
+## 7. Verification cadence
+
+End-of-move (all green): `julia --project=. apps/answer-brain/tests/julia/test_server.jl` (48 checks:
+wire parity + isolation + a live HTTP round-trip — the §4 smoke, automated); the Stage-1 regression
+`test_answer_brain.jl` (57 checks — the `decide_full` refactor is safe); `uv run pytest
+tests/test_bridge.py` (7 hermetic) in life-agent; `ruff` + `mypy --strict` clean on touched
+`life_agent/` src; `tools/credence-lint/credence_lint.py check apps/answer-brain` clean (6 files). No
+model is in this move's loop, so every run is deterministic and reported with exact counts.
+
+## 8. de Finettian discipline self-audit
+
+1. **Every numerical query through `expect`?** Yes — unchanged from Stage 1. `server.jl` calls
+   `candidate_posterior` + `decide_full` (`optimise`/`value`); it computes no probability itself. It
+   serialises their outputs (`credences`, `eu`, `effector`, the report index) — transport, not
+   inference. The parity-boundary mapping computes **no** posterior at all: it returns declared data
+   (the candidate strings + the abstract-obs records).
+2. **Prevision inside a Measure or vice-versa?** No new wrapping — the daemon holds the same
+   `CategoricalMeasure` per question; the wire carries plain JSON.
+3. **Opaque closure where declared structure fits?** No new closures; the kernels/utilities are
+   Stage 1's declared `Kernel`/`Tabular`. The daemon is stateless — it holds no decision object
+   between requests at all.
+4. **`getproperty` override on a Prevision subtype?** No — neither backend adds methods to `src/`
+   types.
+
+## Reviewer checklist
+
+- [x] §0 names transient state explicitly (deferred bridge service + extension + app + e2e; skin
+      still drives prod).
+- [x] §5 holds three non-trivial questions with an argued position each (+ author-approved
+      Resolution).
+- [x] §8 returns "yes" on all four; the mapping's "no inference" claim is the load-bearing one.
+- [x] file:line / SHA citations present for current-state references (pi-mono no-MCP @12bb8dd2;
+      credence-pi `server.jl`; life-agent `lookup.py`/`dump_parity_fixtures.py`).
+- [x] The move needs no later move to retract it (deferred files are additive against a frozen seam).

--- a/docs/answer-brain/move-3-design.md
+++ b/docs/answer-brain/move-3-design.md
@@ -1,0 +1,276 @@
+# answer-brain — Move 3 design (the life-agent capability bridge: retrieve / extract / probe over HTTP)
+
+Follows `docs/posture-4/DESIGN-DOC-TEMPLATE.md`. Strategy is settled in `master-plan.md`; Move 1
+(`move-1-design.md`) landed the native brain with parity; Move 2 (`move-2-design.md`) landed the
+daemon's `decide` wire + the Python parity-boundary mapping, **deferring the bridge *service* to this
+move** (move-2 §2 "Deferred to Move 3"). This move stands up that service — the second of the two
+backends the pi-mono body drives — with no pi-mono and **no model in any loop**. The body + app +
+end-to-end gate are the named successor, **Move 4**.
+
+## 0. Final-state alignment
+
+`master-plan.md` §"Architecture" is three processes: a pi-mono answering agent (TS) that proposes
+`retrieve`/`extract`/`probe`/`answer`; the **answer-brain daemon** (Julia) that holds the candidate
+posterior and governs answer/gather/ask/abstain by EU (Move 2's `POST /decide`); and **life-agent
+capabilities** (Python) the agent's tools call. Move 2 gave the daemon its wire and froze the Python
+parity mapping (`bridge/observations.py`). This move wraps life-agent's existing reads —
+`route`/`retrieve`/`extract`/`probe_*` — in a **stateless HTTP service** so the body (Move 4) has a
+second live, independently-tested backend whose `/extract` output is *exactly* the daemon `/decide`
+input. Two backends, uniform HTTP; the body is the only process that talks to both.
+
+Transient state, named so it is not drift:
+- **The pi-mono body + app + e2e gate are deferred to Move 4.** They need a model in the loop, so
+  they cannot be hermetically tested; and the model-choice-under-PII question (the eval runs over the
+  owner's real corpus — §5 names it) is theirs to resolve, not this move's. What freezes here is the
+  bridge's tool schema, so Move 4 is additive (write the body against a frozen seam), never a
+  retraction.
+- **The bridge exposes capabilities, not policy.** `gather.py`'s Stage-0 *orchestration* — the
+  `_era_split` recency-decoupling (`core/gather.py:63`), the owner-scoped gather guard
+  (`gather.py:141`), the `_top_candidates` fan-out (`gather.py:86`) — is the **throwaway driver**
+  (`gather.py:39` "ports to the Julia answer-brain"). It does **not** move into the bridge; it
+  becomes the brain's VOI job in Move 4 (recency/subject become *probes the brain selects when they
+  discriminate*, `master-plan.md` §Why). The bridge's `/extract` takes `time_indexed` + `covariates`
+  as **inputs**; it never decides them. A bridge that re-encoded the policy would be `gather.py`
+  over HTTP — the wrong cut.
+- **life-agent keeps driving the skin in production** (`core/gather.py`, `scripts/ask.py`); this move
+  adds a *new process* beside the live ask path, it does not reroute it. The bridge **reuses** the
+  reads (`route_question`, `_retrieve_set`, `observe_hits`, `probes.*`, `to_abstract_observations`);
+  it rebuilds nothing, and touches no `pkm`.
+
+## 1. Purpose
+
+Stand up and test the **life-agent capability bridge** (`src/life_agent/bridge/server.py`): a
+long-lived, **stateless** JSON-over-HTTP service (stdlib `http.server`, no new dependency) that
+exposes life-agent's body-side reads as discrete endpoints, each a thin wrapper of an existing,
+tested function. The brain's posterior is **not** here — the bridge gathers and shapes evidence;
+the daemon (Move 2) decides. The bridge owns the **body side** of the parity boundary
+(`route`/`retrieve`/`extract`/`probe`/`abstract`), so its `/extract` returns the candidate display
+strings + the abstract integer observations the daemon consumes verbatim (`to_abstract_observations`,
+the single-source mapping Move 2 froze).
+
+**Why a service at all:** pi-mono ships **no MCP client** (verified `pi-mono@29c1504c`; move-2 §5 Q1),
+its tool surface is `pi.registerTool(ToolDefinition)` with a TS `execute`. A per-call `uv run`
+cold-start (seconds of DuckDB + model init) is rejected for an agent loop, so the reads live behind a
+warm long-lived process the body `fetch`es — uniform with the already-HTTP daemon.
+
+**Proof obligation:** (a) the HTTP contract — each endpoint's request/response shape, dispatch,
+`400` on malformed input, `/ready` — is pinned hermetically (fake corpus / monkeypatched seams, no
+model); (b) `/extract` returns precisely `to_abstract_observations`'s output (the brain stays
+string-blind), proven by routing the endpoint and the function through the **same** assertion; (c)
+statelessness — an interleaved request cannot perturb a repeat; (d) one **system** check (marked,
+live local corpus + local Ollama, fully on-machine) exercises a real `retrieve → extract → probe →
+extract` round-trip end-to-end.
+
+## 2. Files touched
+
+Created — `life-agent` (`src/life_agent/bridge/`):
+- `server.py` — the stateless HTTP service. A warm boot opens one **read-only** DuckDB handle + the
+  extraction client (Ollama) once (as `core/lookup.py` does per ask-session — move-2 §6), then serves:
+
+  | endpoint | wraps (file:line) | request → response |
+  |---|---|---|
+  | `POST /route` | `lookup.route_question` | `{question}` → `{construct, time_indexed} ⎮ null` (null ⇒ narrative path, the brain's non-lookup case) |
+  | `POST /retrieve` | `ask._retrieve_set` (`ask.py:546`, w/ `_expand_terms` `ask.py:518`) | `{question, k}` → `{hits:[{artifact_cache_key, chunk_text, score, origin}]}` |
+  | `POST /extract` | `lookup.observe_hits` (`lookup.py:447`) + `candidates_from` (`lookup.py:520`) + `to_abstract_observations` | `{question, hits, covariates?, time_indexed?, today?}` → `{candidates:[str], observations:[{reports,group,authority,subject_factor,time_factor}], rho, indeterminate}` |
+  | `POST /probe/recency` | `probes.probe_recency` | `{hit_keys}` → `{doc_date:{key: iso⎮null}}` |
+  | `POST /probe/subject` | `probes.probe_subject` (profile loaded server-side) | `{hit_keys}` → `{subject_state:{key: state}}` |
+  | `POST /probe/authority` | `probes.probe_authority` | `{hits}` → `{authority:{key:[class, value]}}` |
+  | `POST /probe/corroborate` | `probes.probe_corroborate` | `{question, leader_value, k?, exclude_keys?}` → `{hits:[…]}` |
+  | `GET /utility` | the utility posterior's `u_bar()` (`utility.py:269`) | → `{u_bar:{u_correct,u_wrong,u_hedged,u_abstain,oracle_p,lambda_int,kappa_att}}` |
+  | `GET /ready` | — | → `200 "ok"` (transport liveness, no reasoning) |
+
+  Host/port from `LIFE_AGENT_BRIDGE_HOST` (`127.0.0.1`) / `LIFE_AGENT_BRIDGE_PORT` (`8798`, adjacent
+  to the daemon's `8799`); localhost-bound so the owner's corpus never leaves the machine. **Holds no
+  per-question state**: every endpoint is a pure function of (corpus, request) — the body holds the
+  hit set + accumulated covariates and resends them, mirroring `/decide`'s discipline (move-2 §5
+  Resolution). Adapts credence-pi's HTTP plumbing (`apps/credence-pi/daemon/server.jl`'s
+  request-parse / JSON-response / `/ready` shape), **shedding** its SSE `/signals` stream + sensor
+  queue (the answer path is synchronous request/response — move-2 §5 Q2).
+- `bridge/__init__.py` — replace the "Move-3 service deferral" docstring with the service's contract.
+- `bin/answer-bridge` — debug entrypoint (`python -m life_agent.bridge.server`), mirroring
+  `bin/ask-live`; prints the bound address and the endpoint list.
+
+Created — tests (`life-agent`):
+- `tests/test_bridge_server.py` — **hermetic**: each endpoint's request/response shape over a fake
+  corpus (seams monkeypatched), dispatch + `400`-on-malformed + `/ready`; the **single-source**
+  assertion (`/extract` ≡ `to_abstract_observations` on the same observations — the brain-blindness
+  proof); statelessness (an interleaved `/extract` does not perturb a repeat). No model, no network
+  beyond loopback.
+- `tests/test_bridge_server_live.py` — **one system check** (`-m system`): boot the service on the
+  live corpus, `retrieve → extract → probe/corroborate → extract`, assert the union grows and the
+  abstract observations are well-formed. Local only; opt-in (the default `-m 'not llm and not
+  system'` excludes it).
+
+No `src/Credence` change; no `apps/answer-brain/` change (the daemon is Move 2's, frozen); no
+`src/pkm` change; no edit to `core/lookup.py` / `core/probes.py` / `scripts/ask.py` math (the bridge
+*calls* them).
+
+Deferred to Move 4 (named): `apps/answer-brain/extension/*` (the pi-mono TS body — the `tool_call`
+governor blocking `answer` on a synchronous `/decide`, the `tool_result` observer accumulating the
+evidence vector, the bridge-tool registrations); `apps/answer-brain/bdsl/*` for *answering*
+(effectors answer/ask/abstain/gather; the candidate-set features); the minimal pi-mono answering app;
+the end-to-end eval run + gate, and with it the **model-choice-under-PII** resolution (§5 Q4).
+
+## 3. Behaviour preserved
+
+The bridge introduces a process; it must change no result of any existing path.
+- **The reads are reused, not reimplemented.** Each endpoint calls the named function; `ask`,
+  `gather`, and the gate keep running unchanged. A divergence between a bridge response and a direct
+  call is a serialisation bug, never a second implementation (there is one).
+- **The parity boundary holds.** `/extract` returns only integers + floats (`reports`, `group`,
+  `authority`, `subject_factor`, `time_factor`) + the candidate strings — never an `Observation`
+  internal — via the same `to_abstract_observations` the daemon's fixtures encode. The daemon stays
+  string-blind; the bridge owns all candidate canon + ancestry-group keying, Python-side.
+- **`/extract` output is `/decide` input.** `{candidates, observations, rho}` from `/extract` + the
+  body's `u_bar` (from `/utility`) compose directly into Move 2's `POST /decide
+  {observations, candidates, rho, u_bar}` — the composition `dump_parity_fixtures.py:129‑142` already
+  performs (`to_abstract_observations` → `lookup_posterior` over the same `rho`/`u_bar`).
+- **Per-question isolation by construction.** Stateless ⇒ two questions interleaved in one process
+  cannot perturb each other; the bridge holds no shared mutable belief (the §6 cross-talk risk move-2
+  voided, voided here the same way).
+- **PII stays server-side.** The owner profile (`owner.load_profile()`, `ask.py:633`) and the
+  utility posterior (`$LIFE_AGENT_KB/utility/model.yaml`) are read **inside** the bridge; `/probe/
+  subject` and `/utility` take no profile/utility over the wire. The body is identity-free; the
+  service is localhost-bound.
+
+## 4. Worked end-to-end example
+
+The canonical mobile-number case (`master-plan.md` §Why) as the body would drive the bridge — synthetic
+values, no real datum (this is a public repo):
+
+```
+POST /retrieve  { "question": "what's my mobile number?", "k": 20 }
+→ { "hits": [ {"artifact_cache_key":"a_email_2015", "chunk_text":"…+852 5xxx…", "score":0.71, "origin":"mail/…"},
+              {"artifact_cache_key":"a_ni_form",    "chunk_text":"…05x xxx…",   "score":0.42, "origin":"docs/…"}, … ] }
+
+POST /extract   { "question":"what's my mobile number?", "hits":[…above…] }      # baseline, no covariates
+→ { "candidates":["<stale-hk>","<current-il>"],
+    "observations":[ {"reports":0,"group":0,"authority":0.90,"subject_factor":1.0,"time_factor":1.0}, … ],
+    "rho":0.5, "indeterminate":[] }
+```
+
+The body POSTs `{candidates, observations, rho}` + `u_bar` (from `GET /utility`) to the daemon's
+`POST /decide`; the corroboration-biased baseline returns `gather` (the stale value leads but below
+the `u_wrong` bar). The body steers the LLM to gather, which calls:
+
+```
+POST /probe/corroborate { "question":"what's my mobile number?", "leader_value":"<current-il>",
+                          "exclude_keys":["a_email_2015","a_ni_form"] }
+→ { "hits":[ {"artifact_cache_key":"a_payslip_2025", …}, … ] }      # high-authority current records surface
+POST /probe/recency     { "hit_keys":["a_email_2015","a_ni_form","a_payslip_2025"] }
+→ { "doc_date":{"a_email_2015":"2015-06-02","a_ni_form":null,"a_payslip_2025":"2025-04-30"} }
+POST /extract  { "question":"…", "hits":[union], "covariates":{"doc_date":{…}}, "time_indexed":true }
+→ { "candidates":["<current-il>","<stale-hk>"], "observations":[ … time_factor decays the 2015 obs … ], "rho":0.5 }
+```
+
+A second `/decide` on the re-weighted abstract observations now reports `<current-il>`. **Every datum
+the bridge returns is a read of the current corpus**; *which* probe to call and *when* to stop is the
+brain's VOI decision (Move 4) — the bridge never decides, exactly as `/decide` never retrieves.
+
+## 5. Open design questions
+
+**Q1 — endpoint granularity: one per capability, or one generic `POST /tool {name, args}`.** A
+generic dispatch is fewer handlers; per-capability endpoints are a 1:1 with the body's
+`pi.registerTool` definitions, individually `curl`-able, and let each carry its own request schema +
+`400`. **I recommend per-capability** (the table above): the body registers one tool per endpoint, so
+the surfaces match, and a typed-per-endpoint contract is easier to pin and to evolve. Push back if you
+want a single dispatch endpoint for a thinner server.
+
+**Q2 — statelessness + state threading (load-bearing).** The bridge holds **no** per-question state;
+the body holds the growing hit set + the accumulated covariates and resends them to `/extract` each
+refinement — the same "the body holds the evidence and resends" discipline `/decide` adopted (move-2
+§5 Resolution). The alternative is a session-keyed bridge that caches the hit set server-side (fewer
+bytes per call) — but it reintroduces the mutable per-question state move-2 deliberately voided, and
+its cross-talk failure mode. **I recommend stateless**, uniform with the daemon: both backends are
+pure functions of their request, the body is the sole stateful coordinator. Push back if the wire
+volume (resending hits) proves a real cost — but that is a Move-4 measurement, not a Move-3 guess.
+
+**Q3 — capability vs policy (what the bridge *is*).** The bridge exposes raw capabilities;
+`gather.py`'s policy (`_era_split`, the owner-scoped guard, the `_top_candidates` fan-out) does **not**
+move into it — `/extract` takes `time_indexed` + `covariates` as inputs, it does not compute them.
+That policy is the **brain's** VOI job in Move 4 (the redesign's whole thesis: recency/subject become
+probes selected when they discriminate, not hard-coded covariates — `master-plan.md` §Why). **I
+recommend the capability-only cut.** The cost is honest: until Move 4's brain reproduces the policy by
+VOI, no single bridge call answers the mobile case end-to-end — the *driver* (Stage-0 `gather.py`, or
+Move 4's brain) supplies the policy. This is the right boundary (the daemon owns decision; the bridge
+owns evidence), but it is the one most worth your explicit assent, because it declines to make the
+bridge a one-call answerer. Push back if you want the bridge to also expose a `gather.py`-equivalent
+*policy* endpoint (a convenience that would duplicate, and risk drifting from, the brain).
+
+**Q4 — the model-choice-under-PII question (flagged here, resolved in Move 4).** The e2e gate runs the
+agent over the owner's **real** corpus; retrieved chunks carry PII (`$LIFE_AGENT_KB`). A cloud model
+driving the loop would send that PII off-machine — disallowed. So Move 4's driver is constrained to
+**local Ollama** (PII-safe) *or* a **deterministic scripted driver** (no model sees the corpus; tests
+the brain's govern+steer in isolation, removing the LLM-tool-use confound). This move does not decide
+it — it has no model in any loop — but I name it now so Move 4's scope is not a surprise. (My lean,
+for Move 4: a scripted driver *is* the gate — confound-free, PII-safe, deterministic — with a local
+Ollama run as a separate qualitative demonstration. Not decided here.)
+
+**Resolution (author-approved, in conversation).** Q1 → **per-capability endpoints** (one HTTP
+endpoint per read, 1:1 with the body's `pi.registerTool` definitions). Q2 → **stateless** (the body
+holds the evidence and resends it; every endpoint is a pure function of (corpus, request), uniform
+with `/decide`). Q3 → **capability-only** (the bridge exposes raw `retrieve`/`extract`/`probe`;
+`gather.py`'s policy stays out and becomes the brain's VOI job in Move 4 — `/extract` takes
+`time_indexed` + `covariates` as inputs, never computing them). All three Move-3 forks took the
+recommended option; §2 is scoped accordingly. Q4 (model-choice-under-PII) is **named, not resolved**:
+it is Move 4's, and is constrained to local Ollama or a deterministic scripted driver because the
+gate runs over the owner's real corpus.
+
+## 6. Risk + mitigation
+
+- **A bridge endpoint silently re-implements a read** (drifts from `ask`/`gather`). *Mitigation:* each
+  endpoint is a one-line call of the named function; the hermetic test asserts the bridge response
+  equals the direct call. No logic in the handler beyond parse/serialise.
+- **`/extract` diverges from the daemon's expected input** (a renamed field, a float rounded).
+  *Caught by:* the single-source assertion — `/extract`'s `observations` is literally
+  `to_abstract_observations`'s output (the move-2 fixtures' oracle), so the daemon receives the shape
+  its parity tests pin.
+- **Per-question cross-talk.** *Voided by design (§5 Q2):* stateless — each call rebuilds from its
+  request; the isolation test pins it.
+- **Python cold-start / per-call model spin-up** making the loop slow. *Mitigation:* warm long-lived
+  process — read-only DuckDB handle + extraction client initialised once at boot (as `core/lookup.py`
+  already does); per call is a read, not an init.
+- **PII egress.** *Mitigation:* localhost-bound (`127.0.0.1`); profile + utility read server-side,
+  never over the wire (§3); no endpoint returns more than the cited reads already expose to `ask`.
+- **pkm-freeze violation.** *Mitigation:* the bridge is `life_agent`, calling existing reads; `pkm`
+  is untouched (the move-2 Q1(a) reason, held).
+
+## 7. Verification cadence
+
+End-of-move (all green): `uv run pytest tests/test_bridge_server.py` (hermetic — contract, dispatch,
+`400`, `/ready`, the single-source brain-blindness assertion, statelessness); `uv run pytest
+tests/test_bridge.py` (Move 2's 7 mapping cases — the bridge consumes that frozen mapping, regression
+it); `uv run pytest -m system tests/test_bridge_server_live.py` (the one live local round-trip, run
+and reported explicitly — it touches the corpus + Ollama, so it is opt-in and its result is stated,
+not assumed); `ruff` + `mypy --strict` clean on touched `life_agent/` src. No model is in the
+hermetic loop, so those runs are deterministic and reported with exact counts; the system check's
+non-determinism is disclosed where it is cited.
+
+## 8. de Finettian discipline self-audit
+
+1. **Every numerical query through `expect`?** Not applicable to the bridge — it computes **no**
+   posterior and **no** decision. It returns declared reads: hits (retrieval), the candidate strings +
+   abstract-obs records (`to_abstract_observations`, declared data), the projected covariates (the
+   probes' projections), and `u_bar()` (the utility posterior's own summary, computed in `utility.py`,
+   not here). The decision stays in the daemon (`candidate_posterior` + `optimise`/`value`); the
+   bridge transports its inputs.
+2. **Prevision inside a Measure or vice-versa?** No new wrapping — the bridge holds no Credence object
+   at all; it is a JSON service over Python reads.
+3. **Opaque closure where declared structure fits?** No closures; the bridge dispatches named
+   functions. It is stateless — it holds no decision object between requests.
+4. **`getproperty` override on a Prevision subtype?** No — the bridge adds no methods to any `src/`
+   type, in either repo.
+
+## Reviewer checklist
+
+- [x] §0 names transient state explicitly (body + app + e2e + model-choice deferred to Move 4; policy
+      stays in the brain not the bridge; skin still drives prod).
+- [x] §5 holds non-trivial questions with an argued position each (Q3 capability-vs-policy is the
+      load-bearing cut; Q4 names the PII constraint it does *not* yet resolve) + author-approved
+      Resolution.
+- [x] §8 returns "no posterior here" on all four; the "the bridge decides nothing" claim is
+      load-bearing and matches §2 (no `lookup_posterior`/`decide` call in any handler).
+- [x] file:line / SHA citations present for current-state references (pi-mono no-MCP @29c1504c;
+      `ask.py`/`lookup.py`/`probes.py`/`gather.py`/`utility.py` seams; credence-pi `server.jl` shape).
+- [x] The move needs no later move to retract it (deferred files are additive against the frozen
+      bridge schema; the bridge changes no existing path).

--- a/docs/answer-brain/move-3-design.md
+++ b/docs/answer-brain/move-3-design.md
@@ -70,7 +70,7 @@ Created — `life-agent` (`src/life_agent/bridge/`):
   | endpoint | wraps (file:line) | request → response |
   |---|---|---|
   | `POST /route` | `lookup.route_question` | `{question}` → `{construct, time_indexed} ⎮ null` (null ⇒ narrative path, the brain's non-lookup case) |
-  | `POST /retrieve` | `ask._retrieve_set` (`ask.py:546`, w/ `_expand_terms` `ask.py:518`) | `{question, k}` → `{hits:[{artifact_cache_key, chunk_text, score, origin}]}` |
+  | `POST /retrieve` | `retrieval.retrieve_set` + `retrieval.build_query` (`core/retrieval.py`) | `{question, terms?, k}` → `{hits:[{artifact_cache_key, chunk_text, score, origin}]}` |
   | `POST /extract` | `lookup.observe_hits` (`lookup.py:447`) + `candidates_from` (`lookup.py:520`) + `to_abstract_observations` | `{question, hits, covariates?, time_indexed?, today?}` → `{candidates:[str], observations:[{reports,group,authority,subject_factor,time_factor}], rho, indeterminate}` |
   | `POST /probe/recency` | `probes.probe_recency` | `{hit_keys}` → `{doc_date:{key: iso⎮null}}` |
   | `POST /probe/subject` | `probes.probe_subject` (profile loaded server-side) | `{hit_keys}` → `{subject_state:{key: state}}` |
@@ -89,6 +89,26 @@ Created — `life-agent` (`src/life_agent/bridge/`):
 - `bridge/__init__.py` — replace the "Move-3 service deferral" docstring with the service's contract.
 - `bin/answer-bridge` — debug entrypoint (`python -m life_agent.bridge.server`), mirroring
   `bin/ask-live`; prints the bound address and the endpoint list.
+
+**As-built refinements (Move 3 — author to confirm).** Three small, behaviour-preserving
+departures from the literal plan, forced by an import boundary the plan hadn't surfaced — the
+retrieval seam (`_retrieve_set`) lived in `scripts/ask.py`, and `src/` deliberately does not
+import from `scripts/` (the boundary `core/matching.py:5` also keeps). All three are tested and
+the full hermetic suite (916) stays green:
+1. **New `src/life_agent/core/retrieval.py`** — `build_query` + `retrieve_set` (verbatim from
+   `ask.py`). `ask.py` re-exports both (its callers and tests are unchanged), so there is still
+   exactly ONE retrieval implementation (the §6 "no second read" obligation). This is the only
+   edit to `ask.py` — its retrieval/expansion *math* is untouched; the functions just moved into
+   the package so the bridge can reuse them.
+2. **`/retrieve` takes `terms` as an INPUT** (the body supplies expansion), rather than the
+   bridge calling the cloud `_expand_terms`. This is the same cut §0/§3 make for `/extract`'s
+   covariates — expansion is a reformulation *policy* (the driver's job), and keeping it out
+   holds the bridge model-free + cloud-free (§8), strengthening the localhost/PII posture.
+   `_expand_terms` stays script-side; Move 4's body owns when to expand.
+3. **Boot reuses `tasks/read.pkm_root()`** for root resolution (not `ask._pkm_root`), again to
+   avoid the `src↛scripts` import; the bridge opens its own read-only catalogue handle with FTS.
+   `BridgeServer` is single-threaded (the body drives one sequential loop) — concurrency, and
+   with it duckdb thread-safety, is the Move-4 measurement §5 Q2 already defers.
 
 Created — tests (`life-agent`):
 - `tests/test_bridge_server.py` — **hermetic**: each endpoint's request/response shape over a fake

--- a/docs/answer-brain/move-4-design.md
+++ b/docs/answer-brain/move-4-design.md
@@ -115,12 +115,19 @@ is run and its result stated, not assumed.
 - The **`gather` branch**: `decide_full` (or a wrapping `decide`) gains the feature-policy. `/decide`'s
   request grows (additively) to carry the body-projected features the daemon cannot see — `era-split`,
   `owner-scoped` (the body holds the covariate/profile info); the daemon computes the posterior-derived
-  features itself — `dispersion`, `leader-band` (from the `weights` it builds). When the features signal
-  a class-valid discriminating covariate-probe **and** the leader is not above the report bar, return
-  `effector="gather"` with `(probe, target)`; else the terminal decision as today. The policy
-  *approximates* VOI for cheap re-weighting probes (it prices no kernel — §5 Q2): it defers a below-bar
-  answer when a covariate the policy deems class-valid is available (recency for era-split contact
-  facts; **not** subject, which mis-fires there).
+  features itself — `dispersion`, `leader-band` (from the `weights` it builds). v0's class-valid probe
+  is **`recency` on `era-split`**, and because it is a *cheap re-weight* it is applied BEFORE the
+  terminal report, not gated behind it: whenever `era-split` holds and `recency` is unapplied the daemon
+  returns `gather(recency, target)`; the body re-weights and re-decides; `applied_probes` (resent) makes
+  it fire at most once → termination. A confident report must first rule out the staleness `era-split`
+  signals — a count-led STALE value can sit ABOVE the bar, so reporting it un-checked is a
+  confident-wrong (`gather.py` applies recency pre-decision; the daemon ports that). The **below-bar
+  EU-gate belongs to the EXPENSIVE gather** — `corroborate` (fetch new docs), the deferred §5 Q2
+  successor; `subject` (mis-fires on contact facts) stays deselected. The policy prices no kernel (§5
+  Q2): for the cheap recency re-weight, "apply when class-valid" is the VOI-sound move. **(Build
+  correction:** an earlier below-bar gate on recency was removed when TDD/parity surfaced the
+  confident-stale-report it would emit — the daemon must recency-check a count-led stale leader even
+  above the bar.**)**
 - `daemon/server.jl` — extend the `/decide` response with the optional `gather` fields; add `/manifest`
   dispatch. (`/decide`'s existing terminal shape is unchanged — additive.)
 - The operator-set policy params (§5 Q5) live in `bdsl/utility.bdsl` (or a sibling `policy.bdsl`):
@@ -161,12 +168,13 @@ would wrongly drop the truth-bearing admin doc.
 
 1. **retrieve / extract (baseline).** Body → `/retrieve` → hits; → `/extract` (no covariates) →
    candidates `{V_current, V_stale(2015), …}`, abstract observations, `rho`. Accumulated.
-2. **decide.** Body composes evidence + `u_bar` (`/utility`) → `POST /decide`. The daemon builds the
-   posterior — `V_stale` leads by corroboration count (the documented failure) — and reads the
-   posterior-shape features: `candidates-era-split = yes`, `leader-band = near-bar` (leads, not robust),
-   `owner-scoped = yes`. The **feature-policy** fires: era-split + owner-scoped + ¬above-bar ⇒ recency is
-   the class-valid discriminator ⇒ `effector = gather`, `probe = recency`, `target = V_stale/leader`.
-   (Subject is **not** selected: the policy knows subject mis-fires on owner-scoped contact facts.)
+2. **decide.** Body composes evidence + `u_bar` (`/utility`) → `POST /decide` with `era_split = yes`.
+   The daemon builds the posterior — `V_stale` leads by corroboration count (the documented failure),
+   whether that leaves it below the bar (it would abstain) or, when it out-documents enough, ABOVE it (it
+   would confidently report the *stale* value). Either way the **feature-policy** fires on `era-split`:
+   recency is the class-valid discriminator and a cheap re-weight, so it precedes the report ⇒ `effector
+   = gather`, `probe = recency`, `target = V_stale`. (Subject is **not** selected: it mis-fires on
+   owner-scoped contact facts.)
 3. **gather (steer).** Body receives `gather(recency)` → `/probe/recency` → `doc_date` covariate →
    `/extract` **with the recency covariate** → observations whose `time_factor` decays `V_stale`.
    Accumulated (the union only grows).
@@ -193,9 +201,12 @@ extension (drags the SSE bus); lift it wholesale into a lib (forces a false tran
 **Q2 — the gather steer (RESOLVED: feature-policy in the daemon).** The daemon emits `gather(probe,
 target)` from the posterior-shape features (`features.bdsl`) via an operator-set policy that encodes
 which covariate is class-valid (recency for era-split contact facts; subject for the partner-ID class;
-**not** subject for contact facts). It is honest as a *calibrated policy approximating VOI for cheap
-re-weighting probes when the leader is below bar* — not yet a kernel-priced VOI. Generalises the
-`gather` effector param `(target)` → `(probe, target)` — a "deployment event" per `capabilities.bdsl`.
+**not** subject for contact facts). It is honest as a *calibrated policy approximating VOI* — not yet a
+kernel-priced VOI. The cheap class-valid re-weight (recency on era-split) is applied **before** the
+report, not gated by it — a count-led stale leader can sit above the bar, so it must be recency-checked
+first (TDD/parity caught a below-bar gate that would have emitted that confident-wrong); the below-bar
+EU-gate is reserved for the **expensive** `corroborate` (successor). Generalises the `gather` effector
+param `(target)` → `(probe, target)` — a "deployment event" per `capabilities.bdsl`.
 *Named successor:* wire the existing `voi_gather` (`answer_brain.jl:204`) with per-probe predictive
 kernels (and a learned per-cell policy from the Stage-3 observation log). *Rejected:* full `voi_gather`
 now (kernel-modelling risk on the gate); model-selects-probes (covariate selection leaves the brain —

--- a/docs/answer-brain/move-4-design.md
+++ b/docs/answer-brain/move-4-design.md
@@ -1,0 +1,279 @@
+# answer-brain — Move 4 design (the body: a shared brain-body lib + the answer-brain governor + the scripted gate)
+
+Follows `docs/posture-4/DESIGN-DOC-TEMPLATE.md`. Strategy is settled in `master-plan.md`; Moves 1–3
+landed the native brain (`move-1-design.md`), the stateless `POST /decide` wire (`move-2-design.md`),
+and the life-agent capability bridge (`move-3-design.md`, in the life-agent repo). Those three gave
+the body its two backends — the **daemon** (`/decide`, the single reasoner) and the **bridge**
+(`/route`/`/retrieve`/`/extract`/`/probe`/`/utility`, the evidence). This move builds the **body**
+that drives them in a govern+steer loop, and — per the author's de-dup decision (§5 Q1) — extracts the
+transport-agnostic machinery into a **shared library** so the body is thin and credence-pi can later
+stand on the same lib. It closes the loop end-to-end and **certifies it with a gate**.
+
+## 0. Final-state alignment
+
+`master-plan.md` §"Architecture" is three processes: a pi-mono answering agent (TS) proposing
+`retrieve`/`extract`/`probe`/`answer`; the **answer-brain daemon** (Julia) holding the candidate
+posterior and governing answer/gather/ask/abstain by EU; and **life-agent capabilities** (Python) the
+agent's tools call. Moves 1–3 stood up the daemon and the bridge and froze the parity boundary
+(`/extract`'s output is exactly `/decide`'s input). This move builds the **first process** — and
+factors its reusable core out, because it is the second consumer of a pattern credence-pi already has.
+
+**The de-dup cut (the author's decision, §5 Q1 — `+ shared TS governor lib`).** credence-pi is one
+*application* of credence; the **library is `src/`**, and it already owns the **one BDSL parser**
+(`src/parse.jl`, `src/eval.jl`) — credence-pi's Julia daemon parses its manifest *through the library*.
+The duplication is credence-pi's TS `extension/src/manifest.ts` (159 lines), a **second parser in a
+second language**. So "use credence as a library" is not "share a TS parser" — it is **own the manifest
+in the library and have the body fetch it**: the answer-brain daemon loads its `*.bdsl` via the library
+parser and serves the vocabulary (`GET /manifest`); the body verifies against it and **has no parser**.
+The transport-agnostic governor (effector dispatch + fail-open/timeout + a pluggable "ask-the-brain"
+seam) is extracted into a **shared TS lib** both bodies can stand on. The two bodies' *transports*
+differ and are **not** shared: credence-pi reaches its daemon over an async SSE `/sensor`+`/signals` bus
+with a correlation table; answer-brain's daemon is the stateless synchronous `POST /decide`
+(`move-2-design.md`; `daemon/server.jl`), so its body just `await fetch`es. The lib abstracts what is
+common (dispatch, fail-open, manifest-verify, wire types) and injects what differs (the transport).
+
+Transient state, named so it is not drift:
+- **credence-pi is not refactored in this move** (§5 Q1 resolution: "migrates later"). The shared lib is
+  written for answer-brain (its first consumer) but with a transport seam credence-pi fits; credence-pi
+  adopts it — and drops its TS parser — in a later move. The lib's API is the thing that freezes here.
+- **The gather decision is an operator-set *feature-policy*, not yet full `voi_gather`** (§5 Q2). The
+  per-probe VOI primitive is built and tested in the brain (`brain/answer_brain.jl:204`, `voi_gather`),
+  but pricing a probe *without running it* needs a predictive kernel per probe (the date distribution
+  for recency, the hit count for corroborate) — a modelling task deferred to a named successor. v0's
+  brain emits `gather` from the **posterior-shape features** the bdsl already declares; honest about
+  being a calibrated policy, not yet a kernel-priced VOI.
+- **The gate is a scripted deterministic driver; the LLM app is a demo** (§5 Q3). The eval runs over the
+  owner's real PII corpus, so no cloud model may drive it. A scripted Python driver (reusing
+  `run_eval`) certifies the closed loop confound-free; the pi-mono TS body + a minimal local-Ollama app
+  is the qualitative demonstration, **off the gate's critical path**. The loop stays thin in both (the
+  daemon owns every decision), so the two drivers are not a meaningful re-implementation of policy.
+- **The daemon stays stateless; learning is Stage 3.** Serving `GET /manifest` is a read; the gather
+  policy is operator-set (cold). The observation-log replay + owner-verdict folding (`master-plan.md`
+  Stage 3) is *not* in this move.
+
+## 1. Purpose
+
+Build the **answer-brain body** as a pi-mono extension (TS) that runs the govern+steer loop over the
+two HTTP backends, factoring its transport-agnostic core into a **shared brain-body library**; add the
+daemon's **`gather` branch** (feature-policy) and **`GET /manifest`**; and stand up the **scripted gate**
+that certifies the closed loop. Concretely, the body: registers `retrieve`/`extract`/`probe_*`/`answer`
+as tools that proxy to the bridge; **observes** their results to accumulate the evidence vector
+(candidates + abstract observations + covariates); and **governs the `answer` tool** — on each `answer`
+attempt it posts the accumulated evidence to `/decide` and, by the returned effector, **allows** the
+answer (rewriting it to the decided value + citations), **blocks-and-steers** to the brain-chosen probe
+(`gather`), **blocks** to an owner question (`ask-user`), or **blocks** to a withheld-leader abstention
+(`abstain`). The brain is the only reasoner; the body transports its inputs and enacts its outputs.
+
+**Why a shared lib (not a copy, not credence-pi-wholesale):** the manifest-verify, the effector
+dispatch, the fail-open/timeout discipline, and the wire types are identical needs across brains; the
+*transport* and the *effector/feature impls* are not. Extracting the former and injecting the latter is
+the only cut that de-duplicates without forcing credence-pi's async bus onto answer-brain's sync daemon.
+
+**Proof obligation:** (a) the shared lib is unit-tested transport-free (a fake `askBrain`, a fake
+manifest) — dispatch, fail-open on timeout/unreachable, manifest-verify rejects a missing effector;
+(b) the body's loop is tested against a **fake daemon + fake bridge** (scripted effector replies) —
+the mobile-class case gathers-then-reports, an abstain withholds its leader, statelessness across
+questions; (c) the daemon's `gather` branch + `/manifest` are tested in Julia (the feature-policy emits
+`gather(recency)` on the era-split case, `report` after; `/manifest` round-trips the bdsl vocabulary);
+(d) the **gate** — the scripted driver over the eval through the real bridge+daemon — runs and is
+reported (zero new confident-wrong; `P(Δ>δ)` stated); (e) one opt-in **local-Ollama** end-to-end demo
+is run and its result stated, not assumed.
+
+## 2. Files touched
+
+### A. The shared brain-body library (NEW) — `packages/brain-body/` (name/placement: §5 Q4)
+- `src/manifest.ts` — `fetchManifest(daemonUrl) → {effectors, features}` (`GET /manifest`) + `verify(reg)`
+  that every declared effector/feature has a registered impl. **No BDSL parsing** — the daemon (via the
+  library `src/parse.jl`) is the one parser. Replaces credence-pi's `manifest.ts`.
+- `src/governor.ts` — the transport-agnostic skeleton: `govern(event, {extractFeatures, askBrain,
+  dispatch, timeoutMs})` → assemble features/evidence → `await askBrain(request)` (injected) → dispatch
+  the returned effector → **fail-open** on timeout/throw. The pluggable seam is `askBrain`.
+- `src/dispatch.ts` — the effector-registry + feature-extractor harness, parametric over the impl types
+  (`EffectorRegistry<TImpl>`, `assembleFeatures(extractors, ctx)`).
+- `src/wire.ts` — shared wire types: the effector signal, the manifest shape, the fail-open result.
+- `package.json`, `tsconfig.json`, `tests/*` (transport-free unit tests).
+
+### B. The answer-brain body (NEW) — `apps/answer-brain/extension/`
+- `src/transport.ts` — the injected synchronous `askBrain`: compose the accumulated evidence + `u_bar`
+  (bridge `/utility`) → `POST /decide` → the effector signal. Plus the bridge proxies
+  (`/route`/`/retrieve`/`/extract`/`/probe/*`).
+- `src/effectors.ts` — `answer` / `ask-user` / `abstain` / `gather` impls, each enacting a pi-mono
+  `tool_call` decision (`{block, reason}` per `ToolCallEventResult`, pi-mono `…/extensions/types.ts:1020`;
+  `answer` may rewrite `event.input` in place to the decided value+citations).
+- `src/features.ts` — the posterior-shape extractors (dispersion / leader-band / era-split /
+  owner-scoped) reading the accumulated evidence; their outputs are sent to `/decide` so the daemon's
+  feature-policy can read them (the body computes the *projections*; the daemon *decides*).
+- `src/tools.ts` — `pi.registerTool` for `retrieve`/`extract`/`probe_*`/`answer` (bridge proxies) + the
+  per-session evidence accumulator (observe `tool_result`, grow candidates+observations+covariates).
+- `src/index.ts` — the `ExtensionFactory` (`(pi) => …`, pi-mono `…/types.ts:1416`): wire the lib's
+  `govern` + the injected transport + effectors + features + tools.
+- `package.json`, `tsconfig.json`, `README.md`, `tests/*` (fake daemon + fake bridge).
+
+### C. The answer-brain daemon (MODIFY) — `apps/answer-brain/daemon/`, `brain/answer_brain.jl`
+- `GET /manifest` — load `bdsl/capabilities.bdsl` + `bdsl/features.bdsl` through the library parser and
+  serve `{effectors, features}`. Read-only; the daemon stays stateless.
+- The **`gather` branch**: `decide_full` (or a wrapping `decide`) gains the feature-policy. `/decide`'s
+  request grows (additively) to carry the body-projected features the daemon cannot see — `era-split`,
+  `owner-scoped` (the body holds the covariate/profile info); the daemon computes the posterior-derived
+  features itself — `dispersion`, `leader-band` (from the `weights` it builds). When the features signal
+  a class-valid discriminating covariate-probe **and** the leader is not above the report bar, return
+  `effector="gather"` with `(probe, target)`; else the terminal decision as today. The policy
+  *approximates* VOI for cheap re-weighting probes (it prices no kernel — §5 Q2): it defers a below-bar
+  answer when a covariate the policy deems class-valid is available (recency for era-split contact
+  facts; **not** subject, which mis-fires there).
+- `daemon/server.jl` — extend the `/decide` response with the optional `gather` fields; add `/manifest`
+  dispatch. (`/decide`'s existing terminal shape is unchanged — additive.)
+- The operator-set policy params (§5 Q5) live in `bdsl/utility.bdsl` (or a sibling `policy.bdsl`):
+  calibration priors, committed before results, folded from outcomes later, **never fitted to the gate**.
+
+### D. The scripted gate driver (NEW) — life-agent `scripts/`
+- A deterministic Python driver: per eval question, run the loop (`/route` → `/retrieve` → `/extract`
+  → `/decide` → [`gather` → `/probe/*` → `/extract` → `/decide`]\* → terminal) against the live
+  bridge+daemon, collect the outcome, feed `run_eval --gate`. Reuses the Move-3 bridge clients and the
+  existing gate. **This is the certification.** No model drives it; extraction is the bridge's local
+  model (already how `/extract` works).
+
+### E. The minimal pi-mono app (NEW) — `apps/answer-brain/app/`
+- `createAgentSession({ model, resourceLoader })` (pi-mono `examples/sdk/01-minimal.ts`,
+  `06-extensions.ts:30` inline factory) loading the answer-brain extension; a **local-Ollama** `Model`
+  (`{provider:"ollama", baseUrl:"http://localhost:11434/v1"}`); a system prompt instructing the agent to
+  retrieve→extract→probe→answer. The **demo**, not the gate.
+
+## 3. Behaviour preserved
+
+- **The parity boundary is untouched.** `/extract`'s output is still exactly `/decide`'s input
+  (`bridge/observations.py` / `to_abstract_observations`, frozen Move 2–3); the body composes them, it
+  does not reshape them. The brain's terminal decision (`decide_full`) is byte-for-byte as Stage 1/2a —
+  the `gather` branch is additive; with the feature-policy disabled, the daemon reduces to Move-2a.
+- **The single reasoner holds.** No posterior or EU is computed in the body or the lib; both transport
+  the brain's outputs. `gather` selection is the *daemon's* (the feature-policy is Julia, beside
+  `decide_full`), not the body's and not the model's.
+- **Statelessness holds.** The daemon rebuilds the posterior per `/decide`; the body holds the
+  per-question evidence and resends it (uniform with the bridge); per-question isolation by construction.
+- **pkm is untouched; life-agent's live ask path is untouched.** The gate driver is a new script beside
+  `ask.py`; it reuses the bridge, rebuilding nothing.
+
+## 4. Worked end-to-end example (the mobile-number class — synthetic, no PII)
+
+The canonical failure (`master-plan.md` §Context): the *current* value is retrieved and cleanly
+extracted but loses on corroboration count to a *stale 2015-era* value; recency would flip it, subject
+would wrongly drop the truth-bearing admin doc.
+
+1. **retrieve / extract (baseline).** Body → `/retrieve` → hits; → `/extract` (no covariates) →
+   candidates `{V_current, V_stale(2015), …}`, abstract observations, `rho`. Accumulated.
+2. **decide.** Body composes evidence + `u_bar` (`/utility`) → `POST /decide`. The daemon builds the
+   posterior — `V_stale` leads by corroboration count (the documented failure) — and reads the
+   posterior-shape features: `candidates-era-split = yes`, `leader-band = near-bar` (leads, not robust),
+   `owner-scoped = yes`. The **feature-policy** fires: era-split + owner-scoped + ¬above-bar ⇒ recency is
+   the class-valid discriminator ⇒ `effector = gather`, `probe = recency`, `target = V_stale/leader`.
+   (Subject is **not** selected: the policy knows subject mis-fires on owner-scoped contact facts.)
+3. **gather (steer).** Body receives `gather(recency)` → `/probe/recency` → `doc_date` covariate →
+   `/extract` **with the recency covariate** → observations whose `time_factor` decays `V_stale`.
+   Accumulated (the union only grows).
+4. **decide again.** `POST /decide` with the augmented evidence. The posterior re-weights; `V_current`
+   now leads **above the report bar** ⇒ `effector = report`, `value = V_current`. Body **allows** the
+   `answer` tool, rewriting its input to `V_current` + the supporting citations.
+5. **contrast — the abstain path.** Had the leader stayed dispersed (no discriminating covariate, or
+   below bar after gathering), `/decide` returns `abstain`; the body **blocks** `answer` and emits the
+   withheld leader (the abstain-show-withheld contract), never a confident wrong.
+
+The loop closed because the **brain** selected recency (not subject) from the posterior's shape — the
+gather.py policy, now brain-resident, EU-gated, and replaceable by `voi_gather`/learning.
+
+## 5. Open design questions
+
+**Q1 — the de-dup boundary (RESOLVED, author, in conversation: `+ shared TS governor lib`).** The one
+BDSL parser stays in the credence library (`src/parse.jl`/`eval.jl`); the daemon serves the manifest
+(`GET /manifest`); the body fetches+verifies and has **no** TS parser. The transport-agnostic governor
+(dispatch + fail-open + the `askBrain` seam + wire types) is extracted into `packages/brain-body/`,
+which answer-brain consumes now and credence-pi migrates onto later. The two transports (credence-pi
+async SSE; answer-brain sync `/decide`) are injected, not shared. *Rejected:* copy credence-pi's
+extension (drags the SSE bus); lift it wholesale into a lib (forces a false transport unification).
+
+**Q2 — the gather steer (RESOLVED: feature-policy in the daemon).** The daemon emits `gather(probe,
+target)` from the posterior-shape features (`features.bdsl`) via an operator-set policy that encodes
+which covariate is class-valid (recency for era-split contact facts; subject for the partner-ID class;
+**not** subject for contact facts). It is honest as a *calibrated policy approximating VOI for cheap
+re-weighting probes when the leader is below bar* — not yet a kernel-priced VOI. Generalises the
+`gather` effector param `(target)` → `(probe, target)` — a "deployment event" per `capabilities.bdsl`.
+*Named successor:* wire the existing `voi_gather` (`answer_brain.jl:204`) with per-probe predictive
+kernels (and a learned per-cell policy from the Stage-3 observation log). *Rejected:* full `voi_gather`
+now (kernel-modelling risk on the gate); model-selects-probes (covariate selection leaves the brain —
+the subject-hurts-contact-facts regression).
+
+**Q3 — the gate driver (RESOLVED: scripted Python gate + local-Ollama demo).** A deterministic scripted
+driver (reusing `run_eval`) over the bridge+daemon certifies the closed loop, PII-safe and
+confound-free; the pi-mono TS body + minimal local-Ollama app is the qualitative demo, off the gate's
+critical path. The daemon owns every decision, so the two thin drivers do not re-implement policy.
+*Rejected:* the LLM app as the gate (tool-use nondeterminism confounds the decision-math measurement).
+
+**Q4 — the shared lib's name + placement + workspace (OPEN, minor).** Proposed: a new top-level
+`packages/brain-body/` (credence has no TS workspace today — only `apps/credence-pi/extension/` — so this
+adds a root npm/pnpm workspace, or answer-brain depends on it by relative path). `brain-body` is a
+placeholder name (alternatives: `pi-governor`, `credence-body`). **I recommend** `packages/brain-body/`
++ a minimal root workspace; push back on the name or if you'd rather it live under `apps/_shared/`.
+
+**Q5 — the operator-set gather-policy params (OPEN, minor).** The feature→probe policy thresholds are
+calibration priors. **I recommend** declaring them in `bdsl/utility.bdsl` (or a sibling `policy.bdsl`),
+committed before the gate runs and folded from the outcomes stream later — **never fitted to the gate**
+(the frozen-blind discipline). Push back if you want them as Julia constants instead of bdsl.
+
+## 6. Risk + mitigation
+
+- **The shared lib over-abstracts the transport.** *Mitigation:* the seam is a single injected
+  `askBrain(request) → Promise<EffectorSignal>`; the lib knows nothing of SSE vs fetch. Proven by
+  answer-brain's sync impl now; credence-pi's async impl (later) is the second consumer that validates
+  it — until then the lib is shaped by one consumer and that is stated.
+- **The body re-implements the gather *policy* (the thing we moved to the brain).** *Mitigation:* the
+  body's `gather` effector only *enacts* a steer the daemon chose (`probe`, `target` come over the wire);
+  the feature *extractors* compute projections, not decisions; the policy is Julia, beside `decide_full`.
+- **A confident-wrong slips in via the gather loop.** *Mitigation (hard gate):* a covariate that mis-
+  fires (subject on a contact fact) is excluded by the feature-policy's class-validity; the gate asserts
+  **zero new confident-wrong**; any increment that adds one is reverted (the loop can only gather or
+  abstain below bar, never report below bar).
+- **The TS body's nondeterminism contaminates the gate.** *Voided by design (Q3):* the gate is the
+  scripted driver; the LLM body is a separate demo whose result is reported, not gated.
+- **`GET /manifest` drift from the bdsl.** *Mitigation:* the daemon serves it *through the library
+  parser* (single source); the body's `verify` fails closed if an effector/feature lacks an impl.
+- **pkm-freeze / PII egress.** *Mitigation:* no pkm change; the bridge stays loopback (Move 3); the gate
+  driver runs fully on-machine; no real value appears in any credence/life-agent doc or fixture.
+
+## 7. Verification cadence
+
+End-of-move (all green): `packages/brain-body` unit tests (dispatch, fail-open on timeout/unreachable,
+manifest-verify) — transport-free, deterministic; `apps/answer-brain/extension` tests against a fake
+daemon + fake bridge (gather-then-report on the mobile class, abstain withholds its leader,
+statelessness) — deterministic; the Julia daemon tests (`/manifest` round-trips the bdsl; the
+feature-policy emits `gather(recency)` on the era-split fixture and `report` after; Stage-1/2a
+regression unchanged with the policy off); `ruff` + `mypy --strict` on the gate driver (life-agent);
+the **gate** (`run_eval --gate` through the scripted driver) **run and reported** — zero new
+confident-wrong, `P(Δ>δ)` stated, the answer-rate + disagreement region published; **one** opt-in
+local-Ollama end-to-end demo run and its result stated (its nondeterminism disclosed, not gated).
+
+## 8. de Finettian discipline self-audit
+
+1. **Every numerical query through `expect`?** The body + lib compute **no** posterior — they transport
+   the daemon's `/decide` (built on `candidate_posterior` + `optimise`/`value`). The gather *selection*
+   is the daemon's feature-policy; it is a *policy over the posterior's shape*, and where it stands in
+   for VOI it says so (§0, §5 Q2) — it does not fabricate an EU it did not compute.
+2. **Prevision inside a Measure or vice-versa?** No new wrapping. The lib + body hold no Credence
+   object; the daemon's additions reuse `decide_full`'s posterior + the declared features.
+3. **Opaque closure where declared structure fits?** The `askBrain` seam is an injected function (the
+   transport genuinely differs per app); the effectors/features are a *declared registry* verified
+   against the library-served manifest, not opaque dispatch.
+4. **`getproperty` override on a Prevision subtype?** No — no methods added to any Prevision/Measure
+   type, in either repo.
+
+## Reviewer checklist
+
+- [ ] §0 names transient state explicitly (credence-pi not refactored now; gather = feature-policy not
+      full VOI; gate = scripted not LLM; daemon stays stateless, learning is Stage 3).
+- [ ] §5 records the three author-approved resolutions (Q1 shared-lib boundary; Q2 feature-policy; Q3
+      scripted gate) + the two minor open questions (Q4 lib placement, Q5 policy params).
+- [ ] §2 keeps the single reasoner: no posterior/EU in the lib or body; `gather` selection is the
+      daemon's; the body enacts and the features project.
+- [ ] file:line / SHA citations for current-state references (pi-mono hooks @ae89286d
+      `…/types.ts:1020`/`:1416`, `examples/sdk/01,06`; the library BDSL parser `src/parse.jl`/`eval.jl`;
+      `daemon/server.jl` stateless; `answer_brain.jl:204` `voi_gather`; `capabilities.bdsl`/`features.bdsl`).
+- [ ] The move needs no later move to retract it (the lib API + `/decide`'s additive `gather` fields +
+      `/manifest` are additive; credence-pi's migration is purely additive onto the frozen lib).

--- a/docs/answer-brain/move-4-design.md
+++ b/docs/answer-brain/move-4-design.md
@@ -134,11 +134,24 @@ is run and its result stated, not assumed.
   calibration priors, committed before results, folded from outcomes later, **never fitted to the gate**.
 
 ### D. The scripted gate driver (NEW) — life-agent `scripts/`
-- A deterministic Python driver: per eval question, run the loop (`/route` → `/retrieve` → `/extract`
-  → `/decide` → [`gather` → `/probe/*` → `/extract` → `/decide`]\* → terminal) against the live
-  bridge+daemon, collect the outcome, feed `run_eval --gate`. Reuses the Move-3 bridge clients and the
-  existing gate. **This is the certification.** No model drives it; extraction is the bridge's local
-  model (already how `/extract` works).
+- A deterministic Python driver: per eval question, run the loop (`route` → baseline `observe` →
+  top-candidate `corroborate`-gather → recency/subject covariates → `/decide` → [`gather(recency)` →
+  re-`observe` → `/decide`]\* → terminal) against the live daemon, **reusing `gather.py`'s own helpers**
+  (`_era_split`/`_top_candidates`/`_gather`, `LK.observe_hits`, `probes`) so only the decision differs.
+  Initial `applied_probes=["recency"]` iff `route.time_indexed`, to mirror `gather.py` exactly.
+- **Certified as end-to-end PARITY to `gather.py`** (the owner's framing, §5 Q3 amended): per question the
+  daemon-driven outcome (action + asserted value) must match `ask.answer(gather=True)`, with **zero new
+  confident-wrong**. The corrected gather policy matches `gather.py` by construction, so this certifies
+  the *wire* (`/extract`→`/decide`→gather→re-extract) end-to-end over the real corpus. A fresh
+  `P(Δ>δ)` run is **not** the target — the gather loop is already the typed policy (`run_eval.py:397`),
+  so it would reproduce ~0.848 (the wide-`u_wrong`-prior FAIL, not mechanics).
+- **Persists a call-matrix** (idea B1, schema from `bayesian-orchestrator`): one append-only JSONL row
+  per (question × policy ∈ {`gather.py`, `daemon`, `monolithic`, `oracle`}) — `{question_id, gold,
+  policy, action, asserted, correct}` — so future policy comparisons are offline+exact (the B1 seed that
+  de-starves the §8 gate's *N* axis; the dominant `u_wrong`-prior blocker is the reaction loop's, not
+  this). The report emits a **gated recommendation** (named gates `parity_holds`, `zero_confident_wrong`,
+  each pass/review; "certified" only if both pass), mirroring her auto-gating discipline. B5 hygiene:
+  append+fsync, fixed seed, resume-by-cached-rows.
 
 ### E. The minimal pi-mono app (NEW) — `apps/answer-brain/app/`
 - `createAgentSession({ model, resourceLoader })` (pi-mono `examples/sdk/01-minimal.ts`,

--- a/packages/brain-body/package-lock.json
+++ b/packages/brain-body/package-lock.json
@@ -1,0 +1,569 @@
+{
+  "name": "@credence/brain-body",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@credence/brain-body",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/brain-body/package.json
+++ b/packages/brain-body/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@credence/brain-body",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Transport-agnostic governor core for credence answer-brains on pi-mono (govern loop, manifest fetch+verify, effector/feature harness).",
+  "exports": {
+    ".": "./src/index.ts",
+    "./governor": "./src/governor.ts",
+    "./manifest": "./src/manifest.ts",
+    "./dispatch": "./src/dispatch.ts",
+    "./wire": "./src/wire.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "node --import tsx --test tests/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/brain-body/src/dispatch.ts
+++ b/packages/brain-body/src/dispatch.ts
@@ -1,0 +1,51 @@
+// dispatch.ts — the effector-registry + feature-extractor harness, parametric
+// over the body's impl and context types. These are the two "plug points" a
+// concrete body fills: a registry of effector implementations (keyed by the
+// manifest's effector names) and a set of feature extractors (keyed by the
+// manifest's feature names). The harness here is vocabulary-agnostic; the body
+// supplies the impls and the names, and `verify` (manifest.ts) checks the two
+// line up against what the daemon declares.
+
+import type { EffectorSignal } from "./wire.js";
+
+/** A body's effector implementations, keyed by manifest effector name. */
+export type EffectorRegistry<TImpl> = Record<string, TImpl>;
+
+/**
+ * Look up the impl for a signal's effector and run it via the body-supplied
+ * `run` adapter (which knows how to call `TImpl` and shape the host result).
+ *
+ * Throws on an unknown effector — the brain named a tentacle the body never
+ * registered. `govern` turns that throw into a fail-open, so an unrecognised
+ * effector degrades safely instead of silently no-op'ing.
+ */
+export async function dispatchEffector<TImpl, TResult>(
+	registry: EffectorRegistry<TImpl>,
+	signal: EffectorSignal,
+	run: (impl: TImpl, parameters: Record<string, unknown>) => TResult | Promise<TResult>,
+): Promise<TResult> {
+	const impl = registry[signal.effector];
+	if (impl === undefined) {
+		throw new Error(`brain-body: no impl registered for effector "${signal.effector}"`);
+	}
+	return run(impl, signal.parameters);
+}
+
+/** A feature extractor reads the body's per-call context and returns one
+ *  kebab-case space member (matching the feature's declared space). */
+export type FeatureExtractor<TCtx> = (ctx: TCtx) => string;
+
+/**
+ * Run every extractor over `ctx`, collecting the feature dict the body sends to
+ * the daemon (the *projections* the daemon's policy reads; the daemon decides).
+ */
+export function assembleFeatures<TCtx>(
+	extractors: Record<string, FeatureExtractor<TCtx>>,
+	ctx: TCtx,
+): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [name, fn] of Object.entries(extractors)) {
+		out[name] = fn(ctx);
+	}
+	return out;
+}

--- a/packages/brain-body/src/governor.ts
+++ b/packages/brain-body/src/governor.ts
@@ -1,0 +1,78 @@
+// governor.ts — the transport-agnostic govern skeleton. Every credence
+// answer-brain body, on the call it governs, does the same three things:
+//
+//   1. compose the brain request from its accumulated evidence + features
+//      (`buildRequest`, body-owned);
+//   2. ask the brain and receive the chosen effector (`askBrain`, the INJECTED
+//      transport — this is the one seam that differs per body: answer-brain's
+//      synchronous POST /decide vs credence-pi's async SSE correlation);
+//   3. enact the effector (`dispatch`, built from the dispatch.ts harness).
+//
+// And — the discipline that makes a governor safe to put in front of a tool —
+// it FAILS OPEN: if the brain is unreachable, errors, or exceeds the timeout,
+// `govern` does not throw and does not hang; it returns the body-supplied
+// `failOpen` value. (What "open" means is the body's call: credence-pi proceeds;
+// an answer body may instead step aside to an abstain so an *ungoverned*
+// confident answer never escapes. The lib only guarantees it returns that value
+// rather than propagating the failure.)
+//
+// No posterior or EU is computed here — `govern` transports the brain's decision
+// (move-4-design §2 single-reasoner invariant).
+
+import type { EffectorSignal } from "./wire.js";
+
+export interface GovernSpec<TReq, TResult> {
+	/** Compose the brain request from accumulated evidence (+ features). */
+	buildRequest: () => TReq | Promise<TReq>;
+	/** The injected transport: send the request, get the chosen effector. */
+	askBrain: (req: TReq) => Promise<EffectorSignal>;
+	/** Enact the effector (look it up in the registry, run it → host result). */
+	dispatch: (signal: EffectorSignal) => TResult | Promise<TResult>;
+	/** Returned on brain-unreachable / error / timeout — the body chooses it. */
+	failOpen: TResult;
+	/** Backstop timeout around `askBrain` (ms). The transport may also abort. */
+	timeoutMs: number;
+	/** Logged once on a fail-open. */
+	onError?: (msg: string, err?: unknown) => void;
+}
+
+/**
+ * Govern one call. Returns the dispatched effector's result, or — on any
+ * failure reaching/decoding the brain decision — the `failOpen` value.
+ */
+export async function govern<TReq, TResult>(spec: GovernSpec<TReq, TResult>): Promise<TResult> {
+	const { buildRequest, askBrain, dispatch, failOpen, timeoutMs, onError } = spec;
+	try {
+		const req = await buildRequest();
+		const signal = await withTimeout(askBrain(req), timeoutMs);
+		return await dispatch(signal);
+	} catch (err) {
+		onError?.("brain-body: govern failed open (brain unavailable / errored)", err);
+		return failOpen;
+	}
+}
+
+/**
+ * Race a promise against a timeout. The underlying promise is not cancelled
+ * (the lib is transport-agnostic and cannot know how) — a transport that holds
+ * a socket should wire its own AbortController; this is the backstop that keeps
+ * a hung brain from hanging the governed call.
+ */
+export function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(
+			() => reject(new Error(`brain-body: askBrain timed out after ${ms}ms`)),
+			ms,
+		);
+		p.then(
+			(v) => {
+				clearTimeout(timer);
+				resolve(v);
+			},
+			(e: unknown) => {
+				clearTimeout(timer);
+				reject(e instanceof Error ? e : new Error(String(e)));
+			},
+		);
+	});
+}

--- a/packages/brain-body/src/index.ts
+++ b/packages/brain-body/src/index.ts
@@ -1,0 +1,29 @@
+// @credence/brain-body — the transport-agnostic governor core shared by
+// credence answer-brain bodies on pi-mono. A body injects its transport
+// (`askBrain`), its effector impls + feature extractors, and the value to fail
+// open with; the lib supplies the govern loop, the manifest fetch+verify (no
+// BDSL parser), and the dispatch/feature harness. See move-4-design §2A.
+
+export type {
+	EffectorSignal,
+	EffectorParam,
+	EffectorDecl,
+	FeatureDecl,
+	Manifest,
+} from "./wire.js";
+
+export {
+	type EffectorRegistry,
+	type FeatureExtractor,
+	dispatchEffector,
+	assembleFeatures,
+} from "./dispatch.js";
+
+export {
+	type FetchManifestOptions,
+	type Registries,
+	fetchManifest,
+	verify,
+} from "./manifest.js";
+
+export { type GovernSpec, govern, withTimeout } from "./governor.js";

--- a/packages/brain-body/src/manifest.ts
+++ b/packages/brain-body/src/manifest.ts
@@ -1,0 +1,78 @@
+// manifest.ts — fetch the body's vocabulary from the daemon and verify the body
+// implements it. There is NO BDSL parser here (the de-dup cut, move-4-design §0,
+// §5 Q1): the daemon owns the single library parser and serves the parsed
+// manifest at GET /manifest; the body fetches it and checks every declared
+// effector / feature has a registered impl / extractor. credence-pi's 159-line
+// TS parser (extension/src/manifest.ts) is replaced by these two functions.
+
+import type { Manifest } from "./wire.js";
+
+export interface FetchManifestOptions {
+	/** Abort the GET after this many ms. Default 10s. */
+	timeoutMs?: number;
+	/** Injectable fetch for tests (defaults to the global). */
+	fetchImpl?: typeof fetch;
+}
+
+/**
+ * GET {daemonUrl}/manifest → the effector/feature vocabulary. Throws on a
+ * non-2xx, a transport error/timeout, or a structurally-malformed body — the
+ * caller (the extension factory) decides whether that is fatal at startup.
+ */
+export async function fetchManifest(
+	daemonUrl: string,
+	opts: FetchManifestOptions = {},
+): Promise<Manifest> {
+	const fetchImpl = opts.fetchImpl ?? fetch;
+	const base = daemonUrl.replace(/\/+$/, "");
+	const ctrl = new AbortController();
+	const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 10_000);
+	try {
+		const resp = await fetchImpl(`${base}/manifest`, { signal: ctrl.signal });
+		if (!resp.ok) {
+			throw new Error(`fetchManifest: GET /manifest → ${resp.status}`);
+		}
+		const json = (await resp.json()) as Manifest;
+		if (!Array.isArray(json?.effectors) || !Array.isArray(json?.features)) {
+			throw new Error("fetchManifest: malformed manifest (missing effectors[] / features[])");
+		}
+		return json;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/** The body's two registries, checked against the manifest. Values are opaque
+ *  here (the harness in dispatch.ts knows how to call them) — `verify` only
+ *  cares that a key exists for every declared name. */
+export interface Registries {
+	effectors: Record<string, unknown>;
+	features: Record<string, unknown>;
+}
+
+/**
+ * Fail closed if the body is missing an impl for any declared effector, or an
+ * extractor for any declared feature. Extra registered impls are fine (the body
+ * may map several daemon actions onto one effector); only *unimplemented
+ * declarations* are an error. Names are reported verbatim (kebab-case) so a
+ * developer can grep the bdsl directly.
+ */
+export function verify(manifest: Manifest, reg: Registries): void {
+	const missingEffectors = manifest.effectors
+		.filter((e) => !(e.name in reg.effectors))
+		.map((e) => e.name);
+	const missingFeatures = manifest.features
+		.filter((f) => !(f.name in reg.features))
+		.map((f) => f.name);
+
+	const problems: string[] = [];
+	if (missingEffectors.length > 0) {
+		problems.push(`no impl for declared effector(s): ${missingEffectors.join(", ")}`);
+	}
+	if (missingFeatures.length > 0) {
+		problems.push(`no extractor for declared feature(s): ${missingFeatures.join(", ")}`);
+	}
+	if (problems.length > 0) {
+		throw new Error(`brain-body manifest verify: ${problems.join("; ")}`);
+	}
+}

--- a/packages/brain-body/src/wire.ts
+++ b/packages/brain-body/src/wire.ts
@@ -1,0 +1,43 @@
+// wire.ts — the shapes that cross the brain↔body seam, shared by every
+// credence answer-brain body. Deliberately tiny and transport-free: a body
+// reaches its daemon over whatever transport it likes (answer-brain's
+// synchronous POST /decide; credence-pi's async SSE bus), but the *manifest*
+// it verifies against and the *effector signal* it dispatches are the same
+// shape. No posterior, no EU, no policy lives here — only the daemon computes
+// those (move-4-design §2 single-reasoner invariant).
+
+/**
+ * The brain's chosen effector and its parameters, as the (injected) transport
+ * surfaces it to the governor. The `effector` name matches a key in the body's
+ * effector registry (= a name declared in the manifest); the transport is
+ * responsible for mapping any daemon-internal action vocabulary onto the
+ * manifest's effector names before the signal reaches `dispatch`.
+ */
+export interface EffectorSignal {
+	effector: string;
+	parameters: Record<string, unknown>;
+}
+
+// ── Manifest (served by the daemon's GET /manifest; the body has NO parser) ──
+// These mirror the JSON the library parser emits (apps/answer-brain/daemon/
+// manifest.jl) and replace credence-pi's body-side BDSL parser.
+
+export interface EffectorParam {
+	name: string;
+	type: string;
+}
+
+export interface EffectorDecl {
+	name: string;
+	parameters: EffectorParam[];
+}
+
+export interface FeatureDecl {
+	name: string;
+	spaceName: string;
+}
+
+export interface Manifest {
+	effectors: EffectorDecl[];
+	features: FeatureDecl[];
+}

--- a/packages/brain-body/tests/dispatch.test.ts
+++ b/packages/brain-body/tests/dispatch.test.ts
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { assembleFeatures, dispatchEffector, type EffectorRegistry } from "../src/dispatch.js";
+import type { EffectorSignal } from "../src/wire.js";
+
+test("assembleFeatures runs every extractor over the ctx", () => {
+	const extractors = {
+		"posterior-dispersion": (c: { disp: string }) => c.disp,
+		"owner-scoped": (_c: { disp: string }) => "yes",
+	};
+	const out = assembleFeatures(extractors, { disp: "sharp" });
+	assert.deepEqual(out, { "posterior-dispersion": "sharp", "owner-scoped": "yes" });
+});
+
+test("dispatchEffector looks up the impl and runs it via the adapter", async () => {
+	const registry: EffectorRegistry<(p: Record<string, unknown>) => string> = {
+		answer: (p) => `answered:${String(p.value)}`,
+	};
+	const sig: EffectorSignal = { effector: "answer", parameters: { value: "V" } };
+	const res = await dispatchEffector(registry, sig, (impl, params) => impl(params));
+	assert.equal(res, "answered:V");
+});
+
+test("dispatchEffector throws on an unknown effector", async () => {
+	const registry: EffectorRegistry<() => void> = {};
+	const sig: EffectorSignal = { effector: "ghost", parameters: {} };
+	await assert.rejects(
+		() => dispatchEffector(registry, sig, (impl) => impl()),
+		/no impl registered for effector "ghost"/,
+	);
+});

--- a/packages/brain-body/tests/governor.test.ts
+++ b/packages/brain-body/tests/governor.test.ts
@@ -1,0 +1,76 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { govern, withTimeout } from "../src/governor.js";
+import type { EffectorSignal } from "../src/wire.js";
+
+const SIGNAL: EffectorSignal = { effector: "answer", parameters: { value: "V" } };
+
+test("govern composes → asks → dispatches on the happy path", async () => {
+	const seen: string[] = [];
+	const res = await govern<{ q: string }, string>({
+		buildRequest: () => {
+			seen.push("build");
+			return { q: "x" };
+		},
+		askBrain: async (req) => {
+			seen.push(`ask:${req.q}`);
+			return SIGNAL;
+		},
+		dispatch: (sig) => {
+			seen.push(`dispatch:${sig.effector}`);
+			return `done:${String(sig.parameters.value)}`;
+		},
+		failOpen: "FAILOPEN",
+		timeoutMs: 1000,
+	});
+	assert.equal(res, "done:V");
+	assert.deepEqual(seen, ["build", "ask:x", "dispatch:answer"]);
+});
+
+test("govern fails open when askBrain throws (brain unreachable)", async () => {
+	let logged = false;
+	const res = await govern<null, string>({
+		buildRequest: () => null,
+		askBrain: async () => {
+			throw new Error("ECONNREFUSED");
+		},
+		dispatch: () => "NEVER",
+		failOpen: "FAILOPEN",
+		timeoutMs: 1000,
+		onError: () => {
+			logged = true;
+		},
+	});
+	assert.equal(res, "FAILOPEN");
+	assert.ok(logged, "onError logged once");
+});
+
+test("govern fails open when askBrain exceeds the timeout", async () => {
+	const res = await govern<null, string>({
+		buildRequest: () => null,
+		askBrain: () => new Promise<EffectorSignal>(() => {}), // never resolves
+		dispatch: () => "NEVER",
+		failOpen: "FAILOPEN",
+		timeoutMs: 20,
+	});
+	assert.equal(res, "FAILOPEN");
+});
+
+test("govern fails open when the brain names an unknown effector (dispatch throws)", async () => {
+	const res = await govern<null, string>({
+		buildRequest: () => null,
+		askBrain: async () => ({ effector: "ghost", parameters: {} }),
+		dispatch: () => {
+			throw new Error('no impl registered for effector "ghost"');
+		},
+		failOpen: "FAILOPEN",
+		timeoutMs: 1000,
+	});
+	assert.equal(res, "FAILOPEN");
+});
+
+test("withTimeout resolves a fast promise and rejects a slow one", async () => {
+	assert.equal(await withTimeout(Promise.resolve(42), 1000), 42);
+	await assert.rejects(() => withTimeout(new Promise(() => {}), 20), /timed out after 20ms/);
+});

--- a/packages/brain-body/tests/manifest.test.ts
+++ b/packages/brain-body/tests/manifest.test.ts
@@ -1,0 +1,74 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { fetchManifest, verify } from "../src/manifest.js";
+import type { Manifest } from "../src/wire.js";
+
+const MANIFEST: Manifest = {
+	effectors: [
+		{ name: "answer", parameters: [{ name: "value", type: "string" }] },
+		{ name: "abstain", parameters: [{ name: "reason", type: "string" }] },
+	],
+	features: [{ name: "owner-scoped", spaceName: "owner-scoped-space" }],
+};
+
+function fakeFetch(status: number, body: unknown): typeof fetch {
+	return (async () => ({
+		ok: status >= 200 && status < 300,
+		status,
+		json: async () => body,
+	})) as unknown as typeof fetch;
+}
+
+test("fetchManifest GETs {daemonUrl}/manifest (trailing slashes trimmed)", async () => {
+	let calledUrl = "";
+	const fetchImpl = (async (url: string) => {
+		calledUrl = url;
+		return { ok: true, status: 200, json: async () => MANIFEST };
+	}) as unknown as typeof fetch;
+	const m = await fetchManifest("http://d:1//", { fetchImpl });
+	assert.equal(calledUrl, "http://d:1/manifest");
+	assert.deepEqual(m, MANIFEST);
+});
+
+test("fetchManifest throws on a non-2xx", async () => {
+	await assert.rejects(
+		() => fetchManifest("http://d:1", { fetchImpl: fakeFetch(500, {}) }),
+		/GET \/manifest → 500/,
+	);
+});
+
+test("fetchManifest throws on a structurally-malformed body", async () => {
+	await assert.rejects(
+		() => fetchManifest("http://d:1", { fetchImpl: fakeFetch(200, { effectors: [] }) }),
+		/malformed manifest/,
+	);
+});
+
+test("verify passes when every declared item has an impl", () => {
+	verify(MANIFEST, {
+		effectors: { answer: 1, abstain: 1 },
+		features: { "owner-scoped": 1 },
+	});
+});
+
+test("verify names a missing effector impl (fails closed)", () => {
+	assert.throws(
+		() => verify(MANIFEST, { effectors: { answer: 1 }, features: { "owner-scoped": 1 } }),
+		/no impl for declared effector\(s\): abstain/,
+	);
+});
+
+test("verify names a missing feature extractor (fails closed)", () => {
+	assert.throws(
+		() => verify(MANIFEST, { effectors: { answer: 1, abstain: 1 }, features: {} }),
+		/no extractor for declared feature\(s\): owner-scoped/,
+	);
+});
+
+test("verify allows extra impls beyond the manifest (action→effector fan-in)", () => {
+	verify(MANIFEST, {
+		effectors: { answer: 1, abstain: 1, gather: 1 },
+		features: { "owner-scoped": 1, extra: 1 },
+	});
+});

--- a/packages/brain-body/tsconfig.json
+++ b/packages/brain-body/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## What

The **answer-brain**: a credence "brain" on pi-mono that governs *answering* — which evidence to gather, whether to answer / ask / abstain — by VOI, a sibling to `credence-pi`. It replaces life-agent's single-pass lookup "patch-treadmill" (every failure → one more hand-coded covariate). This branch is the whole feature, Moves 1–4.

## The arc

- **Move 1 — the native brain** (`apps/answer-brain/brain/answer_brain.jl`): the candidate posterior + EU decide (report / hedge / ask_clarify / abstain), parity-clean vs the life-agent Stage-0 fixtures.
- **Move 2 — the stateless `/decide` wire** (`daemon/server.jl`): a synchronous request/response over the brain; holds no per-question state.
- **Move 3 — the capability bridge** (life-agent repo): route / retrieve / extract / probe / utility — the body's evidence backend.
- **Move 4 — the body + de-dup + gate:**
  - the **gather branch** (`gather_decide`): a feature-policy that steers `gather(recency)` on era-split candidates *before* a terminal report (a count-led stale value can sit above the bar, so recency must precede the report). **Certified end-to-end parity to `gather.py` over the real corpus** (life-agent `answer_brain_gate.py`: 21/21, zero new confident-wrong).
  - **`GET /manifest`** (`daemon/manifest.jl`): serves the bdsl vocabulary through the **one** library parser (`Credence.parse_all`) — the body has **no parser** (the de-dup cut; eliminates credence-pi's 159-line TS duplicate).
  - **`packages/brain-body`**: the shared, transport-agnostic governor lib (govern fail-open loop · manifest fetch+verify · dispatch/feature harness · injected `askBrain`). credence-pi migrates onto it later.
  - **`apps/answer-brain/extension`**: the pi-mono body — the LLM drives retrieve→extract→answer; the brain governs the answer (allow + rewrite to the evidence value / gather-steer / ask / abstain); **fails closed** if the brain is unreachable.
  - **`apps/answer-brain/app`**: a minimal local-Ollama demo (the demo, not the gate).

## Verify

- **Julia:** manifest 16 · server 53 · gather 14 · brain Stage-1 parity — green.
- **TS:** `packages/brain-body` 15 · `apps/answer-brain/extension` 6 (vs a fake daemon + fake bridge) · the app typechecks against published pi-mono **0.79.6**; `check.ts` passes against the live daemon.
- The decision math is **gate-certified** (the parity gate, life-agent side).
- Design docs under `docs/answer-brain/` (master plan + moves 1–4).

Depends on life-agent's `era_split` bridge field (life-agent PR for `bridge-era-split`) for the demo's recency steer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
