### PR TITLE
credence-pi MVP-C: value reporting (GET /report + in-session summary)

### DIFF
--- a/apps/credence-pi/daemon/Dockerfile
+++ b/apps/credence-pi/daemon/Dockerfile
@@ -24,6 +24,9 @@ COPY src/ src/
 COPY apps/credence-pi/bdsl/   apps/credence-pi/bdsl/
 COPY apps/credence-pi/brain/  apps/credence-pi/brain/
 COPY apps/credence-pi/daemon/ apps/credence-pi/daemon/
+# The value-report surface (GET /report): server.jl includes ../savings.jl, which in turn
+# includes daemon/observation_log.jl (already copied above). Without this the daemon won't load.
+COPY apps/credence-pi/savings.jl apps/credence-pi/savings.jl
 
 # Instantiate Credence's declared deps (HTTP ~1.11, JSON3, …) and precompile
 # into the depot, then a load smoke so the first container start is warm.

--- a/apps/credence-pi/daemon/server.jl
+++ b/apps/credence-pi/daemon/server.jl
@@ -54,6 +54,13 @@ using .FeatureBrain: wire_brain!, build_model_from_env, reconstruct_posterior
 include(joinpath(@__DIR__, "..", "brain", "routing_brain.jl"))
 using .RoutingBrain: wire_routing!, route_outcome!
 
+# Value reporting (display-only, non-causal): the governance + dollars-saved surface, exposed
+# over GET /report so the body can show the user what credence-pi delivered — closing the
+# "manual `julia savings.jl`" gap. Savings nests its OWN ObservationLog (distinct from this
+# module's include above), so the two coexist without a name clash.
+include(joinpath(@__DIR__, "..", "savings.jl"))
+using .Savings: savings_report
+
 export start_daemon, stop_daemon, DaemonState
 export SignalQueue, enqueue!, snapshot, drain!
 export handle_sensor_event, action_to_signal, emit_signal!, emit_route_signal!
@@ -682,6 +689,21 @@ function start_daemon(; port::Int,
             HTTP.setheader(stream, "Content-Type" => "text/plain")
             HTTP.startwrite(stream)
             write(stream, "ok\n")
+        elseif method == "GET" && target == "/report"
+            # The value surface (display-only, non-causal): governance + dollars-saved tallies
+            # from the observation log, as JSON, so the body can show the user what credence-pi
+            # delivered this run. No reasoning here — reuses Savings.savings_report verbatim.
+            body = try
+                JSON3.write(savings_report(state.log_path))
+            catch e
+                @warn "report generation failed" error = e
+                JSON3.write(Dict("error" => "report unavailable"))
+            end
+            HTTP.setstatus(stream, 200)
+            HTTP.setheader(stream, "Content-Type" => "application/json")
+            HTTP.setheader(stream, "Content-Length" => string(sizeof(body)))
+            HTTP.startwrite(stream)
+            write(stream, body)
         else
             HTTP.setstatus(stream, 404)
             HTTP.startwrite(stream)

--- a/apps/credence-pi/openclaw-plugin/src/index.ts
+++ b/apps/credence-pi/openclaw-plugin/src/index.ts
@@ -524,6 +524,31 @@ const plugin: PluginEntry = {
       );
     }
 
+    // In-session VALUE SUMMARY: on cleanup (session end / reload), fetch the daemon's report
+    // and log a one-line "what credence-pi did for you" — so the user SEES the value without a
+    // manual CLI (the trust/tune loop). Best-effort + fail-open: a down daemon / bad response is
+    // silently skipped, and it never throws on the cleanup path. Inline fetch (the shared
+    // daemon-client stays verbatim — this is a read-only display call, not the core wire).
+    async function logSessionSummary(): Promise<void> {
+      try {
+        const ctrl = new AbortController();
+        const t = setTimeout(() => ctrl.abort(), 2_000);
+        const res = await fetch(`${daemonUrl.replace(/\/+$/, "")}/report`, { signal: ctrl.signal });
+        clearTimeout(t);
+        if (!res.ok) return;
+        const r = (await res.json()) as Record<string, number>;
+        const n = (k: string) => (typeof r[k] === "number" ? r[k] : 0);
+        if (n("total_events") === 0) return;
+        log(
+          `credence-pi: this run — spend $${n("total_usd").toFixed(4)}; ` +
+            `blocked ${n("prevented_calls")} waste call(s) (~$${n("estimated_prevented_usd").toFixed(4)} saved, est.); ` +
+            `asked ${n("decided_ask")}, you denied ${n("denied")}. Full report: GET ${daemonUrl}/report`,
+        );
+      } catch {
+        /* best-effort display; never throws on cleanup */
+      }
+    }
+
     // Close the SSE stream + drain awaiters on reset/delete/reload so a
     // hot-reload does not accumulate daemon connections. Optional-chained
     // for hosts predating the lifecycle API.
@@ -532,7 +557,10 @@ const plugin: PluginEntry = {
         id: "credence-pi-governor",
         description:
           "Close the credence-pi daemon SSE stream and drain pending tool-call awaiters.",
-        cleanup: () => gov.cleanup(),
+        cleanup: () => {
+          void logSessionSummary(); // fire-and-forget value summary
+          gov.cleanup();
+        },
       });
     } catch (err) {
       log("credence-pi: could not register lifecycle cleanup", err);


### PR DESCRIPTION
Third workstream of the credence-pi viable-MVP. Value was **invisible** — the dollars-saved/governance surface existed only as a manual `julia savings.jl` CLI, so users couldn't trust or tune what they couldn't see. This makes it accessible.

## Daemon (`server.jl`)
A `GET /report` arm returning `Savings.savings_report(log)` as JSON — governance (proposed/blocked/asked/denied) + spend + the labelled prevented-spend estimate. Reuses the existing, tested report **verbatim** (display-only, non-causal — no reasoning); `Savings` nests its own `ObservationLog`, so it coexists with the daemon's without a name clash. **Verified live:** `GET /report` → 200 + the full report JSON (623 events).

## Plugin (`index.ts`)
On the lifecycle cleanup (session end / reload), a best-effort, fail-open inline fetch of `/report` logs a one-line summary:
> credence-pi: this run — spend $X; blocked N waste call(s) (~$Y saved, est.); asked M, you denied K. Full report: GET …/report

Inline fetch keeps the **vendored** daemon-client verbatim (read-only display call, not the core sensor/signals wire); never throws on cleanup.

## Tests
Plugin typecheck + 46 tests green; credence-pi Julia suites (`test_server` 23, `test_savings` 3) pass with `server.jl` now loading the savings include (no module clash). Lint clean.

## Honest scope
The report surfaces **governance + spend** today (loops caught + prevented-spend estimate). Routing savings and the time coordinate are a noted enrichment — the report's data source (the observation log) already carries the `route-decision` + `turn-cost` events to compute them.

Note: branched off master; rebases cleanly after MVP-B (#133) merges (non-overlapping regions in `server.jl`/`index.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)