### PR TITLE
answer-brain: gate the Julia + TS suite in CI

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -64,6 +64,13 @@ jobs:
             julia --project=. "$f"
           done
 
+      - name: answer-brain Julia tests
+        run: |
+          for f in apps/answer-brain/tests/julia/*.jl; do
+            echo "=== $f ==="
+            julia --project=. "$f"
+          done
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -78,6 +85,23 @@ jobs:
 
       - name: credence-pi OpenClaw-plugin build + tests
         working-directory: apps/credence-pi/openclaw-plugin
+        run: |
+          npm install
+          npm run build
+          npm test
+
+      # ── answer-brain (the principled RAG answer-brain on pi-mono) ──
+      # The governor core (brain-body) and the pi-mono body extension.
+      # Each is self-contained: `tsc --noEmit` + node:test via tsx.
+      - name: answer-brain brain-body build + tests
+        working-directory: packages/brain-body
+        run: |
+          npm install
+          npm run build
+          npm test
+
+      - name: answer-brain extension build + tests
+        working-directory: apps/answer-brain/extension
         run: |
           npm install
           npm run build


### PR DESCRIPTION
## What

The answer-brain (the principled RAG answer-brain on pi-mono — Moves 1–4, merged in #125) shipped with **140 Julia + 21 TS** checks that **CI never ran**. The `unit-tests` job exercised only credence-pi; it lints `apps/` (so a broken `.bdsl` is caught) but executes no answer-brain test. A green pipeline therefore said nothing about this code, and the suite had to be run by hand on every change — the gap flagged when #125 merged.

This mirrors the existing credence-pi steps for `apps/answer-brain`, adding to the `unit-tests` job:

- **Julia** — loop `apps/answer-brain/tests/julia/*.jl` under `--project=.`, reusing the existing *Instantiate Credence Julia project* resolution (no new setup):
  - `test_answer_brain` 57 · `test_gather` 14 · `test_manifest` 16 · `test_server` 53
- **TS** — `tsc --noEmit` + `node:test` via tsx, after the existing Node setup:
  - the governor core `packages/brain-body` (15)
  - the pi-mono body `apps/answer-brain/extension` (6)

## Why it gates

`smoke-build`, `daemon-smoke-build`, and both `publish` jobs already `needs: unit-tests`, so the answer-brain suite now blocks the whole pipeline (including image publish) on a regression — the point of the change.

## Validation

Run locally from a fresh worktree off `master` with the exact CI commands (fresh `npm install`; Julia after the instantiate step): **140 Julia + 21 TS green**, both `tsc --noEmit` clean. No source changed — config only; the suites themselves are unchanged from #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)