### PR TITLE
answer-brain: body posts the terminal decision to /log_decision

### DIFF
--- a/apps/answer-brain/extension/src/bridge.ts
+++ b/apps/answer-brain/extension/src/bridge.ts
@@ -3,7 +3,7 @@
 // shapes evidence, the body composes it. Errors throw (the governor fail-opens
 // around the whole loop); these calls are loopback and fast.
 
-import type { ExtractResult, Hit, RouteResult } from "./types.js";
+import type { ExtractResult, Hit, LoggedDecision, RouteResult } from "./types.js";
 
 export interface BridgeClient {
 	route(question: string): Promise<RouteResult | null>;
@@ -16,6 +16,13 @@ export interface BridgeClient {
 		timeIndexed: boolean,
 	): Promise<ExtractResult>;
 	utility(): Promise<Record<string, number>>;
+	/** The verdict-emission seam: record the terminal decision the governor enacted, so the
+	 *  owner's one-bit verdict folds into u_wrong. Returns the decision_id to react against. */
+	logDecision(
+		question: string,
+		retrievalKeys: string[],
+		decision: LoggedDecision,
+	): Promise<{ decision_id: string }>;
 }
 
 export interface BridgeOptions {
@@ -75,6 +82,13 @@ export function createBridgeClient(baseUrl: string, opts: BridgeOptions = {}): B
 		async utility() {
 			const { u_bar } = await call<{ u_bar: Record<string, number> }>("GET", "/utility");
 			return u_bar;
+		},
+		async logDecision(question, retrievalKeys, decision) {
+			return await call<{ decision_id: string }>("POST", "/log_decision", {
+				question,
+				retrieval_keys: retrievalKeys,
+				decision,
+			});
 		},
 	};
 }

--- a/apps/answer-brain/extension/src/daemon.ts
+++ b/apps/answer-brain/extension/src/daemon.ts
@@ -117,6 +117,36 @@ function terminalSignal(resp: DecideResponse, ev: Evidence): EffectorSignal {
 	}
 }
 
+// Terminal brain actions; `gather` is a steer the body enacts internally, never logged.
+const TERMINAL_ACTIONS = new Set(["report", "hedge", "ask_clarify", "abstain"]);
+
+// The verdict-emission seam (move-4 successor): post the terminal decision the governor
+// enacted to the bridge's /log_decision, so the owner's one-bit verdict folds into u_wrong
+// through life-agent's EXISTING reaction loop. BEST-EFFORT: a logging failure is non-fatal —
+// it must never change the decision — so errors are swallowed (noted via onStep). The bridge
+// owns the write and sorts the candidate-order credences leader-first.
+async function logTerminalDecision(
+	ev: Evidence,
+	resp: DecideResponse,
+	bridge: BridgeClient,
+	opts: DecideOptions,
+): Promise<void> {
+	if (!TERMINAL_ACTIONS.has(resp.effector)) return; // a non-terminal slipped through; nothing to log
+	try {
+		const { decision_id } = await bridge.logDecision(ev.question, ev.hitKeys, {
+			effector: resp.effector,
+			credences: resp.credences,
+			p_none: resp.p_none,
+			eu: resp.eu,
+			candidates: ev.candidates,
+			n_obs: ev.observations.length,
+		});
+		opts.onStep?.(`decision logged ${decision_id} — react with: /react ${decision_id} g|b`);
+	} catch (e) {
+		opts.onStep?.(`decision logging failed (non-fatal, answer unaffected): ${String(e)}`);
+	}
+}
+
 /**
  * The injected `askBrain`: decide, enacting any `gather(recency)` steer internally,
  * and return the terminal effector signal. Mutates `ev` (the accumulator) in place —
@@ -139,7 +169,11 @@ export async function decideWithGather(
 			resp.probe === "recency" &&
 			!ev.appliedProbes.includes("recency");
 		if (!steerRecency) {
-			return terminalSignal(resp, ev);
+			const signal = terminalSignal(resp, ev);
+			// Record the enacted decision for the reaction loop — AFTER deciding, best-effort, so a
+			// logging failure can never flip a good answer to a block (the signal returns regardless).
+			await logTerminalDecision(ev, resp, bridge, opts);
+			return signal;
 		}
 
 		opts.onStep?.(

--- a/apps/answer-brain/extension/src/daemon.ts
+++ b/apps/answer-brain/extension/src/daemon.ts
@@ -170,9 +170,12 @@ export async function decideWithGather(
 			!ev.appliedProbes.includes("recency");
 		if (!steerRecency) {
 			const signal = terminalSignal(resp, ev);
-			// Record the enacted decision for the reaction loop — AFTER deciding, best-effort, so a
-			// logging failure can never flip a good answer to a block (the signal returns regardless).
-			await logTerminalDecision(ev, resp, bridge, opts);
+			// Record the enacted decision for the reaction loop — best-effort and FIRE-AND-FORGET:
+			// NOT awaited, so a slow or hung bridge logger can never add latency to the govern path
+			// (an await here could, worst case, eat the govern timeout → fail-closed → silently
+			// withhold a good answer). logTerminalDecision swallows all its own errors, so the
+			// un-awaited promise never rejects.
+			void logTerminalDecision(ev, resp, bridge, opts);
 			return signal;
 		}
 

--- a/apps/answer-brain/extension/src/types.ts
+++ b/apps/answer-brain/extension/src/types.ts
@@ -33,6 +33,20 @@ export interface ExtractResult {
 	era_split: boolean;
 }
 
+/** The terminal decision the body posts to the bridge's POST /log_decision (the
+ *  verdict-emission seam): the effector the governor enacted + the posterior, shaped so
+ *  life-agent appends it as a lookup decision and the owner's one-bit verdict folds into
+ *  u_wrong through the EXISTING reaction loop. `credences`/`candidates` are in candidate
+ *  order (the bridge sorts leader-first). */
+export interface LoggedDecision {
+	effector: string; // report | hedge | ask_clarify | abstain (a terminal action, never gather)
+	credences: number[];
+	p_none: number;
+	eu: number;
+	candidates: string[];
+	n_obs: number;
+}
+
 /** The daemon's POST /decide response (apps/answer-brain/daemon/server.jl). */
 export interface DecideResponse {
 	effector: string; // report | hedge | ask_clarify | abstain | gather

--- a/apps/answer-brain/extension/tests/governor.test.ts
+++ b/apps/answer-brain/extension/tests/governor.test.ts
@@ -309,3 +309,15 @@ test("does not log when the daemon is unreachable (no decision was made)", async
 	assert.ok(outcome?.block, "fail-closed");
 	assert.equal(fb.logged.length, 0, "nothing logged — only real terminal decisions are recorded");
 });
+
+test("a hung logger does not block or delay the decision (fire-and-forget)", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult({ era_split: false }) });
+	// A logger that NEVER resolves: were it awaited, the govern loop would hang to its timeout and
+	// fail-closed — silently withholding a good answer. Fire-and-forget must return the decision
+	// without waiting on the logger. (With `await` instead of `void`, this test would time out.)
+	fb.bridge.logDecision = () => new Promise<{ decision_id: string }>(() => {});
+	const outcome = await runOnce(fb, [
+		decide({ effector: "report", value: "Vcur", report_index: 1, credences: [0.1, 0.85], p_none: 0.05 }),
+	]);
+	assert.equal(outcome, undefined, "report allowed immediately, not waiting on the logger");
+});

--- a/apps/answer-brain/extension/tests/governor.test.ts
+++ b/apps/answer-brain/extension/tests/governor.test.ts
@@ -9,7 +9,7 @@ import assert from "node:assert/strict";
 import type { BridgeClient } from "../src/bridge.js";
 import { createAnswerBrainExtension } from "../src/index.js";
 import type { PiLike, PiToolCallEvent, PiToolDefinition, ToolCallHandler, ToolCallOutcome } from "../src/pi.js";
-import type { DecideResponse, ExtractResult, Hit, RouteResult } from "../src/types.js";
+import type { DecideResponse, ExtractResult, Hit, LoggedDecision, RouteResult } from "../src/types.js";
 
 const MANIFEST = {
 	effectors: [
@@ -83,10 +83,22 @@ interface FakeBridgeOpts {
 	hits?: Hit[];
 	extractBaseline?: ExtractResult;
 	extractRecency?: ExtractResult;
+	logThrows?: boolean; // /log_decision rejects — proves logging is non-fatal to the decision
 }
 
-function fakeBridge(opts: FakeBridgeOpts = {}): { bridge: BridgeClient; extractCalls: boolean[] } {
+interface LogCall {
+	question: string;
+	retrievalKeys: string[];
+	decision: LoggedDecision;
+}
+
+function fakeBridge(opts: FakeBridgeOpts = {}): {
+	bridge: BridgeClient;
+	extractCalls: boolean[];
+	logged: LogCall[];
+} {
 	const extractCalls: boolean[] = [];
+	const logged: LogCall[] = [];
 	const bridge: BridgeClient = {
 		route: async () => (opts.route === undefined ? { construct: "mobile number", time_indexed: false } : opts.route),
 		retrieve: async () => opts.hits ?? [{ artifact_cache_key: "d1" }, { artifact_cache_key: "d2" }],
@@ -98,8 +110,13 @@ function fakeBridge(opts: FakeBridgeOpts = {}): { bridge: BridgeClient; extractC
 				: (opts.extractBaseline ?? extractResult());
 		},
 		utility: async () => ({ u_correct: 1, u_wrong: -4, u_hedged: -0.5, u_abstain: 0, lambda_int: 1 }),
+		logDecision: async (question, retrievalKeys, decision) => {
+			if (opts.logThrows) throw new Error("bridge /log_decision → 500");
+			logged.push({ question, retrievalKeys, decision });
+			return { decision_id: `ab-test-${logged.length}` };
+		},
 	};
-	return { bridge, extractCalls };
+	return { bridge, extractCalls, logged };
 }
 
 // GET /manifest → MANIFEST; POST /decide → the next scripted response.
@@ -160,6 +177,7 @@ test("statelessness: a new narrative question does not reuse the prior question'
 		probeRecency: async () => ({ d1: "2026-01-01" }),
 		extract: async () => extractResult({ candidates: ["A"], era_split: false }),
 		utility: async () => ({ u_correct: 1, u_wrong: -4, u_hedged: -0.5, u_abstain: 0, lambda_int: 1 }),
+		logDecision: async () => ({ decision_id: "ab-test" }),
 	};
 	// Only ONE /decide is scripted (q1). If q2's evidence leaked, q2 would decide → throw.
 	const ff = fakeFetch([decide({ effector: "report", value: "A", report_index: 0, credences: [0.9], p_none: 0.1 })]);
@@ -214,4 +232,80 @@ test("registers retrieve / extract / answer tools", async () => {
 	assert.ok(h.tool("retrieve_documents"));
 	assert.ok(h.tool("extract_candidates"));
 	assert.ok(h.tool("answer"));
+});
+
+// --- the verdict-emission seam: the body posts the terminal decision to /log_decision -----
+
+async function runOnce(
+	fb: ReturnType<typeof fakeBridge>,
+	decideQueue: DecideResponse[],
+	question = "what is my mobile number?",
+): Promise<ToolCallOutcome> {
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, { bridge: fb.bridge, fetchImpl: fakeFetch(decideQueue), log: () => {} });
+	await h.tool("retrieve_documents").execute("1", { question });
+	await h.tool("extract_candidates").execute("2", {});
+	return h.govern({ toolName: "answer", input: { value: "draft" } });
+}
+
+test("logs the terminal report decision to the bridge for the reaction loop", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult({ era_split: false }) });
+	await runOnce(fb, [decide({ effector: "report", value: "Vcur", report_index: 1, credences: [0.1, 0.85], p_none: 0.05 })]);
+	assert.equal(fb.logged.length, 1, "one decision logged");
+	const { question, retrievalKeys, decision } = fb.logged[0];
+	assert.equal(question, "what is my mobile number?");
+	assert.deepEqual(retrievalKeys, ["d1", "d2"], "the hit keys the decision was grounded on");
+	assert.equal(decision.effector, "report");
+	assert.deepEqual(decision.credences, [0.1, 0.85], "credences forwarded in candidate order (bridge sorts)");
+	assert.deepEqual(decision.candidates, ["Vstale", "Vcur"]);
+	assert.equal(decision.p_none, 0.05);
+});
+
+test("logs the abstain decision (the row that folds into u_wrong)", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult({ era_split: false }) });
+	const outcome = await runOnce(fb, [decide({ effector: "abstain", credences: [0.3, 0.25], p_none: 0.45 })]);
+	assert.ok(outcome?.block, "abstain blocks");
+	assert.equal(fb.logged.length, 1);
+	assert.equal(fb.logged[0].decision.effector, "abstain");
+});
+
+test("gather-then-report logs ONCE — the terminal report, not the intermediate steer", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult(), extractRecency: extractResult() });
+	await runOnce(fb, [
+		decide({ effector: "gather", probe: "recency", target: "Vstale", credences: [0.55, 0.3], p_none: 0.15 }),
+		decide({ effector: "report", value: "Vcur", report_index: 1, credences: [0.1, 0.85], p_none: 0.05 }),
+	]);
+	assert.equal(fb.logged.length, 1, "the gather steer is not a logged decision");
+	assert.equal(fb.logged[0].decision.effector, "report");
+});
+
+test("a logging failure is non-fatal: the report is still allowed (answer unaffected)", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult({ era_split: false }), logThrows: true });
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, {
+		bridge: fb.bridge,
+		fetchImpl: fakeFetch([decide({ effector: "report", value: "Vcur", report_index: 1, credences: [0.1, 0.85], p_none: 0.05 })]),
+		log: () => {},
+	});
+	await h.tool("retrieve_documents").execute("1", { question: "my mobile?" });
+	await h.tool("extract_candidates").execute("2", {});
+	const event: PiToolCallEvent = { toolName: "answer", input: { value: "draft" } };
+	const outcome = await h.govern(event);
+	assert.equal(outcome, undefined, "report still ALLOWED despite the logging failure");
+	assert.equal(event.input.value, "Vcur", "value still rewritten to the brain's");
+});
+
+test("does not log when the daemon is unreachable (no decision was made)", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult({ era_split: false }) });
+	const ff = ((url: string) => {
+		if (String(url).endsWith("/manifest")) return Promise.resolve({ ok: true, status: 200, json: async () => MANIFEST });
+		return Promise.reject(new Error("ECONNREFUSED"));
+	}) as unknown as typeof fetch;
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, { bridge: fb.bridge, fetchImpl: ff, log: () => {} });
+	await h.tool("retrieve_documents").execute("1", { question: "my id?" });
+	await h.tool("extract_candidates").execute("2", {});
+	const outcome = await h.govern({ toolName: "answer", input: { value: "draft" } });
+	assert.ok(outcome?.block, "fail-closed");
+	assert.equal(fb.logged.length, 0, "nothing logged — only real terminal decisions are recorded");
 });


### PR DESCRIPTION
## Why

The body half of the **verdict-emission seam** (life-agent half: [#15](https://github.com/gfrmin/life-agent/pull/15) adds bridge `POST /log_decision`). Without it, the answer-brain decides and enacts but **records nothing** — dogfooding accrues no foldable verdicts, and the §8 adoption gate can't move on its named lever (narrow `u_wrong` from real verdicts).

## What

In `decideWithGather`, once the daemon returns a **terminal** effector (`report`/`hedge`/`ask_clarify`/`abstain` — never the `gather` steer, which the body enacts internally), the body POSTs it to the bridge's `/log_decision` with the question, the hit keys it was grounded on, and the posterior (`credences`/`p_none`/`eu`/`candidates`). life-agent appends it shaped as a lookup decision; the owner's `/react <id> g|b` then folds it into `u_wrong` through the existing reaction loop. The app already surfaces the returned `decision_id` via its `log` callback.

## Load-bearing property: logging is best-effort and non-fatal

It runs **after** the decision is computed and **swallows any error** (noted via `onStep`), so a `/log_decision` failure can never flip a good answer into a block. The fail-closed guarantee remains for an unreachable *daemon* (no decision was made), not for a logging hiccup. Only real terminal decisions are logged — the gather steer and a daemon-unreachable failure log nothing.

## Tests

5 new transport-free tests in `governor.test.ts`:
- logs the terminal report (question + hit keys + posterior forwarded)
- logs the abstain (the `u_wrong`-folding row)
- gather-then-report logs **once** (the terminal report, not the steer)
- a logging failure leaves the report **allowed** (non-fatal)
- daemon-unreachable logs **nothing** (only real decisions recorded)

Extension suite: **11 passed**; `tsc --noEmit` clean on the extension and the app. The answer-brain CI added in #128 now gates this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)