### PR TITLE
answer-brain: onDecision hook + app REPL with in-app verdict capture (Stage B)

### DIFF
--- a/apps/answer-brain/app/README.md
+++ b/apps/answer-brain/app/README.md
@@ -1,10 +1,11 @@
-# answer-brain demo app
+# answer-brain app
 
-A minimal pi-mono agent, driven by a local **Ollama** model, that answers the owner's
-point-fact questions through the answer-brain body. **This is the demo, not the gate** —
-the gate (`life-agent/scripts/answer_brain_gate.py`) certifies the decision math
-deterministically; this *shows* the govern+steer loop end-to-end with a real LLM driving
-the tools and the brain governing the answer. Its result is reported, not assumed.
+A pi-mono agent, driven by a local **Ollama** model, that answers the owner's point-fact
+questions through the answer-brain body and **captures a one-bit good/bad verdict** that folds
+into `u_wrong` (Stage B — the dogfood driver). **This is the driver, not the gate** — the gate
+(`life-agent/scripts/answer_brain_gate.py`) certifies the decision math deterministically; this
+runs the govern+steer loop end-to-end with a real (nondeterministic) LLM driving the tools and
+the brain governing the answer, and accrues the owner's verdicts.
 
 Everything runs on-machine (the corpus is the owner's real PII — no cloud model).
 
@@ -19,19 +20,30 @@ npm install
 npm run check
 ```
 
-## main.ts — the full agent (opt-in)
+## main.ts — the full agent (REPL + verdict capture)
+
+The easy way is the launcher (in life-agent), which starts the daemon + bridge, waits for
+both, runs this app, and tears the services down on exit:
 
 ```bash
-# 1. daemon:  julia --project=$HOME/git/credence $HOME/git/credence/apps/answer-brain/daemon/main.jl
-# 2. bridge:  from a life-agent checkout WITH bridge era_split (branch bridge-era-split):
-#             uv run python -m life_agent.bridge.server
-# 3. Ollama:  the model pulled (default qwen2.5:7b-instruct)
-npm run ask -- "what is my mobile phone number?"
+answer-brain                      # REPL: ask, react [g]ood/[b]ad, repeat
+answer-brain "what is my X?"      # one question, react, exit
+```
+
+Or run the app directly, with the three prereqs already up (daemon :8799, bridge :8798,
+Ollama with the model pulled):
+
+```bash
+npm run ask                       # REPL
+npm run ask -- "what is my X?"    # one-shot
 ```
 
 The agent calls `retrieve_documents → extract_candidates → answer`; on `answer` the brain
 posts the accumulated evidence to `/decide` and either lets the answer through (rewritten to
 the evidence-backed value), steers a recency gather (re-extract, re-decide), or withholds.
+After each answer the app prompts a **one-bit** verdict and posts it to the bridge
+(`POST /log_reaction`); an abstain verdict folds into `u_wrong` on the next gate run, a report
+verdict is recorded-not-folded. The verdict is one bit (good/bad) — never free text.
 
 Env: `ANSWER_BRAIN_DAEMON_URL` (:8799), `LIFE_AGENT_BRIDGE_URL` (:8798),
 `ANSWER_BRAIN_MODEL` (qwen2.5:7b-instruct), `OLLAMA_BASE_URL` (http://localhost:11434/v1).

--- a/apps/answer-brain/app/main.ts
+++ b/apps/answer-brain/app/main.ts
@@ -1,19 +1,18 @@
 /**
- * answer-brain demo app — a minimal pi-mono agent driven by a local Ollama model,
- * answering the owner's point-fact questions through the answer-brain body
- * (move-4-design §2E). THIS IS THE DEMO, NOT THE GATE: the gate
- * (life-agent/scripts/answer_brain_gate.py) certifies the decision math
- * deterministically; here a real LLM drives the tools and the brain governs the
- * answer, to *show* the govern+steer loop end-to-end. Its result is reported, not
- * assumed (the LLM is nondeterministic).
+ * answer-brain app — a pi-mono agent driven by a local Ollama model, answering the owner's
+ * point-fact questions through the answer-brain body and capturing a one-bit good/bad verdict
+ * that folds into u_wrong (Stage B). THIS IS THE DOGFOOD DRIVER, NOT THE GATE: the gate
+ * (life-agent/scripts/answer_brain_gate.py) certifies the decision math deterministically; here
+ * a real (nondeterministic) LLM drives the tools and the brain governs the answer, end-to-end.
  *
- * Prereqs (all on-machine; the corpus is the owner's real PII, so no cloud model):
- *   1. the daemon:  julia --project=$HOME/git/credence $HOME/git/credence/apps/answer-brain/daemon/main.jl
- *   2. the bridge:  (from a checkout with bridge `era_split`) python -m life_agent.bridge.server
- *   3. Ollama with the model pulled (default qwen2.5:7b-instruct).
+ * Use `bin/answer-brain` (life-agent), which starts the prereqs for you:
+ *   1. the daemon (Julia, :8799)   2. the bridge (:8798)   3. Ollama (model pulled)
  *
- * Run:  npx tsx main.ts "what is my mobile phone number?"
+ * Run:  npx tsx main.ts                 # REPL: ask, react [g]ood/[b]ad, repeat
+ *       npx tsx main.ts "my mobile?"    # one question, react, exit
  */
+
+import * as readline from "node:readline/promises";
 
 import { getModel as _getModel } from "@earendil-works/pi-ai";
 import {
@@ -54,9 +53,50 @@ function adaptPi(pi: ExtensionAPI): PiLike {
 	};
 }
 
-async function main(): Promise<void> {
-	const question = process.argv.slice(2).join(" ").trim() || "What is my mobile phone number?";
+// The decision the brain just logged for the current question (set by the extension's
+// onDecision hook), or null on a narrative/unlogged answer. The verdict prompt binds to it.
+let lastDecision: { decisionId: string; effector: string } | null = null;
 
+// Post the owner's one-bit verdict to the bridge (/log_reaction) and echo the fold fate.
+// Fail-open: a verdict that fails to record must never break the loop.
+async function postReaction(decisionId: string, valence: "good" | "bad"): Promise<void> {
+	try {
+		const resp = await fetch(`${BRIDGE_URL}/log_reaction`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ decision_id: decisionId, valence }),
+		});
+		if (!resp.ok) {
+			console.error(`  verdict not recorded (HTTP ${resp.status})`);
+			return;
+		}
+		const { folds, chosen_action } = (await resp.json()) as { folds: boolean; chosen_action: string };
+		const fate = folds ? "folds into u_wrong on the next gate run" : "recorded (only abstain verdicts fold)";
+		console.error(`  → ${valence.toUpperCase()} on ${chosen_action} — ${fate}`);
+	} catch (e) {
+		console.error(`  verdict not recorded: ${String(e)}`);
+	}
+}
+
+// One bit, no free text (the owner's prose is the loop's one expensive resource). Enter skips.
+async function captureVerdict(rl: readline.Interface): Promise<void> {
+	if (!lastDecision) return; // narrative path, or the decision was not logged — nothing to grade
+	const ans = (await rl.question("  [g]ood / [b]ad / Enter=skip > ")).trim().toLowerCase();
+	const valence = ans === "g" ? "good" : ans === "b" ? "bad" : null;
+	if (valence) await postReaction(lastDecision.decisionId, valence);
+}
+
+// Ask one question end-to-end: reset the per-question decision, stream the answer, then give the
+// fire-and-forget decision log a beat to land so the verdict prompt can bind to it.
+async function ask(session: { prompt: (q: string) => Promise<unknown> }, question: string): Promise<void> {
+	lastDecision = null;
+	console.error(`\nQ: ${question}\n`);
+	await session.prompt(question);
+	console.log();
+	await new Promise((r) => setTimeout(r, 50)); // the onDecision hook fires just after the answer
+}
+
+async function main(): Promise<void> {
 	const authStorage = AuthStorage.create();
 	const modelRegistry = ModelRegistry.create(authStorage);
 	// Register the local Ollama model (OpenAI-compatible). The apiKey is a dummy Ollama ignores.
@@ -90,6 +130,9 @@ async function main(): Promise<void> {
 					daemonUrl: DAEMON_URL,
 					bridgeUrl: BRIDGE_URL,
 					log: (m) => console.error(`  [answer-brain] ${m}`),
+					onDecision: (d) => {
+						lastDecision = d;
+					},
 				});
 			},
 		],
@@ -107,16 +150,29 @@ async function main(): Promise<void> {
 		thinkingLevel: "off",
 	});
 
-	console.error(`Q: ${question}\n`);
+	session.subscribe((event) => {
+		if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+			process.stdout.write(event.assistantMessageEvent.delta);
+		}
+	});
+
+	const argvQuestion = process.argv.slice(2).join(" ").trim();
+	const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 	try {
-		session.subscribe((event) => {
-			if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
-				process.stdout.write(event.assistantMessageEvent.delta);
+		if (argvQuestion) {
+			await ask(session, argvQuestion);
+			await captureVerdict(rl);
+		} else {
+			console.error("answer-brain — ask a point-fact question about yourself; 'quit' to exit.");
+			for (;;) {
+				const q = (await rl.question("\nask> ")).trim();
+				if (q === "" || q === "quit" || q === "exit") break;
+				await ask(session, q);
+				await captureVerdict(rl);
 			}
-		});
-		await session.prompt(question);
-		console.log();
+		}
 	} finally {
+		rl.close();
 		session.dispose();
 	}
 }

--- a/apps/answer-brain/app/main.ts
+++ b/apps/answer-brain/app/main.ts
@@ -56,6 +56,9 @@ function adaptPi(pi: ExtensionAPI): PiLike {
 // The decision the brain just logged for the current question (set by the extension's
 // onDecision hook), or null on a narrative/unlogged answer. The verdict prompt binds to it.
 let lastDecision: { decisionId: string; effector: string } | null = null;
+// Resolves the current question's "decision logged" wait — set per question in ask(), called by
+// the onDecision hook so the verdict prompt binds deterministically, not on a timed guess.
+let onDecisionLogged: (() => void) | null = null;
 
 // Post the owner's one-bit verdict to the bridge (/log_reaction) and echo the fold fate.
 // Fail-open: a verdict that fails to record must never break the loop.
@@ -90,10 +93,17 @@ async function captureVerdict(rl: readline.Interface): Promise<void> {
 // fire-and-forget decision log a beat to land so the verdict prompt can bind to it.
 async function ask(session: { prompt: (q: string) => Promise<unknown> }, question: string): Promise<void> {
 	lastDecision = null;
+	// Await the fire-and-forget decision log deterministically (bounded) so a verdictable decision
+	// is never dropped on a timing race — the onDecision hook resolves `logged`. Times out at 2s
+	// (a loopback append is sub-ms; a narrative/unlogged answer never resolves it → skip).
+	const logged = new Promise<void>((resolve) => {
+		onDecisionLogged = resolve;
+	});
 	console.error(`\nQ: ${question}\n`);
 	await session.prompt(question);
 	console.log();
-	await new Promise((r) => setTimeout(r, 50)); // the onDecision hook fires just after the answer
+	await Promise.race([logged, new Promise((r) => setTimeout(r, 2000))]);
+	onDecisionLogged = null;
 }
 
 async function main(): Promise<void> {
@@ -132,6 +142,8 @@ async function main(): Promise<void> {
 					log: (m) => console.error(`  [answer-brain] ${m}`),
 					onDecision: (d) => {
 						lastDecision = d;
+						onDecisionLogged?.();
+						onDecisionLogged = null;
 					},
 				});
 			},

--- a/apps/answer-brain/extension/src/daemon.ts
+++ b/apps/answer-brain/extension/src/daemon.ts
@@ -28,6 +28,9 @@ export interface DecideOptions {
 	timeoutMs: number;
 	fetchImpl?: typeof fetch;
 	onStep?: (msg: string) => void;
+	/** Fired best-effort when a terminal decision is logged — the app binds the owner's
+	 *  in-session good/bad verdict to this `decisionId` (POST /log_reaction). */
+	onDecision?: (decision: { decisionId: string; effector: string }) => void;
 }
 
 const MAX_GATHER_STEPS = 4; // recency fires at most once; this is a runaway backstop
@@ -142,6 +145,7 @@ async function logTerminalDecision(
 			n_obs: ev.observations.length,
 		});
 		opts.onStep?.(`decision logged ${decision_id} — react with: /react ${decision_id} g|b`);
+		opts.onDecision?.({ decisionId: decision_id, effector: resp.effector });
 	} catch (e) {
 		opts.onStep?.(`decision logging failed (non-fatal, answer unaffected): ${String(e)}`);
 	}

--- a/apps/answer-brain/extension/src/index.ts
+++ b/apps/answer-brain/extension/src/index.ts
@@ -22,6 +22,9 @@ export interface ExtensionOptions {
 	bridge?: BridgeClient;
 	log?: (msg: string) => void;
 	retrieveK?: number;
+	/** Fired best-effort when a terminal decision is logged — the app binds the owner's
+	 *  in-session good/bad verdict to this decisionId (POST /log_reaction). */
+	onDecision?: (decision: { decisionId: string; effector: string }) => void;
 }
 
 const DEFAULT_DAEMON_URL = "http://127.0.0.1:8799";
@@ -49,6 +52,7 @@ export async function createAnswerBrainExtension(pi: PiLike, opts: ExtensionOpti
 		fetchImpl: opts.fetchImpl,
 		log,
 		retrieveK: opts.retrieveK,
+		onDecision: opts.onDecision,
 	});
 }
 

--- a/apps/answer-brain/extension/src/tools.ts
+++ b/apps/answer-brain/extension/src/tools.ts
@@ -24,6 +24,9 @@ export interface InstallDeps {
 	fetchImpl?: typeof fetch;
 	log?: (msg: string) => void;
 	retrieveK?: number;
+	/** Fired best-effort when a terminal decision is logged — the app binds the owner's
+	 *  in-session verdict to this decisionId (POST /log_reaction). */
+	onDecision?: (decision: { decisionId: string; effector: string }) => void;
 }
 
 const ANSWER_TOOL = "answer";
@@ -157,6 +160,7 @@ export function installAnswerBrain(pi: PiLike, deps: InstallDeps): void {
 					timeoutMs: perCallTimeout,
 					fetchImpl: deps.fetchImpl,
 					onStep: log,
+					onDecision: deps.onDecision,
 				}),
 			dispatch: (signal) => dispatchEffector(effectors, signal, (impl, p) => impl(p, event)),
 			// Fail CLOSED for an answer agent: a brain-unreachable failure must NOT leak an

--- a/apps/answer-brain/extension/tests/governor.test.ts
+++ b/apps/answer-brain/extension/tests/governor.test.ts
@@ -321,3 +321,42 @@ test("a hung logger does not block or delay the decision (fire-and-forget)", asy
 	]);
 	assert.equal(outcome, undefined, "report allowed immediately, not waiting on the logger");
 });
+
+// --- onDecision: the hook the app binds the in-session verdict to -------------------------
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+test("onDecision fires with the logged decision_id and effector (the app's react hook)", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult({ era_split: false }) });
+	const seen: { decisionId: string; effector: string }[] = [];
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, {
+		bridge: fb.bridge,
+		fetchImpl: fakeFetch([decide({ effector: "report", value: "Vcur", report_index: 1, credences: [0.1, 0.85], p_none: 0.05 })]),
+		log: () => {},
+		onDecision: (d) => seen.push(d),
+	});
+	await h.tool("retrieve_documents").execute("1", { question: "my mobile?" });
+	await h.tool("extract_candidates").execute("2", {});
+	await h.govern({ toolName: "answer", input: { value: "draft" } });
+	await flush(); // onDecision fires after the fire-and-forget log resolves
+	assert.equal(seen.length, 1);
+	assert.equal(seen[0].effector, "report");
+	assert.ok(seen[0].decisionId.startsWith("ab-test-"), "carries the bridge's decision_id");
+});
+
+test("onDecision does not fire when no decision is logged (daemon unreachable)", async () => {
+	const fb = fakeBridge({ extractBaseline: extractResult({ era_split: false }) });
+	const seen: unknown[] = [];
+	const ff = ((url: string) => {
+		if (String(url).endsWith("/manifest")) return Promise.resolve({ ok: true, status: 200, json: async () => MANIFEST });
+		return Promise.reject(new Error("ECONNREFUSED"));
+	}) as unknown as typeof fetch;
+	const h = fakePi();
+	await createAnswerBrainExtension(h.pi, { bridge: fb.bridge, fetchImpl: ff, log: () => {}, onDecision: (d) => seen.push(d) });
+	await h.tool("retrieve_documents").execute("1", { question: "my id?" });
+	await h.tool("extract_candidates").execute("2", {});
+	await h.govern({ toolName: "answer", input: { value: "draft" } });
+	await flush();
+	assert.equal(seen.length, 0, "no decision logged → no react hook");
+});


### PR DESCRIPTION
## Stage B (credence half) — the dogfoodable REPL

The verdict seam is wired; this makes the answer-brain a tool the owner actually *uses*, so verdicts accrue. Companion to life-agent [#16](https://github.com/gfrmin/life-agent/pull/16) (`/log_reaction` + `bin/answer-brain` launcher).

### Extension: an `onDecision` hook
A best-effort callback (`ExtensionOptions → InstallDeps → DecideOptions`), fired when a terminal decision is logged, carrying `{ decisionId, effector }`. It rides the existing **fire-and-forget** log, so it stays off the decision path entirely (a non-issue if it never fires). The app binds the owner's in-session verdict to this `decisionId`.

### App: a REPL with verdict capture
`main.ts` becomes a REPL (ask → answer → react, repeat; one-shot preserved for an argv question). After each answer it prompts a **one-bit** verdict (`[g]ood / [b]ad / Enter=skip`) and POSTs it to the bridge's `/log_reaction`, echoing the fold fate. Mirrors ask-live's `capture()`/`react()` exactly: one bit, never free text, fail-open. The launcher (`bin/answer-brain`) brings up the daemon + bridge + this app.

## Tests
TDD, 2 new extension tests (`onDecision` fires with the `decisionId`+effector on a terminal decision; does **not** fire when no decision is logged). Extension suite **14 passed**; `tsc --noEmit` clean on the extension **and** the app. Gated by the answer-brain CI (#128).

Note: the app drives a real local LLM end-to-end — proving local Qwen reliably drives retrieve→extract→answer on the real corpus is **Stage C** (this PR delivers the plumbing + capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)