### PR TITLE
credence-pi routing: finer prompt-length + agentic re-warm (covariates + warm)

### DIFF
--- a/apps/credence-pi/bdsl/routing.bdsl
+++ b/apps/credence-pi/bdsl/routing.bdsl
@@ -22,17 +22,20 @@
 ; --- Routing feature vocabulary ---
 ;
 ; The brain conditions P(correct|X) on these. ONLY features honestly
-; extractable from a raw prompt belong here: before_model_resolve hands
-; the plugin the prompt and nothing else, so semantic category (the
-; signal the offline oracle measured) is NOT available live without a
-; classifier — which would be an arbitrary, unmeasured component. The
-; one honest live feature is prompt-length; the structure-BMA discovers
-; whether it predicts accuracy and collapses to the marginal if it does
-; not (so declaring it can never hurt correctness). The short/long
-; bucket boundary lives in the body extractor (routing-features.ts) —
-; the one train/live synchronisation point.
+; extractable at routing time belong here: before_model_resolve hands the
+; plugin the prompt (and, on current OpenClaw, attachment metadata) — not
+; semantic category, which would need an arbitrary, unmeasured classifier.
+; The honest live feature is prompt-length, now in FINER short/medium/long
+; buckets (prefer fine parameterisation — the structure-BMA discovers which
+; splits predict accuracy and collapses the rest to the marginal, so finer
+; can never hurt correctness). The bucket boundaries live in the body
+; extractor (routing-features.ts) — the train/live synchronisation point —
+; and the warm belief (routing_brain.counts.json) is seeded per bucket from
+; the agentic Terminal-Bench matrix (eval/train_routing_from_matrix.jl), so
+; the buckets carry real, length-varying agentic signal from install.
+; (attachments is the natural next covariate — see routing-features.ts.)
 (define prompt-length-space
-  (space :finite short long))
+  (space :finite short medium long))
 
 (define routing-features
   (list

--- a/apps/credence-pi/brain/routing_brain.counts.json
+++ b/apps/credence-pi/brain/routing_brain.counts.json
@@ -1,61 +1,102 @@
 {
-    "note": "All items are short MCQ ⇒ short cell only; long cell stays at prior. Daemon reconstructs K posteriors by replaying these counts via observe. Frozen in v1 (no live correctness signal yet — needs credit assignment).",
+    "note": "AGENTIC warm — replaces the short-MCQ oracle grid, which eval/calibration.jl showed mis-ranks tiers on agentic tasks (it ordered haiku<sonnet<opus; tb reality is sonnet>opus). Buckets match routing-features.ts: short ≤400, medium ≤1000, long >1000 chars. The daemon reconstructs K StructureBMA posteriors by replaying these counts via observe; empty cells stay at the prior and learn online.",
     "feature_values": [
         [
             "short",
+            "medium",
             "long"
         ]
     ],
     "features": [
         "prompt-length"
     ],
-    "source": "oracle_grid.json (real-model de-risk: 3 frontier models × 50 labelled MCQ)",
+    "source": "tb_matrix_rep3.jsonl (agentic Terminal-Bench: 17 tasks × 3 tiers × 3 reps), bucketed by instruction length",
     "models": [
         "cheap",
         "mid",
         "exp"
     ],
-    "trained_at": "2026-06-16T16:59:29.951",
-    "frozen": true,
-    "model_ids": [
-        "claude-haiku-4-5",
-        "claude-sonnet-4-6",
-        "claude-opus-4-8"
-    ],
     "per_model": [
         {
             "contexts": [
                 {
-                    "n1": 44,
+                    "n1": 10,
                     "ctx": [
                         "short"
                     ],
-                    "n0": 6
+                    "n0": 20
+                },
+                {
+                    "n1": 3,
+                    "ctx": [
+                        "medium"
+                    ],
+                    "n0": 3
+                },
+                {
+                    "n1": 8,
+                    "ctx": [
+                        "long"
+                    ],
+                    "n0": 7
                 }
             ]
         },
         {
             "contexts": [
                 {
-                    "n1": 48,
+                    "n1": 21,
                     "ctx": [
                         "short"
                     ],
-                    "n0": 2
+                    "n0": 9
+                },
+                {
+                    "n1": 3,
+                    "ctx": [
+                        "medium"
+                    ],
+                    "n0": 3
+                },
+                {
+                    "n1": 12,
+                    "ctx": [
+                        "long"
+                    ],
+                    "n0": 3
                 }
             ]
         },
         {
             "contexts": [
                 {
-                    "n1": 49,
+                    "n1": 17,
                     "ctx": [
                         "short"
                     ],
-                    "n0": 1
+                    "n0": 13
+                },
+                {
+                    "n1": 3,
+                    "ctx": [
+                        "medium"
+                    ],
+                    "n0": 3
+                },
+                {
+                    "n1": 12,
+                    "ctx": [
+                        "long"
+                    ],
+                    "n0": 3
                 }
             ]
         }
+    ],
+    "model_ids": [
+        "claude-haiku-4-5",
+        "claude-sonnet-4-6",
+        "claude-opus-4-8"
     ],
     "artifact": "credence-pi warm routing belief P(correct|prompt-length) — per-model counts"
 }

--- a/apps/credence-pi/eval/train_routing_brain.jl
+++ b/apps/credence-pi/eval/train_routing_brain.jl
@@ -2,6 +2,12 @@
 #
 # train_routing_brain.jl — distil the WARM routing belief from the measured oracle grid.
 #
+# SUPERSEDED (2026-06-17) by train_routing_from_matrix.jl: eval/calibration.jl showed this
+# short-MCQ warm MIS-RANKS tiers on agentic tasks (it orders haiku<sonnet<opus, but tb
+# reality is sonnet>opus). The shipped routing_brain.counts.json now comes from the AGENTIC
+# Terminal-Bench matrix. Kept for provenance; do NOT run it to regenerate the shipped belief
+# (it would re-introduce the mis-rank).
+#
 # Reads the real-model oracle grid (the de-risk fixture:
 # apps/python/credence_router/experiments/routing_dominance/oracle_grid.json — per
 # (model, question) measured MCQ correctness on the 50-item labelled bank) and emits

--- a/apps/credence-pi/eval/train_routing_from_matrix.jl
+++ b/apps/credence-pi/eval/train_routing_from_matrix.jl
@@ -1,0 +1,77 @@
+# Role: eval
+#
+# train_routing_from_matrix.jl — warm the routing belief from the AGENTIC Terminal-Bench
+# matrix (replacing the short-MCQ oracle grid that train_routing_brain.jl used).
+#
+# WHY (calibration-motivated): eval/calibration.jl showed the MCQ-warmed belief MIS-RANKS
+# tiers on agentic tasks — it orders haiku<sonnet<opus, but tb reality is sonnet>opus
+# (sonnet 36/51, opus 32/51). The router's job IS agentic (OpenClaw), so warm it from
+# agentic data: per (tier, prompt-length bucket) resolved/not counts over the tb matrix. The
+# length buckets match routing-features.ts EXACTLY (short ≤400, medium ≤1000, long >1000
+# instruction chars) — the train/live synchronisation point — so finer prompt-length carries
+# real, length-varying agentic signal from install.
+#
+# NON-CAUSAL (Role: eval): reads measured data, tallies counts, writes + verifies the
+# routing_brain.counts.json fixture. No belief drives a decision here.
+#   julia --project=. apps/credence-pi/eval/train_routing_from_matrix.jl
+
+push!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..", "src")))
+using JSON3
+
+const MATRIX = normpath(joinpath(@__DIR__, "live_ab", "results", "tb_matrix_rep3.jsonl"))
+const OUT = normpath(joinpath(@__DIR__, "..", "brain", "routing_brain.counts.json"))
+
+# Tier → roster model-id; order MUST match routing.bdsl routing-models (positional warm seed).
+const TIERS = ["haiku", "sonnet", "opus"]
+const TIER_ID = Dict("haiku" => "claude-haiku-4-5", "sonnet" => "claude-sonnet-4-6",
+                     "opus" => "claude-opus-4-8")
+const NAMES = ["cheap", "mid", "exp"]
+const BUCKETS = ["short", "medium", "long"]
+
+# prompt-length bucket — MUST match routing-features.ts (short ≤400, medium ≤1000, long >1000).
+length_bucket(n) = n <= 400 ? "short" : (n <= 1000 ? "medium" : "long")
+
+function main()
+    rows = [JSON3.read(ln) for ln in eachline(MATRIX) if !isempty(strip(ln))]
+    counts = Dict{Tuple{String, String}, Vector{Int}}()        # (tier, bucket) -> [n1, n0]
+    for r in rows
+        tier = String(r.tier)
+        haskey(TIER_ID, tier) || continue
+        c = get!(counts, (tier, length_bucket(Int(r.instr_len))), [0, 0])
+        r.resolved ? (c[1] += 1) : (c[2] += 1)
+    end
+
+    per_model = Any[]
+    for tier in TIERS
+        ctxs = Any[]
+        for b in BUCKETS
+            c = get(counts, (tier, b), [0, 0])
+            (c[1] == 0 && c[2] == 0) && continue              # no data ⇒ leave the cell at prior
+            push!(ctxs, Dict("ctx" => [b], "n1" => c[1], "n0" => c[2]))
+        end
+        push!(per_model, Dict("contexts" => ctxs))
+    end
+
+    out = Dict(
+        "artifact" => "credence-pi warm routing belief P(correct|prompt-length) — per-model counts",
+        "source" => "tb_matrix_rep3.jsonl (agentic Terminal-Bench: 17 tasks × 3 tiers × 3 reps), bucketed by instruction length",
+        "note" => "AGENTIC warm — replaces the short-MCQ oracle grid, which eval/calibration.jl showed mis-ranks tiers on agentic tasks (it ordered haiku<sonnet<opus; tb reality is sonnet>opus). Buckets match routing-features.ts: short ≤400, medium ≤1000, long >1000 chars. The daemon reconstructs K StructureBMA posteriors by replaying these counts via observe; empty cells stay at the prior and learn online.",
+        "features" => ["prompt-length"],
+        "feature_values" => [BUCKETS],
+        "models" => NAMES,
+        "model_ids" => [TIER_ID[t] for t in TIERS],
+        "per_model" => per_model,
+    )
+    open(OUT, "w") do io; JSON3.pretty(io, out); end
+    println("wrote ", OUT)
+    for tier in TIERS, b in BUCKETS
+        c = get(counts, (tier, b), [0, 0]); tot = c[1] + c[2]
+        tot == 0 && continue
+        println("  ", rpad(tier, 8), rpad(b, 8), "n1=", c[1], " n0=", c[2],
+                "  rate=", round(c[1] / tot, digits = 3))
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/apps/credence-pi/openclaw-plugin/src/routing-features.ts
+++ b/apps/credence-pi/openclaw-plugin/src/routing-features.ts
@@ -1,31 +1,40 @@
 // routing-features.ts — the body's sensory periphery for MODEL ROUTING.
 //
-// before_model_resolve hands the plugin the prompt and nothing else, so the only
-// HONESTLY-extractable routing feature is the prompt's length. Semantic category — the
-// signal the offline oracle actually measured — is NOT available live without a
-// classifier, which would be an arbitrary, unmeasured component (and the project bars
-// arbitrary constants/heuristics in the reasoning path). The daemon's structure-BMA
-// discovers whether length predicts accuracy and collapses to the marginal if it does
-// not, so declaring only length is honest and self-correcting.
+// before_model_resolve hands the plugin the prompt (and, on current OpenClaw, attachment
+// metadata) — so the honestly-extractable routing feature is the prompt's LENGTH, now in
+// finer short/medium/long buckets. Semantic category — the signal the offline oracle
+// measured — is NOT available live without a classifier, an arbitrary unmeasured component
+// the project bars. The daemon's structure-BMA discovers which length splits predict
+// accuracy and collapses the rest to the marginal, so finer buckets are self-correcting.
+// (attachments is the natural next covariate: BeforeModelResolveEvent.attachments carries
+// kind/mimeType for file-aware routing — added once it has a warm/online path.)
 //
-// The short/long boundary is the ONE train/live synchronisation point. Training
-// (apps/credence-pi/eval/train_routing_brain.jl) seeds the "short" prompt-length cell
-// from the short-MCQ oracle bank — so this boundary defines the regime the daemon's warm
-// belief was measured on. If you change it, the warm belief's "short" cell no longer
-// matches what the body now calls "short". Keep the value here and documented.
+// The bucket boundaries are the train/live SYNCHRONISATION POINT. The warm belief
+// (apps/credence-pi/eval/train_routing_from_matrix.jl) seeds each prompt-length cell from
+// the agentic Terminal-Bench matrix's instruction lengths bucketed the SAME way — so that
+// is the regime the daemon's warm belief was measured on. Change a boundary here and you
+// must re-seed (re-run that trainer), or the body's "short" stops matching the belief's
+// "short". Keep the values here and documented.
 
 import type { BeforeModelResolveEvent } from "./openclaw-types.js";
 
 export type RoutingFeatures = Record<string, string>;
 
-// Prompts at or below this many characters are "short" (MCQ-scale and brief asks — the
-// regime the warm belief was measured on); longer prompts are "long" (unmeasured warm
-// belief leans on the marginal structure until online learning lands).
-export const PROMPT_LENGTH_SHORT_MAX_CHARS = 1000;
+// Finer than the old binary split: short ≤ 400 chars, medium 401–1000, long > 1000. (Prefer
+// fine parameterisation — the structure-BMA collapses unhelpful splits.) The warm trainer
+// buckets the matrix's instruction lengths with these SAME boundaries.
+export const PROMPT_LENGTH_SHORT_MAX_CHARS = 400;
+export const PROMPT_LENGTH_MEDIUM_MAX_CHARS = 1000;
+
+export function promptLengthBucket(len: number): string {
+  if (len <= PROMPT_LENGTH_SHORT_MAX_CHARS) return "short";
+  if (len <= PROMPT_LENGTH_MEDIUM_MAX_CHARS) return "medium";
+  return "long";
+}
 
 export function extractRoutingFeatures(event: BeforeModelResolveEvent): RoutingFeatures {
   const prompt = typeof event.prompt === "string" ? event.prompt : "";
   return {
-    "prompt-length": prompt.length <= PROMPT_LENGTH_SHORT_MAX_CHARS ? "short" : "long",
+    "prompt-length": promptLengthBucket(prompt.length),
   };
 }

--- a/apps/credence-pi/tests/julia/test_routing.jl
+++ b/apps/credence-pi/tests/julia/test_routing.jl
@@ -54,12 +54,15 @@ let env = routing_env()
     @assert length(rt.costs) == 3 && rt.costs[1] < rt.costs[2] < rt.costs[3]
     ok("wire_routing! parses the declared roster (3 models, ascending cost)")
 
-    # Warm belief: posterior-mean accuracy at a short prompt is ordered cheap<mid<exp,
-    # shrunk from the measured 0.88/0.96/0.98 toward the Beta(2,2) prior.
+    # Warm belief (AGENTIC, from the tb matrix): posterior-mean accuracy at a short prompt is
+    # ordered haiku < opus < sonnet — sonnet is the best-believed on short agentic tasks. (The
+    # superseded MCQ warm wrongly ordered opus top; eval/calibration.jl quantified the
+    # mis-rank.) Beta(2,2)-shrunk from the measured short-bucket rates (haiku 0.33 / sonnet
+    # 0.70 / opus 0.57).
     θ = [posterior_accuracy(rt.model, rt.tops[i], ["short"]) for i in 1:3]
-    @assert θ[1] < θ[2] < θ[3]
-    @assert 0.80 < θ[1] < 0.90 && 0.90 < θ[3] < 0.96
-    ok("warm belief: P(correct|short) ordered haiku<sonnet<opus, Beta-shrunk ($(round.(θ, digits = 3)))")
+    @assert θ[1] < θ[3] < θ[2]          # haiku < opus < sonnet
+    @assert 0.30 < θ[1] < 0.42 && 0.62 < θ[2] < 0.72 && 0.50 < θ[3] < 0.62
+    ok("warm belief: P(correct|short) ordered haiku<opus<sonnet, agentic-warmed ($(round.(θ, digits = 3)))")
 
     @assert haskey(env, Symbol("route-decide"))
     ok("wire_routing! installed env[:route-decide]")
@@ -76,13 +79,14 @@ let env = routing_env()
     ok("cost-hawk (reward 0.02): routes the cheap model (haiku) at short AND long")
 end
 
-# Quality-hawk (reward 1.0): route the BEST-BELIEVED model where the belief is warm.
+# Quality-hawk (reward 1.0): route the BEST-BELIEVED model where the belief is warm — now
+# sonnet (the agentic warm's top tier at short), which is also CHEAPER than opus: better+cheaper.
 let env = routing_env(reward = 1.0)
     wire_routing!(env)
     choice = env[Symbol("route-decide")](Dict("prompt-length" => "short"))
-    @assert choice["model"] == "claude-opus-4-8"
-    @assert choice["provider"] == "anthropic" && choice["name"] == "opus"
-    ok("quality-hawk (reward 1.0): routes the best-believed model (opus) on a short prompt")
+    @assert choice["model"] == "claude-sonnet-4-6"
+    @assert choice["provider"] == "anthropic" && choice["name"] == "sonnet"
+    ok("quality-hawk (reward 1.0): routes the best-believed model (sonnet) on a short prompt — better AND cheaper than opus")
 end
 
 # Per-profile divergence on ONE shared belief is the Wald core: same warm belief, the
@@ -327,16 +331,17 @@ end
 # C4. Human approve/reject is the gold anchor: a KNOWN label drives θ hard.
 let rt = wire_routing!(routing_env())
     before = θat(rt, 1)
-    for _ in 1:25; route_outcome!(rt, rt.model_ids[1], FEAT_SHORT, false; human = false); end
-    @assert θat(rt, 1) < before - 0.2
+    for _ in 1:40; route_outcome!(rt, rt.model_ids[1], FEAT_SHORT, false; human = false); end
+    @assert θat(rt, 1) < before - 0.15      # sharp drop from the agentic warm start (~0.39)
     ok("human reject is the gold anchor: θ falls sharply ($(round(before, digits = 3)) → $(round(θat(rt, 1), digits = 3)))")
 end
 
-# C5. Identifiability (seeded synthetic stream). ρ (correct ⇒ clean-exec, the dominant
-# confound for high-accuracy models) recovers tightly; θ stays anchored-stable. σ (wrong ⇒
-# clean-exec) is only WEAKLY identified — C=0 is rare when models are mostly correct, so
-# little data bears on it (an honest limit; its decode influence is proportionally small).
-# Seeded ⇒ reproducible; bands carry comfortable margin.
+# C5. Identifiability (seeded synthetic stream). With the AGENTIC warm (θ≈0.4–0.7, not the
+# MCQ regime's ≈0.9), C=1 no longer dominates, so ρ = P(exec-clean | correct) is only
+# PARTIALLY identified: it recovers from the 0.67 prior toward 0.9 but lands ~0.78 (fewer C=1
+# samples than the high-accuracy regime — an honest limit of warming on harder tasks). θ
+# stays anchored-stable; σ stays weakly identified. Seeded ⇒ reproducible; bands carry
+# comfortable margin around the recovered values.
 let rt = wire_routing!(routing_env())
     ρ_true, σ_true = 0.9, 0.25
     θtrue = [θat(rt, a) for a in 1:3]            # the warm anchors — data is consistent with them
@@ -349,10 +354,10 @@ let rt = wire_routing!(routing_env())
         route_outcome!(rt, rt.model_ids[a], FEAT_SHORT, e)
     end
     Δθ = maximum(abs.([θat(rt, a) for a in 1:3] .- θtrue))
-    @assert abs(ρ̄of(rt) - ρ_true) < 0.06        # ρ tightly identified
+    @assert ρ̄of(rt) > 0.74 && abs(ρ̄of(rt) - ρ_true) < 0.15   # partially identified: 0.67 prior → ~0.78 → 0.9
     @assert Δθ < 0.05                            # θ anchored-stable under consistent data
-    @assert abs(σ̄of(rt) - σ_true) < 0.25         # σ weakly identified (rare C=0) — honest loose band
-    ok("identifiability: ρ̄=$(round(ρ̄of(rt), digits = 3))≈$(ρ_true) (tight), θ stable (Δ$(round(Δθ, digits = 3))); σ weakly identified")
+    @assert abs(σ̄of(rt) - σ_true) < 0.25         # σ weakly identified — honest loose band
+    ok("identifiability: ρ̄=$(round(ρ̄of(rt), digits = 3)) (0.67 prior → 0.9, partially identified), θ stable (Δ$(round(Δθ, digits = 3))); σ weak")
 end
 
 # ── D. Online learning through the daemon: route-outcome → live tops, exact replay ──


### PR DESCRIPTION
## What (workstreams 3 + warm)

Richer routing covariates + warming the new features — motivated directly by the calibration finding in #126 (the short-MCQ warm mis-ranks tiers on agentic tasks).

- **Finer prompt-length** — short/medium/long (was binary short/long). Your "prefer fine parameterisation"; the structure-BMA collapses unhelpful splits, so finer can't hurt. Synced across `routing.bdsl` (space), `routing-features.ts` (short ≤400 / medium ≤1000 / long >1000 chars), and the warm trainer (the train/live sync point).
- **Agentic re-warm** — `train_routing_from_matrix.jl` seeds `routing_brain.counts.json` per (tier, length-bucket) from the **agentic tb matrix**, replacing the short-MCQ oracle grid. This *fixes the calibration mis-rank*: the warm now orders haiku<opus<sonnet at short (sonnet 0.70 best), matching tb reality (sonnet 36/51 > opus 32/51). `train_routing_brain.jl` marked **SUPERSEDED** (kept for provenance; re-running it would re-introduce the mis-rank).

## ⚠️ Shipped-behavior change (flagging for sign-off)

Quality-biased routing now picks **sonnet, not opus** — which on agentic tasks is **better *and* cheaper**. cost-hawk still routes haiku. This is the calibration-motivated correction, but it does change the default, so it's called out for review.

## Tests

- `test_routing.jl`: warm-belief assertions updated to the agentic ordering; C4/C5 bands recalibrated to the lower-θ regime (ρ is now *partially* identified, 0.67 prior → 0.78 → 0.9 — an honest limit of warming on harder, lower-accuracy tasks, vs the old high-θ MCQ regime). **30/30 Julia**.
- **46/46 plugin**, typecheck clean; lint clean (pragma-free).

## Follow-ups
`attachments` as the next covariate (file-aware routing; needs its own warm/online path); `api.on → registerHook` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)