### PR TITLE
credence-pi eval: routing-belief calibration (ECE/AUROC/reliability)

### DIFF
--- a/apps/credence-pi/eval/calibration.jl
+++ b/apps/credence-pi/eval/calibration.jl
@@ -1,0 +1,165 @@
+# Role: eval
+"""
+    calibration.jl — is the routing belief's θ a TRUE probability?
+
+Every routing decision rests on θ_a(X) = E[P(correct | model a, context X)] being calibrated:
+the EU-max reward·θ − cost trades accuracy against cost in dollars, so a miscalibrated θ makes
+the wrong trade even when it RANKS models correctly. The dominance eval measures realized
+welfare; this measures whether the belief it routes on is honest.
+
+NON-CAUSAL read-out (a diagnostic — nothing here feeds a routing decision or a belief): on
+held-out (task, tier, rep) outcomes it compares the trained belief's predicted θ
+(`posterior_accuracy`, the public diagnostic accessor) against the realized solve via proper
+scores — ECE, Brier, log-score, AUROC — plus a reliability table. Reuses tb_dominance.jl's
+matrix loader + per-tier StructureBMA training (the SAME belief the router uses); the 3-rep
+matrix supplies the realized frequencies to calibrate against.
+
+Run:
+    julia --project=<repo-root> apps/credence-pi/eval/calibration.jl \\
+        apps/credence-pi/eval/live_ab/results/tb_matrix_rep3.jsonl \\
+        [--seeds 100] [--bins 10] [--train-frac 0.6] [--out .../calibration.summary.json]
+"""
+
+include(joinpath(@__DIR__, "tb_dominance.jl"))   # load_matrix, build_model, train_tops, …
+
+using Printf
+using JSON3
+using Random: MersenneTwister, shuffle!
+
+_clamp01(p) = min(1.0 - 1e-12, max(1e-12, p))
+
+# Held-out (predicted θ, realized outcome) pairs: train the per-tier belief on the train split,
+# then for each test (task, tier, rep) read the belief's predicted accuracy at that task's
+# context against the rep's realized solve. `posterior_accuracy` is the public diagnostic
+# accessor (E[θ|X] through `expect`); this read-out never feeds a decision.
+function collect_pairs(tasks::Vector{TaskRow}, fvals, seeds::Int, train_frac::Float64)
+    ps = Float64[]; ys = Float64[]
+    ids = [t.id for t in tasks]
+    for seed in 0:(seeds - 1)
+        rng = MersenneTwister(seed)
+        ord = shuffle!(rng, collect(eachindex(ids)))
+        ntr = max(2, round(Int, train_frac * length(ids)))
+        trainset = Set(ids[ord[1:ntr]])
+        train = [t for t in tasks if t.id in trainset]
+        test  = [t for t in tasks if !(t.id in trainset)]
+        isempty(test) && continue
+        model = build_model(FEATURES, fvals; alpha0 = ALPHA0, beta0 = BETA0, p_edge = PEDGE)
+        tops = train_tops(model, train)
+        for t in test, a in eachindex(TIERS)
+            X = context_from_features(model, featuredict(t))
+            p = posterior_accuracy(model, tops[a], X)         # predicted E[θ_a|X] (diagnostic)
+            for r in 1:nreps(t)
+                push!(ps, p); push!(ys, t.resolved[a][r] ? 1.0 : 0.0)
+            end
+        end
+    end
+    ps, ys
+end
+
+# ── proper scores over the (p, y) pairs — plain arithmetic on diagnostic readouts ──
+_brier(ps, ys) = sum((ps .- ys) .^ 2) / length(ps)
+_logscore(ps, ys) =
+    -sum(ys .* log.(_clamp01.(ps)) .+ (1.0 .- ys) .* log.(1.0 .- _clamp01.(ps))) / length(ps)
+
+_bin_idx(ps, lo, hi, last) =
+    last ? findall(p -> lo <= p <= hi, ps) : findall(p -> lo <= p < hi, ps)
+
+# Expected calibration error: equal-width bins, Σ (n_b/n)·|mean(y) − mean(p)| over bins.
+function _ece(ps, ys, bins::Int)
+    edges = range(0.0, 1.0; length = bins + 1)
+    n = length(ps); ece = 0.0
+    for b in 1:bins
+        idx = _bin_idx(ps, edges[b], edges[b + 1], b == bins)
+        isempty(idx) && continue
+        ece += (length(idx) / n) * abs(sum(@view ys[idx]) - sum(@view ps[idx])) / length(idx)
+    end
+    ece
+end
+
+# AUROC via the Mann–Whitney U statistic (rank-based; ties take the average rank).
+function _auroc(ps, ys)
+    npos = count(==(1.0), ys); nneg = length(ys) - npos
+    (npos == 0 || nneg == 0) && return NaN
+    order = sortperm(ps)
+    ranks = Vector{Float64}(undef, length(ps))
+    i = 1
+    while i <= length(ps)
+        j = i
+        while j < length(ps) && ps[order[j + 1]] == ps[order[i]]; j += 1; end
+        r = (i + j) / 2.0
+        for k in i:j; ranks[order[k]] = r; end
+        i = j + 1
+    end
+    sum_pos = sum(ranks[k] for k in eachindex(ys) if ys[k] == 1.0; init = 0.0)
+    (sum_pos - npos * (npos + 1) / 2) / (npos * nneg)
+end
+
+function reliability_table(ps, ys, bins::Int)
+    edges = range(0.0, 1.0; length = bins + 1)
+    println("  ", rpad("bin", 13), rpad("n", 8), rpad("mean pred", 12),
+            rpad("mean real", 12), "gap")
+    for b in 1:bins
+        idx = _bin_idx(ps, edges[b], edges[b + 1], b == bins)
+        isempty(idx) && continue
+        mp = sum(@view ps[idx]) / length(idx); mr = sum(@view ys[idx]) / length(idx)
+        println("  ", rpad(@sprintf("[%.1f,%.1f)", edges[b], edges[b + 1]), 13),
+                rpad(string(length(idx)), 8), rpad(@sprintf("%.3f", mp), 12),
+                rpad(@sprintf("%.3f", mr), 12), @sprintf("%+.3f", mr - mp))
+    end
+end
+
+function parse_args(argv)
+    a = Dict{String, Any}("path" => "", "seeds" => 100, "bins" => 10,
+                          "train-frac" => 0.6, "out" => "")
+    i = 1
+    while i <= length(argv)
+        t = argv[i]
+        if     t == "--seeds";      a["seeds"] = parse(Int, argv[i + 1]);          i += 2
+        elseif t == "--bins";       a["bins"] = parse(Int, argv[i + 1]);           i += 2
+        elseif t == "--train-frac"; a["train-frac"] = parse(Float64, argv[i + 1]); i += 2
+        elseif t == "--out";        a["out"] = argv[i + 1];                        i += 2
+        elseif !startswith(t, "--") && isempty(a["path"]); a["path"] = t;          i += 1
+        else; error("unknown arg $t"); end
+    end
+    isempty(a["path"]) && error("usage: calibration.jl <matrix.jsonl> [--seeds N] [--bins N] [--train-frac f] [--out f]")
+    a
+end
+
+function run_calibration()
+    args = parse_args(ARGS)
+    tasks = load_matrix(args["path"])
+    @assert length(tasks) >= 4 "need ≥4 fully-measured tasks, got $(length(tasks))"
+    fvals = feature_values(tasks)
+    ps, ys = collect_pairs(tasks, fvals, args["seeds"], args["train-frac"])
+
+    ece = _ece(ps, ys, args["bins"]); brier = _brier(ps, ys)
+    logs = _logscore(ps, ys); auroc = _auroc(ps, ys)
+
+    bar = "="^72
+    println("\n", bar)
+    println("ROUTING-BELIEF CALIBRATION  (held-out predicted θ vs realized solve)")
+    println(bar)
+    println("tasks: ", length(tasks), "   tiers: ", join(TIERS, "/"),
+            "   features: ", join(FEATURES, "/"),
+            "   seeds: ", args["seeds"], "   pairs: ", length(ps))
+    @printf("\n  ECE (%d-bin):  %.4f      Brier: %.4f      log-score: %.4f      AUROC: %.4f\n",
+            args["bins"], ece, brier, logs, auroc)
+    println("\nReliability (perfect calibration ⇒ gap ≈ 0 every bin):")
+    reliability_table(ps, ys, args["bins"])
+    println(bar, "\n")
+
+    if !isempty(args["out"])
+        out = Dict{String, Any}(
+            "config" => Dict("tasks" => length(tasks), "tiers" => TIERS, "features" => FEATURES,
+                             "seeds" => args["seeds"], "bins" => args["bins"],
+                             "train_frac" => args["train-frac"], "pairs" => length(ps)),
+            "ece" => ece, "brier" => brier, "log_score" => logs, "auroc" => auroc)
+        mkpath(dirname(args["out"]))
+        open(args["out"], "w") do io; JSON3.pretty(io, out); end
+        println("summary → ", args["out"])
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_calibration()
+end

--- a/apps/credence-pi/eval/live_ab/EXPERIMENT.md
+++ b/apps/credence-pi/eval/live_ab/EXPERIMENT.md
@@ -158,6 +158,28 @@ leads.
 *Verified by a 5-skeptic adversarial workflow (leakage clean; foil-fairness caught the
 clairvoyant mislabel — now fixed; metric/data/mechanism minor caveats folded in above).*
 
+## Calibration of the up-front belief (`eval/calibration.jl`)
+
+Is the belief's θ a *true* probability? The EU trade reward·θ − cost is only as good as θ's
+calibration, not just its ranking. Held-out predicted-θ vs realized-solve over the 3-rep
+matrix (100 seeds, 6300 pairs, difficulty/category/length features):
+
+| metric | value | read |
+|---|---|---|
+| ECE (10-bin) | **0.074** | moderate; under-confident at the low end (predicts ~0.17 where reality is ~0.77), well-calibrated mid-range |
+| AUROC | **0.59** | near-chance — the up-front belief barely *ranks* solve-vs-fail on held-out tasks |
+| Brier / log-score | 0.243 / 0.679 | — |
+
+The weak AUROC has a real, honest root cause: the warm belief orders haiku<sonnet<opus (from
+the MCQ oracle grid), but tb reality is sonnet>opus (sonnet solves 36/51, opus 32/51), so it
+**mis-ranks tiers** on agentic tasks. This is the dominance eval's verdict — **difficulty/
+category/length + the MCQ warm-seed don't predict the agentic capability boundary** — now
+quantified. It is exactly why **observe-then-escalate wins**: it needs no calibrated up-front
+θ, just an observed failure. The implication for live up-front routing: re-warm the belief on
+agentic outcomes and/or enrich the features (the structure-BMA auto-sophisticates) — bounded
+by what is honestly extractable at routing time. (Non-causal diagnostic; never feeds a
+decision — `posterior_accuracy` read-out only.)
+
 ## Status
 
 - [x] Stack validated (oracle + 3 tiers on hello-world; clean cost capture)

--- a/apps/credence-pi/eval/results/calibration.summary.json
+++ b/apps/credence-pi/eval/results/calibration.summary.json
@@ -1,0 +1,23 @@
+{
+    "auroc": 0.5892362512592484,
+    "config": {
+        "tiers": [
+            "haiku",
+            "sonnet",
+            "opus"
+        ],
+        "tasks": 17,
+        "features": [
+            "difficulty",
+            "category",
+            "length"
+        ],
+        "seeds": 100,
+        "train_frac": 0.6,
+        "bins": 10,
+        "pairs": 6300
+    },
+    "brier": 0.24287858596088088,
+    "log_score": 0.6792109297319038,
+    "ece": 0.07364564137344302
+}


### PR DESCRIPTION
## What

`eval/calibration.jl` — a non-causal diagnostic answering "is the routing belief's θ a *true* probability?" The EU trade `reward·θ − cost` rests on θ's calibration, not just its ranking; the dominance eval measured realized welfare, this measures the belief it routes on.

Held-out predicted-θ (the `posterior_accuracy` diagnostic accessor) vs realized solve over the 3-rep matrix → ECE, Brier, log-score, AUROC + a reliability table. Reuses `tb_dominance.jl`'s loader + per-tier `StructureBMA` training.

## Result (100 seeds, 6300 pairs)

| metric | value |
|---|---|
| ECE (10-bin) | **0.074** (under-confident at the low end; well-calibrated mid-range) |
| AUROC | **0.59** (near-chance ranking) |
| Brier / log-score | 0.243 / 0.679 |

**Honest root cause:** the warm belief orders haiku<sonnet<opus (from the MCQ oracle grid), but tb reality is sonnet>opus (sonnet 36/51, opus 32/51) — it mis-ranks tiers on agentic tasks. This *quantifies* the dominance eval's honest-negative (difficulty/category/length + the MCQ warm-seed don't predict the agentic capability boundary) and is exactly why observe-then-escalate wins (it needs no calibrated up-front θ). Folded into `EXPERIMENT.md`.

Non-causal (read-out only); lint clean (pragma-free). No brain/plugin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)