### PR TITLE
credence-pi MVP-A: time as a decision coordinate (time/money trade-off)

### DIFF
--- a/apps/credence-pi/bdsl/utility.bdsl
+++ b/apps/credence-pi/bdsl/utility.bdsl
@@ -74,3 +74,17 @@
 ; the cheap model until the belief shows a pricier one is worth it. Inert
 ; unless routing.bdsl declares a roster.
 (define correct-answer-value 0.02)
+
+; ── Time coordinate (w-time) ────────────────────────────────────────────
+; w-time (dollars per SECOND of the user's wall-clock): the value of one
+; second of the user's time — the most intuitive dial of all ("what is your
+; time worth?"). The EU folds in w_time·E[time|action,X], where E[time] is a
+; LEARNED Poisson-Gamma latency belief (turns × measured s/turn,
+; brain/routing_latency.counts.json) and w-time the declared weight. This is
+; the TIME/MONEY (and time/quality) trade-off dial: raise it and the router
+; prefers a FASTER model and escalates sooner (a slow cheap model burns the
+; user's expensive seconds); lower it and time is ignored. 0.0 ⇒ time-blind,
+; BIT-IDENTICAL to the pre-time brain. A $50/hr user values a second at
+; ~$0.014; a $180/hr user ~$0.05. Default 0 (each profile opts in). Read by
+; both the router (wire_routing!) and the governor (wire_brain!).
+(define w-time 0.0)

--- a/apps/credence-pi/brain/feature_brain.jl
+++ b/apps/credence-pi/brain/feature_brain.jl
@@ -32,7 +32,7 @@ action argmax is the single canonical `optimise`.
 module FeatureBrain
 
 using Main.Credence: BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision,
-    ProductPrevision, MixturePrevision,
+    ProductPrevision, MixturePrevision, GammaPrevision,
     Prevision, Kernel, Interval, Finite, BetaBernoulli, SoftBernoulli, Flat, FiringByTag, Identity,
     Projection, LinearCombination, TestFunction, GeometricTail, mean, FeatureDecl, condition, expect,
     cell_at, wrap_in_measure
@@ -349,10 +349,14 @@ block prevents (0 ⇒ the myopic per-call decision; supplied by the tail brain a
 `expect(continuation_belief, GeometricTail())`).
 """
 function decide(model::StructureBMA, top::MixturePrevision, X::AbstractVector, cost::Float64;
-                aversion::Float64, interrupt_cost::Float64, expected_repeats::Float64 = 0.0)
+                aversion::Float64, interrupt_cost::Float64, expected_repeats::Float64 = 0.0,
+                w_time::Float64 = 0.0, exp_time::Float64 = 0.0)
     bx = belief_at_context(model, top, X)
     tf = 1.0 + expected_repeats                       # expected calls a block prevents: this one + the tail
-    block_fn = _lin(-cost * (tf + aversion), cost * tf)   # c·(1+m) − c·[(1+m)+λ]·θ
+    # TIME coordinate: a block also SAVES the call's wall-clock (E[time]·tf seconds), valued at
+    # w_time $/sec. Folds into the block offset next to the money saving c·tf. 0 ⇒ bit-identical.
+    tcost = w_time * exp_time * tf
+    block_fn = _lin(-cost * (tf + aversion), cost * tf + tcost)   # c·(1+m) + w_time·E[time]·(1+m) − c·[(1+m)+λ]·θ
     fpa_pb = Dict{Symbol, LinearCombination}(:proceed => _const(0.0), :block => block_fn)
     # EU(ask) = voi − q, computed through the canonical `net_voi` stdlib op (the
     # cost subtraction lives in stdlib, not as host arithmetic here) and entered
@@ -392,19 +396,21 @@ function decide_multi(waste_model::StructureBMA, top_waste::MixturePrevision,
                       harm_model::StructureBMA, harm_top::MixturePrevision,
                       Xw::AbstractVector, Xh::AbstractVector, cost::Float64;
                       aversion::Float64, interrupt_cost::Float64, harm_cost::Float64,
-                      expected_repeats::Float64 = 0.0)
+                      expected_repeats::Float64 = 0.0,
+                      w_time::Float64 = 0.0, exp_time::Float64 = 0.0)
     bxa = belief_at_context(waste_model, top_waste, Xw)   # P(approve|Xw)
     bxu = belief_at_context(harm_model, harm_top, Xh)     # P(unsafe|Xh)
     joint = ProductMeasure(Measure[wrap_in_measure(bxa), wrap_in_measure(bxu)])
     tf = 1.0 + expected_repeats        # expected calls a block prevents (waste tail; harm is one-shot)
-    # EU(block) = c·(1+m)·[1−θ_a] − cλθ_a + H·θ_u over the joint (Projection(1)=θ_a, Projection(2)=θ_u)
+    tcost = w_time * exp_time * tf      # time a block saves (w_time $/sec × E[time]·tf); 0 ⇒ bit-identical
+    # EU(block) = c·(1+m)·[1−θ_a] + w_time·E[time]·(1+m) − cλθ_a + H·θ_u over the joint
     block_fn = LinearCombination(Tuple{Float64, TestFunction}[
-        (-cost * (tf + aversion), Projection(1)), (harm_cost, Projection(2))], cost * tf)
-    # EU(ask): VOI of the user resolving approve, against the SAME tail-aware block payoff so
+        (-cost * (tf + aversion), Projection(1)), (harm_cost, Projection(2))], cost * tf + tcost)
+    # EU(ask): VOI of the user resolving approve, against the SAME tail+time-aware block payoff so
     # asking about a likely-long loop inherits the (1+m)× value; a constant so all three
     # actions compare through one optimise.
     eu_ask = net_voi(bxa, _decision_kernel(), [:proceed, :block],
-                     Dict(:proceed => _const(0.0), :block => _lin(-cost * (tf + aversion), cost * tf)),
+                     Dict(:proceed => _const(0.0), :block => _lin(-cost * (tf + aversion), cost * tf + tcost)),
                      [0, 1], interrupt_cost)
     fpa = Dict(:proceed => _const(0.0), :block => block_fn, :ask => _const(eu_ask))
     optimise(joint, [:proceed, :block, :ask], fpa)
@@ -466,6 +472,7 @@ function wire_brain!(env)
 
     H        = Float64(get(env, Symbol("harm-cost"), 0.0))
     hresp    = Symbol(get(env, Symbol("harm-response"), "ask"))  # :ask (confirm) | :block (enforce)
+    wtime    = Float64(get(env, Symbol("w-time"), 0.0))          # TIME coordinate: $/sec of wall-clock
 
     model = build_model_from_env(env; alpha0 = a0, beta0 = b0, p_edge = p_edge)
 
@@ -530,6 +537,31 @@ function wire_brain!(env)
     m_at(X) = tail_top === nothing ? 0.0 :
               expect(belief_at_context(model, tail_top, X), GeometricTail())
 
+    # Optional governance LATENCY belief (TIME coordinate) — OPT-IN by file presence, like the
+    # tail belief. Per-context Poisson-Gamma E[turns|X] (read by `expect`=α/β) × measured s̄/turn
+    # ⇒ E[time|X] seconds a block would save. Absent ⇒ exp_time=0 ⇒ time-blind governance
+    # (bit-identical). Version-stable counts-JSON (sufficient statistic), reconstructed exactly.
+    gov_latency = nothing
+    lpath = get(env, Symbol("governance-latency-path"), joinpath(@__DIR__, "governance_latency.counts.json"))
+    if lpath !== nothing && !isempty(string(lpath)) && isfile(string(lpath))
+        try
+            data = JSON3.read(read(string(lpath), String))
+            α0, β0 = Float64(data["turns_prior"][1]), Float64(data["turns_prior"][2])
+            rate = Float64(data["rate_s"])
+            tm = Dict{String, Float64}()
+            for ctx in data["contexts"]
+                g = GammaPrevision(α0 + Float64(ctx["sum_turns"]), β0 + Float64(ctx["n_obs"]))
+                tm[join(string.(ctx["ctx"]), "|")] = Float64(expect(g, Identity())) * rate
+            end
+            gov_latency = tm
+            @info "credence-pi: governance latency belief ON (time coordinate)" path=string(lpath)
+        catch e
+            @warn "credence-pi: governance latency failed to load; time-blind" error=e
+            gov_latency = nothing
+        end
+    end
+    time_at(X) = gov_latency === nothing ? 0.0 : get(gov_latency, join(string.(X), "|"), 0.0)
+
     env[Symbol("make-prior")] = () -> build_prior(model)
 
     env[Symbol("decide-action")] = (top, features, cost) -> begin
@@ -542,7 +574,8 @@ function wire_brain!(env)
             Xh = context_from_features(harm_model, features)
             m = m_at(Xw)
             d = decide_multi(model, top, harm_model, harm_top, Xw, Xh, c;
-                             aversion = λ, interrupt_cost = q, harm_cost = H, expected_repeats = m)
+                             aversion = λ, interrupt_cost = q, harm_cost = H, expected_repeats = m,
+                             w_time = wtime, exp_time = time_at(Xw))
             # Research-stage effector policy (harm-response = :ask): a harm-DRIVEN stop is a
             # CONFIRMATION, not a refusal — the harm belief is benchmark-seeded, not yet
             # user-calibrated, so asking has value and the response is the calibration
@@ -550,13 +583,15 @@ function wire_brain!(env)
             # Like shadowMode, this is an effector policy, not a change to the EU reasoning:
             # the harm term decided "do not proceed"; :ask realises that as "confirm".
             if d === :block && hresp === :ask
-                d_waste = decide(model, top, Xw, c; aversion = λ, interrupt_cost = q, expected_repeats = m)
+                d_waste = decide(model, top, Xw, c; aversion = λ, interrupt_cost = q,
+                                 expected_repeats = m, w_time = wtime, exp_time = time_at(Xw))
                 d = d_waste === :block ? :block : :ask   # harm was the driver ⇒ confirm
             end
             d
         else
             X = context_from_features(model, features)
-            decide(model, top, X, c; aversion = λ, interrupt_cost = q, expected_repeats = m_at(X))
+            decide(model, top, X, c; aversion = λ, interrupt_cost = q, expected_repeats = m_at(X),
+                   w_time = wtime, exp_time = time_at(X))
         end
     end
 

--- a/apps/credence-pi/brain/routing_brain.jl
+++ b/apps/credence-pi/brain/routing_brain.jl
@@ -33,9 +33,9 @@ independence across models is the ProductMeasure, exactly as the waste⊗harm jo
 """
 module RoutingBrain
 
-using Main.Credence: MixturePrevision, BetaPrevision, Projection, LinearCombination,
-    TestFunction, Identity, Kernel, Interval, Finite, WeightedBernoulli, mean,
-    condition, expect, wrap_in_measure
+using Main.Credence: MixturePrevision, BetaPrevision, GammaPrevision, Projection,
+    LinearCombination, TestFunction, Identity, Kernel, Interval, Finite, WeightedBernoulli,
+    mean, condition, expect, wrap_in_measure
 import Main.Credence.Ontology: optimise, ProductMeasure, Measure
 # `..FeatureBrain` (the sibling submodule), NOT `Main.FeatureBrain`: this resolves both
 # when the eval includes both brains at Main (siblings of Main) and when the daemon
@@ -46,14 +46,62 @@ using ..FeatureBrain: StructureBMA, belief_at_context, context_from_features,
 using JSON3
 
 export route, route_eu, escalation_next, posterior_accuracy, wire_routing!,
-    RoutingState, EmissionBelief, route_outcome!, decode_correctness
+    RoutingState, EmissionBelief, route_outcome!, decode_correctness,
+    LatencyBelief, reconstruct_latency, latency_at
+
+# ── Latency belief: E[time | model, X] = E[turns|X]·s̄, the TIME coordinate ─────────
+#
+# Time is the profile coordinate that lets a user trade wall-clock against money/quality.
+# It is a LEARNED belief (you cannot know a call's duration before making it): the SAME
+# Poisson-Gamma "turns" belief the dominance eval already uses for E[cost] (tb_dominance.jl
+# `CostBelief`), reused for E[time]. E[time|model,X] = E[turns|model,X]·s̄_model, where the
+# per-model turns posterior is a Gamma (reconstructed below) read by `expect(·,Identity)`=α/β,
+# and s̄_model is the measured seconds/turn. The decision folds w_time·E[time] into the EU
+# offset (route/escalation_next), so a slow-but-cheap model loses to a fast one exactly when
+# the user values their seconds enough — the time/money trade-off, via the one `optimise`.
+#
+# Version-stable like the other warm artifacts: ship the Gamma sufficient statistic
+# (sum_turns, n_obs) per (model, context) + the measured rate_s per model + the prior; the
+# posterior Gamma(α0+Σt, β0+n) is order-independent, so reconstruction is exact (no
+# Serialization). E[time] is computed once at load through `expect` and cached per cell.
+struct LatencyBelief
+    time_mean::Dict{Tuple{String, String}, Float64}   # (model_id, ctx_key) -> E[time] seconds
+end
+
+# Reconstruct E[time] per (model, context) from the counts-JSON. Shape:
+# { "turns_prior":[α0,β0], "per_model":[ {"model_id":..., "rate_s":..,
+#   "contexts":[ {"ctx":["short"], "sum_turns":412, "n_obs":30 } ]} ] }
+function reconstruct_latency(path)::LatencyBelief
+    data = JSON3.read(read(String(path), String))
+    α0, β0 = Float64(data["turns_prior"][1]), Float64(data["turns_prior"][2])
+    tm = Dict{Tuple{String, String}, Float64}()
+    for pm in data["per_model"]
+        id = String(pm["model_id"]); rate = Float64(pm["rate_s"])
+        for ctx in pm["contexts"]
+            g = GammaPrevision(α0 + Float64(ctx["sum_turns"]), β0 + Float64(ctx["n_obs"]))
+            etime = Float64(expect(g, Identity())) * rate     # E[turns]=α/β, ×s̄ ⇒ E[time]
+            tm[(id, _ctx_key([String(c) for c in ctx["ctx"]]))] = etime
+        end
+    end
+    LatencyBelief(tm)
+end
+
+# E[time|model,X] seconds, or 0.0 for an unknown (model, context) ⇒ that candidate carries no
+# time term (conservative: time never penalises a model we have no latency belief for).
+latency_at(lb::LatencyBelief, model_id::AbstractString, X::AbstractVector) =
+    get(lb.time_mean, (String(model_id), _ctx_key(X)), 0.0)
+latency_at(::Nothing, ::AbstractString, ::AbstractVector) = 0.0
 
 # Per-action EU functional: reward·θ_a − cost_a, expressed over the joint belief's
 # a-th component (Projection(a) = θ_a). `reward` and `cost` are declared utility DATA;
 # multiplying them into LinearCombination coefficients is coefficient construction, not
 # probability arithmetic (mirrors decide_multi's `(-cost*(tf+aversion), Projection(1))`).
-_eu_functional(a::Int, reward::Float64, cost::Float64) =
-    LinearCombination(Tuple{Float64, TestFunction}[(reward, Projection(a))], -cost)
+# `time_cost` = w_time·E[time|a,X] (declared weight × learned latency, prepared upstream); it
+# folds into the SAME constant offset as `-cost` — E[time] is a known scalar at decision time
+# (it does not co-vary with the routing posterior θ), so it belongs in the offset, not a new
+# Projection. time_cost=0 ⇒ `-(cost+0.0)`==`-cost` ⇒ bit-identical to the pre-time functional.
+_eu_functional(a::Int, reward::Float64, cost::Float64, time_cost::Float64 = 0.0) =
+    LinearCombination(Tuple{Float64, TestFunction}[(reward, Projection(a))], -(cost + time_cost))
 
 # Build the joint belief over all K models at context X: a ProductMeasure of each
 # model's belief-at-context view (the independence-across-models assumption made
@@ -66,9 +114,12 @@ function _joint_at(model::StructureBMA, tops::AbstractVector, X::AbstractVector)
     ProductMeasure(cells), K
 end
 
-function _fpa(K::Int, reward::Real, costs::AbstractVector)
-    r = Float64(reward)
-    Dict{Int, LinearCombination}(a => _eu_functional(a, r, Float64(costs[a])) for a in 1:K)
+function _fpa(K::Int, reward::Real, costs::AbstractVector,
+             w_time::Real = 0.0, times = nothing)
+    r = Float64(reward); wt = Float64(w_time)
+    Dict{Int, LinearCombination}(
+        a => _eu_functional(a, r, Float64(costs[a]),
+                            times === nothing ? 0.0 : wt * Float64(times[a])) for a in 1:K)
 end
 
 """
@@ -85,11 +136,13 @@ fixed table is the Bayes rule for more than one profile — the Wald complete-cl
 core of the dominance proof.
 """
 function route(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
-               costs::AbstractVector, reward::Real)
+               costs::AbstractVector, reward::Real; w_time::Real = 0.0, times = nothing)
     length(tops) == length(costs) ||
         error("route: tops/costs length mismatch ($(length(tops)) vs $(length(costs)))")
+    (times === nothing || length(times) == length(tops)) ||
+        error("route: tops/times length mismatch ($(length(tops)) vs $(length(times)))")
     joint, K = _joint_at(model, tops, X)
-    optimise(joint, collect(1:K), _fpa(K, reward, costs))
+    optimise(joint, collect(1:K), _fpa(K, reward, costs, w_time, times))
 end
 
 """
@@ -100,9 +153,9 @@ The EU is `expect` of the chosen action's functional — the same number `optimi
 maximised — so this re-reads through the canalised path, never recomputing it by hand.
 """
 function route_eu(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
-                  costs::AbstractVector, reward::Real)
+                  costs::AbstractVector, reward::Real; w_time::Real = 0.0, times = nothing)
     joint, K = _joint_at(model, tops, X)
-    fpa = _fpa(K, reward, costs)
+    fpa = _fpa(K, reward, costs, w_time, times)
     a = optimise(joint, collect(1:K), fpa)
     a, Float64(expect(joint, fpa[a]))
 end
@@ -140,15 +193,17 @@ exact sequential value is a future refinement. This is the ONE escalation decisi
 calls it rather than reimplementing the gate (no host-side decision mechanism).
 """
 function escalation_next(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
-                         costs_X::AbstractVector, reward::Real, tried)
-    r = Float64(reward)
+                         costs_X::AbstractVector, reward::Real, tried;
+                         w_time::Real = 0.0, times_X = nothing)
+    r = Float64(reward); wt = Float64(w_time)
     for a in eachindex(tops)                       # costs_X ascending ⇒ cheapest-first
         a in tried && continue
+        tc = times_X === nothing ? 0.0 : wt * Float64(times_X[a])   # w_time·E[time|a,X]
         # Single-tier joint + Projection(1) — mirror `route`'s ProductMeasure path so
         # `expect` resolves to Measure×LinearCombination (a bare MixtureMeasure×TestFunction
         # is ambiguous against the LinearCombination method).
         belief = ProductMeasure(Measure[wrap_in_measure(belief_at_context(model, tops[a], X))])
-        tryf = LinearCombination(Tuple{Float64, TestFunction}[(r, Projection(1))], -Float64(costs_X[a]))
+        tryf = LinearCombination(Tuple{Float64, TestFunction}[(r, Projection(1))], -(Float64(costs_X[a]) + tc))
         return optimise(belief, [1, 2], Dict(1 => tryf, 2 => _STOP_FUNCTIONAL)) == 1 ? a : 0
     end
     0
@@ -254,6 +309,8 @@ mutable struct RoutingState
     model_ids::Vector{String}
     costs::Vector{Float64}
     reward::Float64
+    w_time::Float64                             # profile weight on time ($/sec of the user's wall-clock)
+    latency::Union{LatencyBelief, Nothing}      # learned E[time|model,X]; nothing ⇒ time-blind (default)
 end
 
 # Fetch model_id's belief plus a setter to write an update back. KNOWN models (the default
@@ -381,6 +438,21 @@ function wire_routing!(env;
 
     reward = Float64(get(env, Symbol("correct-answer-value"), 0.02))
 
+    # TIME coordinate (profile dial): w-time = $/sec of the user's wall-clock. 0.0 ⇒ time-blind
+    # (bit-identical to the pre-time router). The latency belief is opt-in by file presence
+    # (like the tail belief): absent ⇒ nothing ⇒ no time term. routing-latency-path overrides.
+    w_time = Float64(get(env, Symbol("w-time"), 0.0))
+    latency = let p = get(env, Symbol("routing-latency-path"),
+                          joinpath(@__DIR__, "routing_latency.counts.json"))
+        (p === nothing || isempty(string(p)) || !isfile(string(p))) ? nothing :
+            try
+                reconstruct_latency(p)
+            catch e
+                @warn "routing latency belief failed to load; time-blind" path = string(p) error = e
+                nothing
+            end
+    end
+
     # Emission prior: declared (`emission-prior`) auditable data, else the directional default.
     ep = get(env, Symbol("emission-prior"), nothing)
     emission_prior = (ep isa AbstractVector && length(ep) == 4) ?
@@ -395,7 +467,7 @@ function wire_routing!(env;
 
     rt = RoutingState(rmodel, tops, Dict{String, MixturePrevision}(),
                       EmissionBelief(emission_prior), names, providers,
-                      model_ids, costs, reward)
+                      model_ids, costs, reward, w_time, latency)
 
     # The daemon's routing call-site: (feature dict[, live roster]) → the chosen model's wire
     # fields, or `nothing` (inert ⇒ body keeps OpenClaw's model). Reads rt's beliefs LIVE
@@ -424,7 +496,8 @@ function _route_decide(rt::RoutingState, features, roster)
     names, providers, ids, costs, tops = _resolve_roster(rt, roster)
     length(ids) >= 2 || return nothing
     X = context_from_features(rt.model, features)
-    a = route(rt.model, tops, X, costs, rt.reward)
+    times = Float64[latency_at(rt.latency, ids[a], X) for a in eachindex(ids)]   # E[time|a,X], 0 if unknown
+    a = route(rt.model, tops, X, costs, rt.reward; w_time = rt.w_time, times = times)
     Dict{String, Any}("model" => ids[a], "provider" => providers[a], "name" => names[a])
 end
 
@@ -441,7 +514,9 @@ function _escalate_decide(rt::RoutingState, features, roster, tried, reward)
     order = sortperm(costs)                              # cheapest → dearest
     X = context_from_features(rt.model, features)
     triedset = Set{Int}(Int(t) for t in tried)          # indices in cost-ascending space
-    a = escalation_next(rt.model, tops[order], X, costs[order], Float64(reward), triedset)
+    times = Float64[latency_at(rt.latency, ids[i], X) for i in order]   # E[time], aligned to tops[order]
+    a = escalation_next(rt.model, tops[order], X, costs[order], Float64(reward), triedset;
+                        w_time = rt.w_time, times_X = times)
     a == 0 && return nothing                             # no positive-EU rung ⇒ STOP
     j = order[a]
     Dict{String, Any}("model" => ids[j], "provider" => providers[j], "name" => names[j],

--- a/apps/credence-pi/brain/routing_latency.counts.json
+++ b/apps/credence-pi/brain/routing_latency.counts.json
@@ -1,0 +1,92 @@
+{
+    "note": "Gamma sufficient statistic (sum_turns,n_obs) per (model,bucket) + measured rate_s (s/turn) per model. E[time]=expect(Gamma(α0+Σt,β0+n),Identity)·rate_s. Buckets match routing-features.ts.",
+    "turns_prior": [
+        1,
+        0.1
+    ],
+    "source": "tb_matrix_rep3.jsonl (agentic Terminal-Bench), bucketed by instruction length (short ≤400 / medium ≤1000 / long)",
+    "per_model": [
+        {
+            "rate_s": 6.213644524236984,
+            "model_id": "claude-haiku-4-5",
+            "contexts": [
+                {
+                    "sum_turns": 277,
+                    "n_obs": 30,
+                    "ctx": [
+                        "short"
+                    ]
+                },
+                {
+                    "sum_turns": 88,
+                    "n_obs": 6,
+                    "ctx": [
+                        "medium"
+                    ]
+                },
+                {
+                    "sum_turns": 192,
+                    "n_obs": 15,
+                    "ctx": [
+                        "long"
+                    ]
+                }
+            ]
+        },
+        {
+            "rate_s": 8.964745011086475,
+            "model_id": "claude-sonnet-4-6",
+            "contexts": [
+                {
+                    "sum_turns": 239,
+                    "n_obs": 30,
+                    "ctx": [
+                        "short"
+                    ]
+                },
+                {
+                    "sum_turns": 124,
+                    "n_obs": 6,
+                    "ctx": [
+                        "medium"
+                    ]
+                },
+                {
+                    "sum_turns": 142,
+                    "n_obs": 15,
+                    "ctx": [
+                        "long"
+                    ]
+                }
+            ]
+        },
+        {
+            "rate_s": 10.530043859649126,
+            "model_id": "claude-opus-4-8",
+            "contexts": [
+                {
+                    "sum_turns": 253,
+                    "n_obs": 30,
+                    "ctx": [
+                        "short"
+                    ]
+                },
+                {
+                    "sum_turns": 108,
+                    "n_obs": 6,
+                    "ctx": [
+                        "medium"
+                    ]
+                },
+                {
+                    "sum_turns": 112,
+                    "n_obs": 15,
+                    "ctx": [
+                        "long"
+                    ]
+                }
+            ]
+        }
+    ],
+    "artifact": "credence-pi routing LATENCY belief E[time|model,prompt-length] — Poisson-Gamma turns × measured s/turn"
+}

--- a/apps/credence-pi/eval/train_latency_brain.jl
+++ b/apps/credence-pi/eval/train_latency_brain.jl
@@ -1,0 +1,92 @@
+# Role: eval
+#
+# train_latency_brain.jl — warm the routing LATENCY belief E[time | model, prompt-length] from
+# the agentic Terminal-Bench matrix, the TIME-coordinate sibling of train_routing_from_matrix.jl
+# (which warms the accuracy belief). Time is the profile coordinate that lets a user trade
+# wall-clock against money/quality (speed-first vs cost-saver); it is a LEARNED belief because a
+# call's duration is unknown until after the call.
+#
+# MODEL (reused, not reinvented): the Poisson-Gamma "turns" belief from tb_dominance.jl. Per
+# (tier, prompt-length bucket) we ship the Gamma sufficient statistic (sum_turns, n_obs) — the
+# posterior Gamma(α0+Σt, β0+n) is order-independent, so reconstruction is exact and version-
+# stable (no Serialization). Per tier we ship the measured rate_s = Σduration_s / Σnum_turns
+# (seconds/turn). The daemon's RoutingBrain.reconstruct_latency reads these and computes
+# E[time|model,X] = expect(Gamma, Identity)·rate_s = (α/β)·s̄ at load.
+#
+# Buckets MUST match routing-features.ts / routing.bdsl (short ≤400, medium ≤1000, long >1000
+# instruction chars) — the train/live synchronisation point, same as the accuracy trainer.
+#
+# NON-CAUSAL (Role: eval): reads measured data, tallies sufficient statistics, writes + verifies
+# the fixture. No belief drives a decision here.
+#   julia --project=. apps/credence-pi/eval/train_latency_brain.jl
+
+push!(LOAD_PATH, abspath(joinpath(@__DIR__, "..", "..", "..", "src")))
+using JSON3
+
+const MATRIX = normpath(joinpath(@__DIR__, "live_ab", "results", "tb_matrix_rep3.jsonl"))
+const OUT = normpath(joinpath(@__DIR__, "..", "brain", "routing_latency.counts.json"))
+
+# Tier → roster model-id; order/ids identical to train_routing_from_matrix.jl.
+const TIERS = ["haiku", "sonnet", "opus"]
+const TIER_ID = Dict("haiku" => "claude-haiku-4-5", "sonnet" => "claude-sonnet-4-6",
+                     "opus" => "claude-opus-4-8")
+const BUCKETS = ["short", "medium", "long"]
+# Gamma prior on turns — identical to tb_dominance.jl's TURNS_A0/TURNS_B0 (the reconstruction
+# in RoutingBrain.reconstruct_latency reads this from the JSON, so it stays in lockstep).
+const TURNS_A0, TURNS_B0 = 1.0, 0.1
+
+length_bucket(n) = n <= 400 ? "short" : (n <= 1000 ? "medium" : "long")
+
+function main()
+    rows = [JSON3.read(ln) for ln in eachline(MATRIX) if !isempty(strip(ln))]
+    # (tier, bucket) -> [sum_turns, n_obs];  tier -> [Σduration_s, Σturns] for the rate
+    cells = Dict{Tuple{String, String}, Vector{Float64}}()
+    rate_acc = Dict{String, Vector{Float64}}()
+    for r in rows
+        tier = String(r.tier)
+        haskey(TIER_ID, tier) || continue
+        r.num_turns === nothing && continue               # need a turn count for the Poisson belief
+        turns = Float64(r.num_turns)
+        c = get!(cells, (tier, length_bucket(Int(r.instr_len))), [0.0, 0.0])
+        c[1] += turns; c[2] += 1.0
+        if r.duration_s !== nothing                        # rate needs both duration and turns
+            ra = get!(rate_acc, tier, [0.0, 0.0]); ra[1] += Float64(r.duration_s); ra[2] += turns
+        end
+    end
+
+    per_model = Any[]
+    for tier in TIERS
+        ctxs = Any[]
+        for b in BUCKETS
+            c = get(cells, (tier, b), [0.0, 0.0])
+            c[2] == 0.0 && continue                           # no data ⇒ leave the cell at prior
+            push!(ctxs, Dict("ctx" => [b], "sum_turns" => c[1], "n_obs" => Int(c[2])))
+        end
+        ra = get(rate_acc, tier, [0.0, 0.0])
+        rate_s = ra[2] > 0.0 ? ra[1] / ra[2] : 0.0            # measured Σduration / Σturns
+        push!(per_model, Dict("model_id" => TIER_ID[tier], "rate_s" => rate_s, "contexts" => ctxs))
+    end
+
+    out = Dict(
+        "artifact" => "credence-pi routing LATENCY belief E[time|model,prompt-length] — Poisson-Gamma turns × measured s/turn",
+        "source" => "tb_matrix_rep3.jsonl (agentic Terminal-Bench), bucketed by instruction length (short ≤400 / medium ≤1000 / long)",
+        "note" => "Gamma sufficient statistic (sum_turns,n_obs) per (model,bucket) + measured rate_s (s/turn) per model. E[time]=expect(Gamma(α0+Σt,β0+n),Identity)·rate_s. Buckets match routing-features.ts.",
+        "turns_prior" => [TURNS_A0, TURNS_B0],
+        "per_model" => per_model,
+    )
+    open(OUT, "w") do io; JSON3.pretty(io, out); end
+    println("wrote ", OUT)
+    for pm in per_model
+        println("  ", rpad(pm["model_id"], 22), "rate_s=", round(pm["rate_s"], digits = 2), " s/turn")
+        for ctx in pm["contexts"]
+            mean_turns = (TURNS_A0 + ctx["sum_turns"]) / (TURNS_B0 + ctx["n_obs"])
+            println("    ", rpad(ctx["ctx"][1], 8), "E[turns]=", round(mean_turns, digits = 2),
+                    "  E[time]=", round(mean_turns * pm["rate_s"], digits = 1), "s",
+                    "  (n=", ctx["n_obs"], ")")
+        end
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/apps/credence-pi/tests/julia/test_feature_brain.jl
+++ b/apps/credence-pi/tests/julia/test_feature_brain.jl
@@ -261,6 +261,20 @@ let
         check("attention-precious + tail-aware → governs (≠proceed)", d_la !== :proceed, "got $d_la")
     end
 
+    # (d-time) TIME coordinate (the MVP's time dial in governance): a call the time-blind EU
+    #     PROCEEDS on, valuing the user's wall-clock GOVERNS. θ=0.6, λ=1 ⇒ block EU=−0.2 (<0,
+    #     proceed); a block also SAVES E[time] seconds (here w_time·E[time]=0.02·30=0.60 > the
+    #     0.20 gap) ⇒ block wins. w_time=0 ⇒ bit-identical regardless of exp_time. q=1.0 isolates
+    #     proceed-vs-block (ask suppressed), mirroring (d).
+    let wt = mk(4, 2)
+        d_blind = decide(wm, wt, X, 1.0; aversion=1.0, interrupt_cost=1.0, w_time=0.0, exp_time=30.0)
+        d_ref   = decide(wm, wt, X, 1.0; aversion=1.0, interrupt_cost=1.0)
+        d_time  = decide(wm, wt, X, 1.0; aversion=1.0, interrupt_cost=1.0, w_time=0.02, exp_time=30.0)
+        check("time-blind (w_time=0) ≡ default decide regardless of exp_time", d_blind === d_ref, "blind=$d_blind ref=$d_ref")
+        check("time-blind → proceed (under-values the loop's wall-clock)", d_blind === :proceed, "got $d_blind")
+        check("valuing time (w_time·E[time]=0.60 saved) → governs (≠proceed)", d_time !== :proceed, "got $d_time")
+    end
+
     # (e) decide_multi: m=0 ≡ default; m>0 scales the waste tail (harm term untouched).
     let hm = build_model(["ctx"], [["c"]])
         function mkh(a, d)

--- a/apps/credence-pi/tests/julia/test_routing.jl
+++ b/apps/credence-pi/tests/julia/test_routing.jl
@@ -24,7 +24,7 @@ include(joinpath(@__DIR__, "..", "..", "brain", "feature_brain.jl"))
 using .FeatureBrain: build_model, observe, observe_soft
 include(joinpath(@__DIR__, "..", "..", "brain", "routing_brain.jl"))
 using .RoutingBrain: wire_routing!, route, escalation_next, posterior_accuracy,
-    route_outcome!, _ctx_key
+    route_outcome!, _ctx_key, reconstruct_latency, latency_at, LatencyBelief
 
 const BDSL_DIR = joinpath(@__DIR__, "..", "..", "bdsl")
 const TOL = 1e-12
@@ -174,6 +174,48 @@ let env = routing_env(reward = 1.0)
     g = decide(Dict("prompt-length" => "short"), reverse(roster), Int[])
     @assert g["model"] == "claude-haiku-4-5" && g["tier_index"] == 1
     ok("escalate-decide sorts by cost: a dearest-first roster still escalates cheapest-first")
+end
+
+# ── A'''. The TIME coordinate: w_time·E[time] in the routing EU (time vs money/quality) ──
+# Time is the profile dial that lets a user trade wall-clock against money/quality. E[time] is a
+# learned Poisson-Gamma latency belief; w_time the declared $/sec weight; the EU folds w_time·
+# E[time] into the offset. w_time=0 ⇒ bit-identical (the GeometricTail-rollout discipline).
+const LATENCY_JSON = joinpath(@__DIR__, "..", "..", "brain", "routing_latency.counts.json")
+
+# The latency belief reconstructs E[time|model,X] from version-stable counts; opus is slower
+# than haiku on the measured matrix (the time signal); unknown (model/ctx) ⇒ 0 (no time term).
+let lb = reconstruct_latency(LATENCY_JSON)
+    t_opus = latency_at(lb, "claude-opus-4-8", ["short"])
+    t_haiku = latency_at(lb, "claude-haiku-4-5", ["short"])
+    @assert t_opus > 0.0 && t_haiku > 0.0
+    @assert t_opus > t_haiku                                   # opus slower/turn ⇒ more wall-clock
+    @assert latency_at(lb, "unknown-model", ["short"]) == 0.0  # conservative: no belief ⇒ no penalty
+    @assert latency_at(nothing, "claude-opus-4-8", ["short"]) == 0.0
+    # credence-lint: allow — precedent:test-oracle — exact reconstruction-determinism oracle
+    @assert latency_at(reconstruct_latency(LATENCY_JSON), "claude-opus-4-8", ["short"]) == t_opus
+    ok("latency belief: E[time] reconstructs (opus $(round(Int, t_opus))s > haiku $(round(Int, t_haiku))s short), 0 for unknown, deterministic")
+end
+
+# w_time=0 ⇒ the time term is exactly 0 ⇒ route is bit-identical regardless of the times vector.
+let env = routing_env(reward = 1.0)
+    rt = wire_routing!(env); X = ["short"]; costs = [0.01, 0.05, 0.20]; times = [99.0, 5.0, 50.0]
+    base = route(rt.model, rt.tops, X, costs, 1.0)
+    # credence-lint: allow — precedent:test-oracle — w_time=0 bit-identical equality oracle
+    @assert route(rt.model, rt.tops, X, costs, 1.0; w_time = 0.0, times = times) == base
+    @assert route(rt.model, rt.tops, X, costs, 1.0; w_time = 0.0, times = nothing) == base
+    ok("route: w_time=0 is bit-identical regardless of times (time-blind ⇒ unchanged)")
+end
+
+# Time/quality trade-off, LIVE through route-decide (the wired path: w-time read + latency
+# loaded). Same belief + reward; the TIME dial alone flips the choice from the accuracy winner
+# (sonnet) to the FASTER model (haiku) — the "time vs money/quality" the MVP must express.
+let q0 = (e = routing_env(reward = 1.0); wire_routing!(e); e[Symbol("route-decide")](Dict("prompt-length" => "short"))),
+    qt = (e = routing_env(reward = 1.0); e[Symbol("w-time")] = 0.03; wire_routing!(e);
+          e[Symbol("route-decide")](Dict("prompt-length" => "short")))
+    @assert q0["model"] == "claude-sonnet-4-6"    # w-time 0: the accuracy winner
+    @assert qt["model"] == "claude-haiku-4-5"     # w-time 0.03: the faster model
+    @assert q0["model"] != qt["model"]
+    ok("time/quality trade-off (live): reward 1.0 + w-time 0 → sonnet (accurate); + w-time 0.03 → haiku (fast)")
 end
 
 # ── A''. Roster-aware routing: the LIVE roster (the user's actual models) ────────


### PR DESCRIPTION
First workstream of the credence-pi **viable-MVP** (a proxy welfare-maximiser for OpenClaw). The mechanism already runs one EU-max over a shared belief with per-user utilities; this adds the one missing decision coordinate — **time** — so a user can trade wall-clock against money/quality.

## What
- **Latency belief (reuse):** the SAME Poisson-Gamma turns belief the dominance eval uses for E[cost], reused for `E[time] = E[turns|model,X]·s̄`. `reconstruct_latency` loads a version-stable counts-JSON (Gamma sufficient statistic + measured `rate_s`; order-independent ⇒ exact). Warmed from the agentic TB matrix (`train_latency_brain.jl`): opus ~89s vs haiku ~57s on short — the time signal.
- **`w_time·E[time]` in the EU offset** of `route`/`escalation_next` (routing) and `decide`/`decide_multi` (governance — a block also *saves* the call's wall-clock). E[time] is a known scalar at decision time, so it folds into the `LinearCombination` offset next to `-cost` — **no new TestFunction/axiom op**.
- **`w-time` dial** (`$/sec of the user's wall-clock`, the most intuitive dial) in `utility.bdsl`, read by **both** wirings — one profile coordinate, all decision sites.

## Bit-identical guarantee
`w_time=0` ⇒ every time term is exactly 0 ⇒ decisions are **bit-identical** to today (the GeometricTail rollout precedent). The governance latency belief is opt-in by file presence (default off).

## Tests (+6, all green; 38 routing assertions + full feature-brain suite)
- latency reconstructs E[time] (opus>haiku, 0 for unknown model/ctx, deterministic);
- `route` w_time=0 bit-identical regardless of the times vector;
- **time/quality flip LIVE through `route-decide`**: reward 1.0 + w-time 0 → sonnet (accurate); + w-time 0.03 → haiku (faster) — the "time vs money/quality" trade-off, demonstrated;
- governance: time-blind ≡ default `decide`; valuing the saved wall-clock turns proceed → govern.

Brain stays **lint-pragma-free** (the time term is the clean learned-belief × declared-weight offset idiom).

Next (MVP-B): expose the trade-offs as user-selectable profiles (presets + advanced) via the plugin config, sent per-request — no daemon restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)