### PR TITLE
credence-pi MVP-B: user-selectable profiles (presets + per-request override)

### DIFF
--- a/apps/credence-pi/brain/feature_brain.jl
+++ b/apps/credence-pi/brain/feature_brain.jl
@@ -339,6 +339,13 @@ const _ID = Identity()
 _lin(coeff::Float64, off::Float64) = LinearCombination(Tuple{Float64, TestFunction}[(coeff, _ID)], off)
 _const(off::Float64) = LinearCombination(Tuple{Float64, TestFunction}[], off)
 
+# Per-request profile override (the user's utility weights, shipped by the body PER REQUEST so a
+# user switches their trade-off with no daemon restart): the value for `key` if present, else the
+# wired default. Preference DATA from the body; the brain still does all the EU-max.
+_pget(profile, key::AbstractString, default::Float64)::Float64 =
+    (profile isa AbstractDict && haskey(profile, key) && profile[key] !== nothing) ?
+        Float64(profile[key]) : default
+
 """
     decide(model, top, X, cost; aversion, interrupt_cost, expected_repeats=0.0) -> Symbol
 
@@ -564,9 +571,13 @@ function wire_brain!(env)
 
     env[Symbol("make-prior")] = () -> build_prior(model)
 
-    env[Symbol("decide-action")] = (top, features, cost) -> begin
+    env[Symbol("decide-action")] = (top, features, cost, profile = nothing) -> begin
         c = cost === nothing ? fallback : Float64(cost)
         c = c <= 0.0 ? fallback : c
+        # Per-request profile override (the user's utility weights, no daemon restart): λ/q/H/w_time
+        # for THIS decision only; absent ⇒ the wired defaults. Beliefs untouched.
+        λc = _pget(profile, "lambda", λ); qc = _pget(profile, "q", q)
+        Hc = _pget(profile, "harm", H); wt = _pget(profile, "w_time", wtime)
         # Multi-outcome only when harm is active AND the body sent the safety features for
         # this event; otherwise the single-outcome waste decision (unchanged).
         if harm_model !== nothing && harm_top !== nothing && _has_features(harm_model, features)
@@ -574,8 +585,8 @@ function wire_brain!(env)
             Xh = context_from_features(harm_model, features)
             m = m_at(Xw)
             d = decide_multi(model, top, harm_model, harm_top, Xw, Xh, c;
-                             aversion = λ, interrupt_cost = q, harm_cost = H, expected_repeats = m,
-                             w_time = wtime, exp_time = time_at(Xw))
+                             aversion = λc, interrupt_cost = qc, harm_cost = Hc, expected_repeats = m,
+                             w_time = wt, exp_time = time_at(Xw))
             # Research-stage effector policy (harm-response = :ask): a harm-DRIVEN stop is a
             # CONFIRMATION, not a refusal — the harm belief is benchmark-seeded, not yet
             # user-calibrated, so asking has value and the response is the calibration
@@ -583,15 +594,15 @@ function wire_brain!(env)
             # Like shadowMode, this is an effector policy, not a change to the EU reasoning:
             # the harm term decided "do not proceed"; :ask realises that as "confirm".
             if d === :block && hresp === :ask
-                d_waste = decide(model, top, Xw, c; aversion = λ, interrupt_cost = q,
-                                 expected_repeats = m, w_time = wtime, exp_time = time_at(Xw))
+                d_waste = decide(model, top, Xw, c; aversion = λc, interrupt_cost = qc,
+                                 expected_repeats = m, w_time = wt, exp_time = time_at(Xw))
                 d = d_waste === :block ? :block : :ask   # harm was the driver ⇒ confirm
             end
             d
         else
             X = context_from_features(model, features)
-            decide(model, top, X, c; aversion = λ, interrupt_cost = q, expected_repeats = m_at(X),
-                   w_time = wtime, exp_time = time_at(X))
+            decide(model, top, X, c; aversion = λc, interrupt_cost = qc, expected_repeats = m_at(X),
+                   w_time = wt, exp_time = time_at(X))
         end
     end
 

--- a/apps/credence-pi/brain/routing_brain.jl
+++ b/apps/credence-pi/brain/routing_brain.jl
@@ -473,7 +473,8 @@ function wire_routing!(env;
     # fields, or `nothing` (inert ⇒ body keeps OpenClaw's model). Reads rt's beliefs LIVE
     # (route_outcome! mutates them); the argmax is the single canonical `optimise` inside
     # `route` (Invariant 1); the only arithmetic is reward/cost coefficient construction.
-    env[Symbol("route-decide")] = (features, roster = nothing) -> _route_decide(rt, features, roster)
+    env[Symbol("route-decide")] = (features, roster = nothing, profile = nothing) ->
+        _route_decide(rt, features, roster, profile)
 
     # Observe-then-escalate call-site (the dominance proof's WINNING policy, now wired live):
     # (feature dict, live roster, tried-set, reward) → the next rung's wire fields + its
@@ -482,8 +483,9 @@ function wire_routing!(env;
     # the single canonical `optimise` inside `escalation_next` (Invariant 1); the host drives
     # the try→observe→escalate loop. Reads rt's beliefs LIVE, same as route-decide.
     env[Symbol("escalate-decide")] =
-        (features, roster = nothing, tried = Int[], reward = rt.reward) ->
-            _escalate_decide(rt, features, roster, tried, reward)
+        (features, roster = nothing, tried = Int[], reward = nothing, profile = nothing) ->
+            _escalate_decide(rt, features, roster, tried,
+                             reward === nothing ? rt.reward : Float64(reward), profile)
 
     rt
 end
@@ -492,12 +494,22 @@ end
 # or the declared default roster. Returns `nothing` — body keeps OpenClaw's model — when fewer
 # than 2 candidates exist (routing is a no-op with nothing to choose between), so routing-on-
 # by-default is safe for a single-model install.
-function _route_decide(rt::RoutingState, features, roster)
+# Per-request profile override: the user's utility weights, sent by the body PER REQUEST (like
+# the live roster), so a user switches their cost/time/quality trade-off with NO daemon restart.
+# Returns the override value for `key` if the profile carries it, else the wired default. The
+# profile is preference DATA the body ships; the brain still does all the EU-max (body math-free).
+_pget(profile, key::AbstractString, default::Float64)::Float64 =
+    (profile isa AbstractDict && haskey(profile, key) && profile[key] !== nothing) ?
+        Float64(profile[key]) : default
+
+function _route_decide(rt::RoutingState, features, roster, profile = nothing)
     names, providers, ids, costs, tops = _resolve_roster(rt, roster)
     length(ids) >= 2 || return nothing
+    reward = _pget(profile, "reward", rt.reward)        # quality coordinate (per-request override)
+    w_time = _pget(profile, "w_time", rt.w_time)        # time coordinate (per-request override)
     X = context_from_features(rt.model, features)
     times = Float64[latency_at(rt.latency, ids[a], X) for a in eachindex(ids)]   # E[time|a,X], 0 if unknown
-    a = route(rt.model, tops, X, costs, rt.reward; w_time = rt.w_time, times = times)
+    a = route(rt.model, tops, X, costs, reward; w_time = w_time, times = times)
     Dict{String, Any}("model" => ids[a], "provider" => providers[a], "name" => names[a])
 end
 
@@ -508,15 +520,17 @@ end
 # rungs are ordered cheapest-first because `escalation_next` scans `eachindex(tops)` ascending.
 # The returned `tier_index` is in that cost-ascending space, so the host pushes it straight
 # back into `tried` on a failure (mirrors the eval's `push!(tried, a)` loop).
-function _escalate_decide(rt::RoutingState, features, roster, tried, reward)
+function _escalate_decide(rt::RoutingState, features, roster, tried, reward, profile = nothing)
     names, providers, ids, costs, tops = _resolve_roster(rt, roster)
     length(ids) >= 2 || return nothing
+    reward = _pget(profile, "reward", Float64(reward))   # per-request quality override
+    w_time = _pget(profile, "w_time", rt.w_time)         # per-request time override
     order = sortperm(costs)                              # cheapest → dearest
     X = context_from_features(rt.model, features)
     triedset = Set{Int}(Int(t) for t in tried)          # indices in cost-ascending space
     times = Float64[latency_at(rt.latency, ids[i], X) for i in order]   # E[time], aligned to tops[order]
-    a = escalation_next(rt.model, tops[order], X, costs[order], Float64(reward), triedset;
-                        w_time = rt.w_time, times_X = times)
+    a = escalation_next(rt.model, tops[order], X, costs[order], reward, triedset;
+                        w_time = w_time, times_X = times)
     a == 0 && return nothing                             # no positive-EU rung ⇒ STOP
     j = order[a]
     Dict{String, Any}("model" => ids[j], "provider" => providers[j], "name" => names[j],

--- a/apps/credence-pi/daemon/server.jl
+++ b/apps/credence-pi/daemon/server.jl
@@ -422,7 +422,9 @@ function handle_sensor_event(state::DaemonState,
             error("tool-proposed event $event_id missing required 'features' (Pass 2 brain)")
         state.pending_contexts[event_id] = features
         decide = state.env[Symbol("decide-action")]
-        action = decide(state.posterior[], features, state.last_cost[])
+        # Per-request profile (the user's utility weights) — body-supplied, no daemon restart.
+        action = decide(state.posterior[], features, state.last_cost[],
+                        get(event_dict, "profile", nothing))
         action isa Symbol || error("decide-action returned non-Symbol: $(typeof(action))")
         emit_signal!(state, event_id, action, event_dict)
 
@@ -503,7 +505,8 @@ function handle_sensor_event(state::DaemonState,
             # OpenClaw actually has + their costs. Absent ⇒ route-decide falls back to the
             # declared default roster (back-compat with an older body).
             roster = get(event_dict, "models", nothing)
-            choice = route_decide(features, roster)
+            # Per-request profile (the user's utility weights: reward/w_time) — body-supplied.
+            choice = route_decide(features, roster, get(event_dict, "profile", nothing))
             if choice === nothing
                 # Inert: fewer than 2 candidate models ⇒ nothing to route between. Emit no
                 # signal; the body keeps OpenClaw's model (fail open). No pending-route stash.
@@ -538,9 +541,9 @@ function handle_sensor_event(state::DaemonState,
             roster = get(event_dict, "models", nothing)
             tried  = get(event_dict, "tried", Int[])
             reward = get(event_dict, "reward", nothing)
-            choice = reward === nothing ?
-                escalate_decide(features, roster, tried) :
-                escalate_decide(features, roster, tried, Float64(reward))
+            # Per-request profile (reward/w_time override); reward field kept for back-compat.
+            choice = escalate_decide(features, roster, tried, reward,
+                                     get(event_dict, "profile", nothing))
             choice === nothing ? (ack_extra["stop"] = true) : (ack_extra["route"] = choice)
         end
 

--- a/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
+++ b/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
@@ -49,6 +49,17 @@
         "type": "object",
         "description": "Optional per-model USD price overrides in $/million tokens: { \"<model-id>\": { \"input\": <num>, \"output\": <num>, \"cacheRead\": <num>, \"cacheWrite\": <num> } }. Merged over the built-in table.",
         "additionalProperties": true
+      },
+      "profile": {
+        "type": "string",
+        "enum": ["cost-saver", "balanced", "quality-first", "speed-first"],
+        "description": "Your cost/time/quality/risk trade-off, as a named preset. cost-saver: cheapest models, block waste readily, time cheap. balanced: the middle. quality-first: pay for the best model, escalate fully, fewer false blocks. speed-first: fastest models, escalate sooner, rarely interrupt (your time is valuable). Sent to the daemon per request — switch any time, no restart. credence-pi does ONE EU-max over a shared belief with YOUR utility (Savage factorisation).",
+        "default": "balanced"
+      },
+      "profileOverride": {
+        "type": "object",
+        "description": "Advanced: override individual utility dials on top of the preset. Keys: reward ($ value of a correct answer — quality), lambda (false-block aversion), q (interruption cost $), harm (harm cost $), w_time ($ per SECOND of your wall-clock — e.g. a $50/hr user ≈ 0.014). Any subset; unspecified dials keep the preset's value.",
+        "additionalProperties": true
       }
     }
   }

--- a/apps/credence-pi/openclaw-plugin/src/index.ts
+++ b/apps/credence-pi/openclaw-plugin/src/index.ts
@@ -34,6 +34,7 @@ import { SafetyTracker } from "./safety.js";
 import { extractRoutingFeatures } from "./routing-features.js";
 import { buildRoster, type RoutingModel } from "./roster.js";
 import { buildPriceTable, computeTurnCost, type PriceTable } from "./cost.js";
+import { resolveProfile, type Profile } from "./profile.js";
 import type {
   PluginEntry,
   BeforeToolCallEvent,
@@ -151,6 +152,10 @@ export interface GovernorOpts {
   /** The user's model roster (discovered from api.config), sent in each route-request so the
    *  brain routes over the models OpenClaw actually has. Empty ⇒ routing is not registered. */
   roster: RoutingModel[];
+  /** The user's utility profile (cost/time/quality/risk trade-offs), sent in each sensor event
+   *  so the daemon applies the user's preferences per-request (no restart). The brain does the
+   *  EU-max; this is preference DATA the body ships. */
+  profile: Profile;
   log: Logger;
 }
 
@@ -177,7 +182,7 @@ export function createGovernor(
   opts: GovernorOpts,
 ): Governor {
   const { hookTimeoutMs, approvalTimeoutMs, priceTable, redactToolInputs,
-    shadowMode, roster, log } = opts;
+    shadowMode, roster, profile, log } = opts;
   const tracker = new FeatureTracker();
   // Safety (multi-outcome): accumulates taint from tool results and emits the taint-flow
   // features the harm posterior conditions on. The daemon ignores them unless harm
@@ -243,6 +248,8 @@ export function createGovernor(
         tool_name: event.toolName,
         input: redactToolInputs ? null : event.params,
       },
+      // The user's utility weights (λ/q/harm/w_time read here) — preference, not learning.
+      profile,
     });
 
     if (!post.ok) {
@@ -317,6 +324,8 @@ export function createGovernor(
       // The user's live model roster (roster-aware routing): the brain routes over THESE
       // models + their costs, not a hardcoded list. Always ≥2 here (register gates on it).
       models: roster,
+      // The user's utility weights (reward + w_time read here) — the time/money trade-off.
+      profile,
     });
 
     if (!post.ok) {
@@ -425,6 +434,15 @@ const plugin: PluginEntry = {
     const shadowMode = cfg.shadowMode === true;
     const routingEnabled = cfg.routing !== false; // model routing is ON by default
     const priceTable = buildPriceTable(cfg.pricing);
+    // The user's utility profile: a named preset (default `balanced`) + an optional per-dial
+    // override, resolved to the full weight vector sent with each sensor event. This is how a
+    // user expresses their cost/time/quality/risk trade-off — no daemon restart, no Julia edit.
+    const profile = resolveProfile(
+      typeof cfg.profile === "string" ? cfg.profile : undefined,
+      typeof cfg.profileOverride === "object" && cfg.profileOverride !== null
+        ? (cfg.profileOverride as Record<string, unknown>)
+        : undefined,
+    );
 
     const log: Logger = (m, e) => {
       if (silent) return;
@@ -456,6 +474,7 @@ const plugin: PluginEntry = {
       redactToolInputs,
       shadowMode,
       roster,
+      profile,
       log,
     });
     if (shadowMode) log("credence-pi: SHADOW MODE — observing only, never enforcing");

--- a/apps/credence-pi/openclaw-plugin/src/profile.ts
+++ b/apps/credence-pi/openclaw-plugin/src/profile.ts
@@ -1,0 +1,60 @@
+// profile.ts — the user's utility PROFILE (their cost / time / quality / risk trade-offs).
+//
+// credence-pi is a proxy welfare-maximiser: ONE shared learned belief, the USER'S utility, one
+// EU-max (Savage factorisation). The utility weights are the user's PREFERENCE, so the BODY
+// ships them — like the model roster — per request, and the daemon applies them with NO restart.
+// A "profile" is a named bundle of the dials; the four presets are points in the dial space, and
+// `profileOverride` lets a power user set any dial directly. The numbers mirror the welfare.jl
+// anchors (cost-hawk λ=0.25/q=0.05, flow-guard λ=4.0/q=1.0) plus the routing reward and the time
+// dial. The body stays MATH-FREE — it ships numbers; the brain does all the EU-max.
+//
+// Wire keys (read by the daemon's _pget): reward (quality: $ value of a correct answer), lambda
+// (false-block aversion), q (interruption $), harm (harm $), w_time ($/sec of the user's
+// wall-clock — "what is your time worth?"). The full profile is attached to tool-proposed and
+// route/escalate-request; the daemon reads whichever keys each decision needs.
+
+export interface Profile {
+  reward: number; // quality coordinate ($ value of a correct answer)
+  lambda: number; // false-block aversion (unitless)
+  q: number; // interruption cost ($)
+  harm: number; // harm cost ($)
+  w_time: number; // time coordinate ($/sec of wall-clock)
+}
+
+export const PROFILE_KEYS = ["reward", "lambda", "q", "harm", "w_time"] as const;
+
+// Four presets spanning the trade-off space:
+//  - cost-saver:    money precious — cheap models, block readily, ask freely, time cheap.
+//  - balanced:      the middle.
+//  - quality-first: pay for the best — escalate fully, fewer false blocks, more harm-averse.
+//  - speed-first:   time precious — faster models, escalate sooner, rarely interrupt (asking
+//                   costs the user's seconds), high $/sec.
+export const PRESETS: Record<string, Profile> = {
+  "cost-saver": { reward: 0.02, lambda: 0.25, q: 0.05, harm: 1.0, w_time: 0.002 },
+  balanced: { reward: 1.0, lambda: 1.0, q: 0.02, harm: 1.0, w_time: 0.014 },
+  "quality-first": { reward: 5.0, lambda: 2.0, q: 0.1, harm: 2.0, w_time: 0.014 },
+  "speed-first": { reward: 1.0, lambda: 1.0, q: 0.5, harm: 1.0, w_time: 0.05 },
+};
+
+export const DEFAULT_PROFILE = "balanced";
+export const PRESET_NAMES = Object.keys(PRESETS);
+
+/**
+ * Resolve the active profile: a preset name (default `balanced`) with an optional per-dial
+ * override merged on top. An unknown preset falls back to the default. `override` accepts any
+ * subset of the dials. Returns the full weight vector the body attaches to sensor events.
+ */
+export function resolveProfile(
+  preset: string | undefined,
+  override: Partial<Record<(typeof PROFILE_KEYS)[number], unknown>> | undefined,
+): Profile {
+  const base = (preset && PRESETS[preset]) || PRESETS[DEFAULT_PROFILE];
+  const merged: Profile = { ...base };
+  if (override && typeof override === "object") {
+    for (const k of PROFILE_KEYS) {
+      const v = override[k];
+      if (typeof v === "number" && Number.isFinite(v)) merged[k] = v;
+    }
+  }
+  return merged;
+}

--- a/apps/credence-pi/openclaw-plugin/tests/index.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/index.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { createGovernor } from "../src/index.js";
 import { buildPriceTable } from "../src/cost.js";
+import { resolveProfile } from "../src/profile.js";
 import type { DaemonClient, SignalEnvelope } from "../src/daemon-client.js";
 import type { BeforeToolCallEvent, ToolContext } from "../src/openclaw-types.js";
 
@@ -37,6 +38,7 @@ function harness(postOk = true, shadowMode = false) {
     redactToolInputs: false,
     shadowMode,
     roster: [],
+    profile: resolveProfile("balanced", undefined),
     log: () => {},
   });
   const find = (t: string) => posted.find((e) => e.event_type === t);
@@ -137,6 +139,7 @@ test("redactToolInputs: tool input omitted from the sensor event", async () => {
     redactToolInputs: true,
     shadowMode: false,
     roster: [],
+    profile: resolveProfile("balanced", undefined),
     log: () => {},
   });
   await gov.beforeToolCall(ev("bash", { params: { command: "secret-token-123" } }), ctx);

--- a/apps/credence-pi/openclaw-plugin/tests/profile.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/profile.test.ts
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  PRESETS,
+  PRESET_NAMES,
+  DEFAULT_PROFILE,
+  resolveProfile,
+  PROFILE_KEYS,
+} from "../src/profile.js";
+
+test("the four presets exist with every dial", () => {
+  assert.deepEqual(PRESET_NAMES.sort(), ["balanced", "cost-saver", "quality-first", "speed-first"]);
+  for (const name of PRESET_NAMES) {
+    for (const k of PROFILE_KEYS) {
+      assert.equal(typeof PRESETS[name][k], "number", `${name}.${k}`);
+    }
+  }
+});
+
+test("resolveProfile: a named preset returns that vector", () => {
+  assert.deepEqual(resolveProfile("speed-first", undefined), PRESETS["speed-first"]);
+  assert.deepEqual(resolveProfile("cost-saver", undefined), PRESETS["cost-saver"]);
+});
+
+test("resolveProfile: default + unknown preset fall back to balanced", () => {
+  assert.equal(DEFAULT_PROFILE, "balanced");
+  assert.deepEqual(resolveProfile(undefined, undefined), PRESETS["balanced"]);
+  assert.deepEqual(resolveProfile("nonsense", undefined), PRESETS["balanced"]);
+});
+
+test("resolveProfile: a per-dial override merges on top of the preset", () => {
+  const p = resolveProfile("cost-saver", { w_time: 0.5, reward: 3.0 });
+  assert.equal(p.w_time, 0.5); // overridden
+  assert.equal(p.reward, 3.0); // overridden
+  assert.equal(p.lambda, PRESETS["cost-saver"].lambda); // untouched
+  assert.equal(p.q, PRESETS["cost-saver"].q); // untouched
+});
+
+test("resolveProfile: non-number / non-finite override values are ignored", () => {
+  const p = resolveProfile("balanced", { w_time: "fast" as unknown as number, q: NaN, harm: 9 });
+  assert.equal(p.w_time, PRESETS["balanced"].w_time); // string ignored
+  assert.equal(p.q, PRESETS["balanced"].q); // NaN ignored
+  assert.equal(p.harm, 9); // valid number applied
+});
+
+test("the presets encode the intended trade-off ordering", () => {
+  // time dial: speed-first values a second most, cost-saver least.
+  assert.ok(PRESETS["speed-first"].w_time > PRESETS["balanced"].w_time);
+  assert.ok(PRESETS["balanced"].w_time > PRESETS["cost-saver"].w_time);
+  // quality dial: quality-first pays the most for a correct answer, cost-saver the least.
+  assert.ok(PRESETS["quality-first"].reward > PRESETS["balanced"].reward);
+  assert.ok(PRESETS["balanced"].reward > PRESETS["cost-saver"].reward);
+  // speed-first rarely interrupts (asking costs the user's time): highest q among non-quality.
+  assert.ok(PRESETS["speed-first"].q > PRESETS["balanced"].q);
+});

--- a/apps/credence-pi/tests/julia/test_routing.jl
+++ b/apps/credence-pi/tests/julia/test_routing.jl
@@ -380,6 +380,34 @@ let path = tempname() * ".jsonl"
     rm(path; force = true)
 end
 
+# ── B''. Per-request PROFILE override: one daemon, many users' trade-offs, no restart ──
+# The user's utility weights ride in the route-request `profile` (like the live roster), so a
+# user switches cost/time/quality WITHOUT a daemon restart. The SAME daemon + belief routes
+# differently per profile: speed-first (high w_time) → the faster model; quality-first (high
+# reward, no time pressure) → a stronger one. This is the MVP's "handle different trade-offs".
+let path = tempname() * ".jsonl"
+    state = init_state(; bdsl_dir = DAEMON_BDSL, log_path = path)
+    w_before2 = weights(state.posterior[])
+    route_with(profile) = begin
+        handle_sensor_event(state, Dict{String, Any}("event_type" => "route-request",
+            "event_id" => "rp", "features" => Dict("prompt-length" => "short"), "profile" => profile))
+        snapshot(state.signal_queue)[end]["parameters"]["model"]
+    end
+    speed   = route_with(Dict("reward" => 1.0, "w_time" => 0.05))   # time precious
+    quality = route_with(Dict("reward" => 5.0, "w_time" => 0.0))    # quality precious, time free
+    @assert speed == "claude-haiku-4-5"        # speed-first ⇒ the FASTER model
+    @assert quality != "claude-haiku-4-5"      # quality-first ⇒ a stronger model
+    @assert speed != quality
+    ok("per-request profile: same daemon, speed-first → $speed, quality-first → $quality (no restart)")
+
+    # A profile override is PREFERENCE, never learning: a route-request with a profile must not
+    # touch the governance posterior (separate belief, like the un-profiled path).
+    # credence-lint: allow — precedent:test-oracle — governance-posterior equality oracle (profile is preference, not learning)
+    @assert weights(state.posterior[]) == w_before2
+    ok("per-request profile: routing with a profile leaves the governance posterior untouched")
+    rm(path; force = true)
+end
+
 # ── C. Online correctness learning (brain): soft evidence + learned confounds ───
 #
 # The deferred online signal, landed. We never see model correctness; we see whether the

--- a/apps/credence-pi/tests/julia/test_server.jl
+++ b/apps/credence-pi/tests/julia/test_server.jl
@@ -135,8 +135,8 @@ fresh_state(; tmp_log) = init_state(; bdsl_dir = BDSL_DIR, log_path = tmp_log)
 
 let path = tempname() * ".jsonl"
     state = fresh_state(; tmp_log = path)
-    # Sabotage decide-action (now 3-arg: posterior, features, cost) AFTER init.
-    state.env[Symbol("decide-action")] = (posterior, features, cost) -> error("simulated brain failure")
+    # Sabotage decide-action (posterior, features, cost, profile) AFTER init.
+    state.env[Symbol("decide-action")] = (posterior, features, cost, profile = nothing) -> error("simulated brain failure")
 
     event = Dict{String, Any}(
         "event_type" => "tool-proposed",


### PR DESCRIPTION
Second workstream of the credence-pi viable-MVP. The user's cost/time/quality/risk trade-off was hardcoded in Julia BDSL (changeable only by editing `utility.bdsl` + restarting). This makes it a **one-click choice in the OpenClaw plugin config, sent per-request — no restart, no Julia.**

## Design: profiles are body-supplied (like the roster)
A profile is the user's *preference* (their utility weights), so the body ships it — exactly like the live model roster — and the daemon applies a **per-request override**; `utility.bdsl` stays the default. Body stays **math-free**; the brain does all the EU-max. No TS↔Julia drift (presets live in one place).

## Plugin (`openclaw-plugin/`)
- **`src/profile.ts`**: 4 presets — **cost-saver / balanced / quality-first / speed-first** — as points in `(reward, lambda, q, harm, w_time)` space (mirroring the welfare.jl anchors + the time/quality dials); `resolveProfile(preset, override)` merges an optional advanced per-dial override. Default `balanced`.
- **`openclaw.plugin.json`**: `profile` enum + `profileOverride` object in configSchema (discoverable in the OpenClaw UI).
- **`index.ts`**: `register()` resolves the active profile; `createGovernor` attaches it to every `tool-proposed` and `route-request`.

## Daemon (per-request override, beliefs untouched)
- `routing_brain.jl` / `feature_brain.jl`: a `_pget(profile, key, default)` helper; the `route-decide` / `escalate-decide` / `decide-action` closures take an optional profile and substitute `reward`/`w_time` (routing) or `lambda`/`q`/`harm`/`w_time` (governance) for **that decision only** — absent ⇒ wired defaults (**bit-identical**).
- `server.jl`: the three handlers forward the event's `profile`.

## Tests
- **Julia (40 routing assertions):** same daemon, **speed-first → haiku (fast), quality-first → sonnet (best), NO restart**; a profile override never touches the governance posterior (preference, not learning).
- **Plugin (52 TS tests, +`profile.test.ts`):** preset→vector, default/unknown fallback, override merge, non-number guard, and the intended trade-off ordering. Typecheck + lint clean.

Together with MVP-A (time coordinate), a user can now express **time vs money vs quality** with one config knob, and the one EU-max produces their behaviour.

Next (MVP-C): show the user the welfare delivered (saved $X + Ys, caught N loops) so they can trust + tune it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)