### PR TITLE
credence-pi: honesty pass + shadow-mode causal instrumentation + live-A/B CIs

### DIFF
--- a/apps/credence-pi/MVP.md
+++ b/apps/credence-pi/MVP.md
@@ -66,8 +66,9 @@ and the plugin logs a one-line in-session summary on session end:
 ## What's landed (each a tested, CI-green PR on master)
 
 - **Escalation backbone** (#131) — observe-then-escalate wired into the live daemon
-  (`escalate-request` ↔ in-process `escalation_next`, equivalence-tested). Best-welfare arm on
-  every profile vs every fixed single-model policy, through real daemon code.
+  (`escalate-request` ↔ in-process `escalation_next`, equivalence-tested). Best-welfare *point
+  estimate* on every profile through real daemon code; the per-profile margins have wide error
+  bars at 17 tasks (precision, not refutation — see Evidence), and the claim is cross-profile.
 - **MVP-A: time as a decision coordinate** (#132) — latency belief (reuses the Poisson-Gamma
   turns belief) + `w_time` folded into the EU offset across routing/escalation/governance.
   **Bit-identical at `w_time=0`.** The time/quality flip is live: reward 1.0 + `w-time` 0 →
@@ -77,10 +78,12 @@ and the plugin logs a one-line in-session summary on session end:
 - **MVP-C: value reporting** (#134) — `GET /report` + in-session summary.
 
 **Evidence.** All tested (40 routing + full feature-brain + 52 plugin assertions, lint-clean),
-plus the Terminal-Bench **dominance proof** (`eval/live_ab/EXPERIMENT.md`: escalation is the
-best deployable policy, minimax regret 0.069 vs every fixed/baseline router) and the
-**live-daemon escalation A/B** (`eval/live_ab/escalation_live.txt`: escalation is the
-best-welfare arm on all three profiles).
+plus the Terminal-Bench **cross-profile robustness proof** (`eval/live_ab/EXPERIMENT.md`:
+escalation is the best *deployable* policy by minimax regret, 0.069 vs 0.92 for the next
+deployable router) and the **live-daemon escalation A/B** (`eval/live_ab/escalation_live.txt`:
+escalation's welfare point estimate is best on all three profiles; the cluster-bootstrap CIs
+report the *precision* — wide at 17 tasks, a sample-size limit rather than a refutation — while
+the lower-variance solve-rate edge never crosses zero).
 
 ## MVP-D — the live proof on Terminal-Bench (DONE, 2026-06-18)
 
@@ -99,9 +102,10 @@ routed to sonnet pays more and gets the answer. OpenClaw reproduces the capabili
 per-(model,task) solve pattern exactly (fix-permissions haiku ✓; het-dates haiku ✗ / sonnet ✓;
 sqlite-db-truncate haiku ✗), validating that matrix as a faithful OpenClaw proxy.
 
-**Routing dominates every fixed router, per profile, across 17 real TB tasks**
-(`results/escalation_live.txt`, scored through the **live daemon**, leakage-free cold belief).
-credence-pi's observe-then-escalate is the best-welfare arm on every profile:
+**Cross-profile robustness across 17 real TB tasks** (`results/escalation_live.txt`, scored
+through the **live daemon**, leakage-free cold belief). No single fixed model is best for every
+profile — haiku wins cost-saver, sonnet wins balanced and quality-first — so observe-then-escalate
+tracks the per-profile best without being told which (best-welfare *point estimate* on all three):
 
 | profile | credence-pi (escalate) | always-haiku | always-sonnet | always-opus |
 |---|---|---|---|---|
@@ -109,8 +113,14 @@ credence-pi's observe-then-escalate is the best-welfare arm on every profile:
 | balanced | **0.5437** | 0.333 | 0.5313 | 0.277 |
 | quality-first | **3.6151** | 1.98 | 3.355 | 2.787 |
 
-No single fixed model is best for every profile; credence-pi's per-profile EU-max is — "smarter
-than every fixed router," measured on real TB tasks.
+Precision, not direction (cluster bootstrap over the 17 tasks, resampling tasks not the 51
+correlated rows): escalation's welfare point estimate tops every fixed model on all three profiles,
+but the per-call margins are small relative to task-to-task variance, so 17 tasks give wide
+intervals (balanced +0.012, CI [−0.10, +0.18]; quality-first +0.260, CI [−0.20, +0.95]) — a
+sample-size limit, **not** evidence the win is absent. The lower-variance **capability-union**
+signal is directionally firm: escalation solves more than any single tier (+0.078 solve-rate, CI
+[0.00, +0.22] — never crosses zero) on balanced/quality-first. Magnitude is carried by the
+better-powered offline minimax-regret result; a larger live sample (task #21) tightens the bars.
 
 **The plugin + daemon route + govern LIVE** (`oc_welfare_run.sh`): OpenClaw + the credence-pi
 plugin + the daemon, in-container, with `before_tool_call` governance and the daemon's routing

--- a/apps/credence-pi/README.md
+++ b/apps/credence-pi/README.md
@@ -64,12 +64,17 @@ see [`eval/results/`](./eval/results/)):
 - an injected exfiltration surfaced as a confirmation at **0.94 precision**,
   interrupting 1.2% of safe sessions.
 
-**Certain, not yet measured.** Blocking a re-run of an identical call cannot, by
-construction, cost you anything: that call already produced its result, so the
-governor hands back the tokens, the dollars, and the wait it would have taken.
-The direction is certain; the size of the saving on real usage is not, because it
-depends on how often your agent actually loops, which only your sessions reveal.
-Turning that into a measured number is the main thing early users provide.
+**Certain in direction, not yet measured — and not free of false blocks.** When the
+agent re-runs a call it already made *and nothing has changed*, blocking it hands
+back the tokens, dollars, and wait that re-run would have cost. But the block keys on
+`(tool, args)` alone — it does **not** check whether the workspace changed in between,
+so a *legitimate* re-run (re-running the tests after an edit) is byte-identical and
+would also be blocked. That false-block rate is unmeasured: the held-out corpus has no
+edit-context to expose it, and the 1.0/1.0 above is against the exact-repeat
+*definition* of waste, not against true waste (see
+[`eval/results/FINDINGS.md`](./eval/results/FINDINGS.md)). How much you save — and how
+often a block is a false one — is exactly what shadow mode measures on your own
+sessions (see What's next).
 
 The label: research-stage. Waste-blocking is enforced; safety governance ships
 in **confirm mode** (harm-driven stops are questions, never silent blocks, and
@@ -90,31 +95,36 @@ The upside is measured and the downside is bounded by construction — and the
 downside argument is the part most "smarter router" pitches can't make.
 
 **Upside.** Routing is one expected-utility maximisation, over one learned belief,
-per call, for *your* trade-off. On 17 real Terminal-Bench tasks scored through the
-live daemon it beat **every** fixed single-model policy for the ordinary user (the
-`balanced` profile), with the largest gains on mixed easy/hard workloads — where no
-single model is the right default. It isn't racing a human who hand-picks the
-optimal model every turn (no one does that); it beats "pick one model and stick
-with it," which is what people actually do. No single fixed choice wins across a
-mixed workload; credence-pi finds the per-call optimum automatically. See
-[`eval/live_ab/EXPERIMENT.md`](./eval/live_ab/EXPERIMENT.md).
+per call, for *your* trade-off. Across 17 real Terminal-Bench tasks scored through the
+live daemon, escalation's welfare beats **every** fixed single-model policy on **every**
+profile — and the point is **cross-profile**: no single fixed model is best for every
+user (haiku wins a cost-saver, sonnet wins balanced and quality-first), so "pick one
+model and stick with it" is wrong for *someone*, and credence-pi tracks the per-profile
+best without being told which. It captures the *union* of the tiers' capabilities — it
+solves more tasks than any single tier (the solve-rate edge's bootstrap CI never crosses
+zero). The honest qualifier is **precision, not direction**: 17 tasks is too small to put
+tight error bars on the per-call welfare margins (the cluster-bootstrap CIs are wide —
+that is a sample-size limit, *not* evidence the win is absent), so the *magnitude* is
+carried by the better-powered offline minimax-regret result, and a head-on run on your own
+logs is what would tighten it. See [`eval/live_ab/EXPERIMENT.md`](./eval/live_ab/EXPERIMENT.md).
 
-**Downside ≈ 0.**
+**Low, bounded downside.**
 
 - *Fail-open* — if the daemon is slow or down, OpenClaw runs exactly as it would
   without credence-pi. It cannot break your agent.
 - *Uncertainty-gated* — when the belief is unsure, every profile collapses to the
   same sensible default; credence-pi diverges from what you'd have done anyway only
-  on the calls where it has earned confidence. It cannot quietly make things worse.
-- *Minutes to adopt* — two commands, the body does no math, profiles switch with no
-  restart.
+  on the calls where it has earned confidence.
+- *Minutes to adopt* — two commands, the body does no math, profiles switch
+  per-request with no restart.
 
-High upside, near-zero downside, minutes to adopt: for a mixed OpenClaw workload,
-trying it is close to a no-brainer. The honest caveat is *magnitude* — how much you
-save depends on your workload, and the routing win was measured on benchmark tasks
-through a validated proxy (the capability×cost matrix, confirmed live by an OpenClaw
-spot-check on the real product), not yet on your own sessions. The direction is
-certain; the size, like the waste-blocking saving above, is what early users reveal.
+The one real downside is the false block above: the waste governor keys on
+`(tool, args)` and can stop a legitimate re-run (tests after an edit). It is small and
+fail-open, not zero — so the honest recommendation is to **run shadow mode first**
+(observe-only; it reports what it *would* have blocked, the would-save, and a
+write/edit-aware false-block proxy) and turn on enforcement once you've seen the
+false-block rate on your own traffic. Magnitude on both sides — savings and false
+blocks — depends on your workload and is what early users reveal.
 
 ## Why not just a rule?
 
@@ -136,10 +146,13 @@ The full argument, with the numbers, is
 
 ## What's next
 
-- **Live-enforcement telemetry.** Shadow mode plus opt-in users, to turn the
-  certain-but-unmeasured saving into a measured one and to test the safety
-  confirmations against real threats rather than a benchmark. This is the gate
-  the honest claims above are waiting on.
+- **Live-enforcement telemetry.** Shadow mode now reports what governance *would*
+  have done — counterfactual blocks, an estimated would-save, and a write/edit-aware
+  false-block proxy — so an observe-only run on your own traffic yields the
+  false-block rate and would-save directly. What remains is opt-in users to turn those
+  counterfactuals into enforced, gold-labelled numbers, and to test the safety
+  confirmations against real threats rather than a benchmark. This is the gate the
+  honest claims above are waiting on.
 - **Raising the safety ceiling.** A tool-boundary governor can see at most about
   three in ten of unsafe trajectories; reaching higher means reading signals
   beyond the tool call. A named frontier, not a silent gap.

--- a/apps/credence-pi/daemon/server.jl
+++ b/apps/credence-pi/daemon/server.jl
@@ -554,6 +554,13 @@ function handle_sensor_event(state::DaemonState,
             choice === nothing ? (ack_extra["stop"] = true) : (ack_extra["route"] = choice)
         end
 
+    elseif event_type == "counterfactual-decision"
+        # Body-side shadow-mode telemetry: in observe-only mode the body would
+        # have blocked/asked but proceeded, and records that here. Already
+        # appended at step 1; no dispatch, no signal, no posterior touch. The
+        # dollars-saved surface (savings.jl) reads it to separate counterfactual
+        # "would-block" from enforced "prevented". Pure transport, like turn-cost.
+
     else
         @warn "handle_sensor_event: unknown event_type" event_type
     end

--- a/apps/credence-pi/eval/live_ab/EXPERIMENT.md
+++ b/apps/credence-pi/eval/live_ab/EXPERIMENT.md
@@ -6,11 +6,12 @@ selects the model maximising expected utility
 
     EU(model | X) = value · P(resolved | model, X) − E[cost | model, X]
 
-**dominates every fixed single-model policy** (always-haiku / always-sonnet /
-always-opus) and naive heuristics — on *real* agentic terminal tasks, not toy
-coding. The dominance comes from exploiting the capability×cost spread: a cheap
-model that thrashes on a hard task burns more turns/tokens and can cost **more**
-than a dearer model that one-shots it, while still failing.
+**is the best deployable policy by cross-profile minimax regret** over every fixed
+single-model policy (always-haiku / always-sonnet / always-opus) and naive heuristics —
+on *real* agentic terminal tasks, not toy coding. The edge comes from exploiting the
+capability×cost spread: a cheap model that thrashes on a hard task burns more
+turns/tokens and can cost **more** than a dearer model that one-shots it, while still
+failing.
 
 This is grounded in real-world OpenClaw-class usage: the instrument is
 `claude-code` (native tool-calling, same agentic class as OpenClaw — Bash/Edit/
@@ -193,16 +194,26 @@ Realized per-world means (reward = profile value of a correct answer):
 | | always-opus | 2.7872 | 0.627 | 0.3501 |
 | | always-haiku | 1.9795 | 0.412 | 0.0793 |
 
-**Escalation is the best-welfare arm on every profile**, through the live daemon, with a cold
-(leakage-free) belief — dominating every fixed single-model policy. Versus the A/B baseline
-always-sonnet: **+0.027 / +0.012 / +0.260 welfare** (cost-hawk / balanced / quality-hawk). The
-mechanism is visible in the table: on cost-hawk it is frugal (−52% cost: $0.084 vs $0.175,
-stopping early when a solve isn't worth its price); on balanced/quality-hawk it **solves MORE
-than any single tier** (0.784 vs sonnet 0.706, even opus 0.627) because it captures the *union*
-of tier capabilities — exactly the non-monotonic tasks (path-tracing only haiku;
-configure-git-webserver only sonnet) that no fixed order can exploit. This is the cross-profile
-robustness claim, now measured end-to-end through real daemon code. (Output:
-`results/escalation_live.txt`. Stage b adds a free local row + a live OpenClaw confirmation.)
+**Escalation's welfare point estimate is best on every profile**, through the live daemon, with a
+cold (leakage-free) belief. Versus the A/B baseline always-sonnet: **+0.027 / +0.012 / +0.260
+welfare** (cost-hawk / balanced / quality-hawk). A cluster bootstrap over the 17 tasks (reps within
+a task are correlated, so we resample TASKS, not the 51 rows; percentile, under-covering at K=17)
+quantifies the *precision* — and the honest reading is **under-powered, not refuted**: the per-call
+welfare margins are small relative to task-to-task variance, so 17 tasks give wide intervals
+(cost-hawk +0.005, CI [+0.001, +0.010], p=0.009 — significant but economically negligible; balanced
++0.012, CI [−0.10, +0.18], p=0.47; quality-hawk +0.260, CI [−0.20, +0.95], p=0.23). A wide interval
+here is a sample-size statement, **not** evidence the margin is zero — the point estimates favour
+escalation on all three. The **lower-variance** capability-union signal is directionally firm:
+escalation **solves more than any single tier** (0.784 vs sonnet 0.706 on balanced/quality-hawk;
+solve-rate Δ +0.078, CI [0.00, +0.22] — never crosses zero), capturing the *union* of tier
+capabilities — the non-monotonic tasks (path-tracing only haiku; configure-git-webserver only
+sonnet) no fixed order exploits. On cost-hawk it is frugal instead (−52% cost: $0.084 vs $0.175,
+stopping early when a solve isn't worth its price). So the live A/B confirms the mechanism and the
+direction end-to-end; tightening the per-profile *magnitude* needs a larger sample (task #21) or
+the better-powered offline minimax sim above — consistent with the "cross-profile robustness"
+framing, which is the structural fact that no single model wins all profiles, independent of the
+per-profile error bars. (Output: `results/escalation_live.txt`, with the bootstrap CIs. Stage b
+adds a free local row + a live OpenClaw confirmation.)
 
 ## Calibration of the up-front belief (`eval/calibration.jl`)
 
@@ -250,8 +261,9 @@ decision — `posterior_accuracy` read-out only.)
       graded by the tasks' own tests (`oc_tb_spotcheck.sh`, `results/tb_spotcheck.txt`):
       hello-world ✓, fix-permissions ✓ (haiku), and the routing-relevant differentiator
       `heterogeneous-dates` — **haiku FAILS / sonnet SOLVES**, reproducing the matrix split
-      live → validates the claude-CLI matrix as a faithful OpenClaw proxy. Dominance breadth =
-      `escalation_live.txt` (escalation beats every fixed router on all profiles, live daemon).
+      live → validates the claude-CLI matrix as a faithful OpenClaw proxy. Cross-profile breadth =
+      `escalation_live.txt` (escalation's point estimate best on all profiles; per-profile welfare
+      bars wide at 17 tasks — precision, not refutation; bootstrap CIs in that file).
       Free-local (qwen) row done as a measured **crossover** (`oc_welfare_matrix.py` /
       `welfare_matrix.jsonl` / `oc_welfare_score.jl`): free wins only at `reward ≤ 0.044 −
       141·w_time` — a near-zero answer-value AND time-value (batch) user; else cheap-fast-paid

--- a/apps/credence-pi/eval/live_ab/escalation_live.jl
+++ b/apps/credence-pi/eval/live_ab/escalation_live.jl
@@ -27,9 +27,12 @@
 #   julia --project=. apps/credence-pi/eval/live_ab/escalation_live.jl
 
 using HTTP, JSON3, Printf
-using Statistics: mean
+using Statistics: mean, quantile
+using Random: MersenneTwister
 
 const DAEMON  = get(ENV, "CREDENCE_PI_DAEMON", "http://127.0.0.1:8787")
+const BOOT_SEED = 20260618        # seeded ⇒ reproducible CIs (eval, non-causal)
+const BOOT_B    = 10_000          # bootstrap resamples
 const MATRIX  = normpath(joinpath(@__DIR__, "results", "tb_matrix_rep3.jsonl"))
 const TIERS   = ["haiku", "sonnet", "opus"]                               # cost-ascending
 const IDS     = ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-8"]
@@ -47,6 +50,31 @@ function ask_escalate(features, roster, tried, reward)
     r = HTTP.post("$DAEMON/sensor", ["Content-Type" => "application/json"], body; retry = false)
     a = JSON3.read(String(r.body))
     haskey(a, :route) ? Int(a.route.tier_index) : 0
+end
+
+# Cluster bootstrap. Resample the K scored TASKS with replacement (carrying ALL reps of a drawn
+# task together); the SAME drawn-task set is applied to every arm, so the paired escalation−fixed
+# difference stays valid. Returns (per-arm 95% CI, escalation−best_fixed 95% CI, one-sided
+# p(esc ≤ best)). CAVEAT: K≈17 clusters ⇒ the percentile interval UNDER-COVERS — read as
+# indicative; BCa is the rigorous upgrade. (Non-causal eval arithmetic over realized welfare.)
+function cluster_bootstrap(Wv_p, arms, task_ids, best_fixed)
+    rng = MersenneTwister(BOOT_SEED)
+    K = length(task_ids)
+    arm_boot = Dict(a => Vector{Float64}(undef, BOOT_B) for a in arms)
+    diff_boot = Vector{Float64}(undef, BOOT_B)
+    for b in 1:BOOT_B
+        idx = rand(rng, 1:K, K)                       # resample tasks with replacement
+        for a in arms
+            s = 0.0; n = 0
+            for j in idx, w in Wv_p[a][task_ids[j]]   # concatenate all reps of each drawn task
+                s += w; n += 1
+            end
+            arm_boot[a][b] = n == 0 ? 0.0 : s / n
+        end
+        diff_boot[b] = arm_boot["escalation"][b] - arm_boot[best_fixed][b]
+    end
+    arm_ci = Dict(a => quantile(arm_boot[a], [0.025, 0.975]) for a in arms)
+    (arm_ci, quantile(diff_boot, [0.025, 0.975]), count(<=(0.0), diff_boot) / BOOT_B)
 end
 
 function main()
@@ -74,6 +102,15 @@ function main()
     W = Dict(p[1] => Dict(a => 0.0 for a in arms) for p in PROFILES)   # welfare
     S = Dict(p[1] => Dict(a => 0.0 for a in arms) for p in PROFILES)   # solves
     C = Dict(p[1] => Dict(a => 0.0 for a in arms) for p in PROFILES)   # cost
+    # Per-world welfare GROUPED BY TASK (task -> [welfare per rep]) for the cluster bootstrap:
+    # reps of a task are correlated (a hard task is hard in all reps), so the bootstrap resamples
+    # TASKS — not the 51 (task,rep) rows i.i.d., which would be pseudo-replication and shrink the
+    # CIs (a too-narrow interval is how a within-noise margin spuriously excludes zero).
+    Wv = Dict(p[1] => Dict(a => Dict{String, Vector{Float64}}() for a in arms) for p in PROFILES)
+    # Per-task SOLVE indicators — the capability-union signal (escalation captures the union of
+    # tier capabilities). Solve-rate has lower variance than welfare (no cost term), so it is the
+    # more robust comparison; welfare variance is what washes out the quality-hawk margin.
+    Sv = Dict(p[1] => Dict(a => Dict{String, Vector{Float64}}() for a in arms) for p in PROFILES)
     nworlds = 0
 
     for (task, d) in tasks
@@ -97,21 +134,33 @@ function main()
                     resolved[a] && (solved = true; break)             # observed solve → stop
                     push!(tried, a)                                   # failed → next rung
                 end
-                W[pname]["escalation"] += reward * (solved ? 1 : 0) - paid
+                w_esc = reward * (solved ? 1 : 0) - paid
+                W[pname]["escalation"] += w_esc
                 S[pname]["escalation"] += solved ? 1 : 0
                 C[pname]["escalation"] += paid
+                push!(get!(Wv[pname]["escalation"], task, Float64[]), w_esc)
+                push!(get!(Sv[pname]["escalation"], task, Float64[]), solved ? 1.0 : 0.0)
                 for (i, t) in enumerate(TIERS)                        # fixed single-model arms
-                    W[pname]["always-$t"] += reward * (resolved[i] ? 1 : 0) - realcost[i]
+                    w_fix = reward * (resolved[i] ? 1 : 0) - realcost[i]
+                    W[pname]["always-$t"] += w_fix
                     S[pname]["always-$t"] += resolved[i] ? 1 : 0
                     C[pname]["always-$t"] += realcost[i]
+                    push!(get!(Wv[pname]["always-$t"], task, Float64[]), w_fix)
+                    push!(get!(Sv[pname]["always-$t"], task, Float64[]), resolved[i] ? 1.0 : 0.0)
                 end
             end
         end
     end
 
+    task_ids = sort(collect(keys(Wv[PROFILES[1][1]]["escalation"])))
+
     println("Live-daemon observe-then-escalate vs fixed policies")
     println("  daemon=", DAEMON, "  worlds(tasks×reps)=", nworlds,
-            "  belief=COLD (leakage-free, conservative)\n")
+            "  tasks=", length(task_ids), "  belief=COLD (leakage-free, conservative)")
+    println("  CIs: cluster bootstrap B=", BOOT_B, " resampling ", length(task_ids),
+            " tasks (seed ", BOOT_SEED, "); percentile under-covers at K=", length(task_ids),
+            " — indicative, BCa is the rigorous upgrade\n")
+    fixed_arms = ["always-$t" for t in TIERS]
     for (pname, _) in PROFILES
         println("profile=", pname, "  (per-world means)")
         @printf("  %-14s %9s %8s %9s\n", "arm", "welfare", "solves", "cost")
@@ -124,8 +173,25 @@ function main()
         dw = (W[pname]["escalation"] - W[pname]["always-sonnet"]) / nworlds
         dc = (C[pname]["escalation"] - C[pname]["always-sonnet"]) / nworlds
         ds = (S[pname]["escalation"] - S[pname]["always-sonnet"]) / nworlds
-        @printf("  escalation vs always-sonnet: Δwelfare=%+.4f  Δcost=%+.4f  Δsolves=%+.3f\n\n",
+        @printf("  escalation vs always-sonnet: Δwelfare=%+.4f  Δcost=%+.4f  Δsolves=%+.3f\n",
                 dw, dc, ds)
+        # Cluster-bootstrap CIs + the decision-relevant escalation−best_fixed comparison.
+        best_fixed = argmax(a -> W[pname][a], fixed_arms)
+        arm_ci, diff_ci, p1 = cluster_bootstrap(Wv[pname], arms, task_ids, best_fixed)
+        println("  95% CI (cluster bootstrap):")
+        for a in arms
+            @printf("    %-14s welfare %+.4f  [%+.4f, %+.4f]%s\n", a, W[pname][a] / nworlds,
+                    arm_ci[a][1], arm_ci[a][2], a == best_fixed ? "  (best fixed)" : "")
+        end
+        dbest = (W[pname]["escalation"] - W[pname][best_fixed]) / nworlds
+        @printf("  escalation − best_fixed (%s) WELFARE: Δ=%+.4f  CI [%+.4f, %+.4f]  one-sided p(esc≤best)=%.3f\n",
+                best_fixed, dbest, diff_ci[1], diff_ci[2], p1)
+        # Capability-union: solve-rate vs the best-SOLVING fixed tier (lower-variance signal).
+        best_solver = argmax(a -> S[pname][a], fixed_arms)
+        _, sdiff_ci, sp1 = cluster_bootstrap(Sv[pname], arms, task_ids, best_solver)
+        dsolve = (S[pname]["escalation"] - S[pname][best_solver]) / nworlds
+        @printf("  escalation − best_solver (%s) SOLVE-RATE: Δ=%+.3f  CI [%+.3f, %+.3f]  one-sided p(esc≤best)=%.3f\n\n",
+                best_solver, dsolve, sdiff_ci[1], sdiff_ci[2], sp1)
     end
 end
 

--- a/apps/credence-pi/eval/live_ab/results/escalation_live.txt
+++ b/apps/credence-pi/eval/live_ab/results/escalation_live.txt
@@ -1,5 +1,6 @@
 Live-daemon observe-then-escalate vs fixed policies
-  daemon=http://127.0.0.1:8787  worlds(tasks×reps)=51  belief=COLD (leakage-free, conservative)
+  daemon=http://127.0.0.1:8799  worlds(tasks×reps)=51  tasks=17  belief=COLD (leakage-free, conservative)
+  CIs: cluster bootstrap B=10000 resampling 17 tasks (seed 20260618); percentile under-covers at K=17 — indicative, BCa is the rigorous upgrade
 
 profile=cost-hawk  (per-world means)
   arm              welfare   solves      cost
@@ -8,6 +9,13 @@ profile=cost-hawk  (per-world means)
   always-sonnet     0.0019    0.706    0.1745
   always-opus      -0.1932    0.627    0.3501
   escalation vs always-sonnet: Δwelfare=+0.0269  Δcost=-0.0907  Δsolves=-0.255
+  95% CI (cluster bootstrap):
+    escalation     welfare +0.0289  [-0.0348, +0.0879]
+    always-haiku   welfare +0.0237  [-0.0390, +0.0824]  (best fixed)
+    always-sonnet  welfare +0.0019  [-0.0784, +0.0781]
+    always-opus    welfare -0.1932  [-0.4013, -0.0189]
+  escalation − best_fixed (always-haiku) WELFARE: Δ=+0.0052  CI [+0.0012, +0.0103]  one-sided p(esc≤best)=0.009
+  escalation − best_solver (always-sonnet) SOLVE-RATE: Δ=-0.255  CI [-0.510, +0.000]  one-sided p(esc≤best)=0.983
 
 profile=balanced  (per-world means)
   arm              welfare   solves      cost
@@ -16,6 +24,13 @@ profile=balanced  (per-world means)
   always-sonnet     0.5313    0.706    0.1745
   always-opus       0.2774    0.627    0.3501
   escalation vs always-sonnet: Δwelfare=+0.0123  Δcost=+0.0661  Δsolves=+0.078
+  95% CI (cluster bootstrap):
+    escalation     welfare +0.5437  [+0.2729, +0.7815]
+    always-haiku   welfare +0.3325  [+0.1328, +0.5351]
+    always-sonnet  welfare +0.5313  [+0.2959, +0.7432]  (best fixed)
+    always-opus    welfare +0.2774  [-0.0429, +0.5726]
+  escalation − best_fixed (always-sonnet) WELFARE: Δ=+0.0123  CI [-0.1036, +0.1761]  one-sided p(esc≤best)=0.466
+  escalation − best_solver (always-sonnet) SOLVE-RATE: Δ=+0.078  CI [+0.000, +0.216]  one-sided p(esc≤best)=0.119
 
 profile=quality-hawk  (per-world means)
   arm              welfare   solves      cost
@@ -24,4 +39,11 @@ profile=quality-hawk  (per-world means)
   always-sonnet     3.3549    0.706    0.1745
   always-opus       2.7872    0.627    0.3501
   escalation vs always-sonnet: Δwelfare=+0.2603  Δcost=+0.1319  Δsolves=+0.078
+  95% CI (cluster bootstrap):
+    escalation     welfare +3.6151  [+2.4627, +4.5723]
+    always-haiku   welfare +1.9795  [+1.0006, +2.9729]
+    always-sonnet  welfare +3.3549  [+2.1808, +4.2947]  (best fixed)
+    always-opus    welfare +2.7872  [+1.6695, +3.8622]
+  escalation − best_fixed (always-sonnet) WELFARE: Δ=+0.2603  CI [-0.2025, +0.9514]  one-sided p(esc≤best)=0.231
+  escalation − best_solver (always-sonnet) SOLVE-RATE: Δ=+0.078  CI [+0.000, +0.216]  one-sided p(esc≤best)=0.119
 

--- a/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
+++ b/apps/credence-pi/eval/results/ROUTING_DOMINANCE.md
@@ -1,12 +1,15 @@
-# Routing dominance: credence-pi routes better AND smarter than every system
+# Routing dominance: credence-pi is Wald-admissible across user profiles, and strictly dominant when the belief is well-resolved
 
 **Claim.** For model routing — pick which LLM answers each request — Bayesian
-EU-maximisation over a feature-conditioned belief *dominates every competing router*:
-on a cost-sensitive user it strictly beats all of them (every seed), and on a
-quality-maximising user it matches the provably-optimal rule. No fixed router can do
-this, because for k ≥ 2 models the per-user-profile optimum genuinely differs and a
-single table is the Bayes rule for at most one profile (Wald complete class). The
-richer the belief, the larger the win — and the belief gets richer *on its own*.
+EU-maximisation over a feature-conditioned belief is **undominated by every competing
+router** (Wald-admissible across user profiles), and **strictly dominates** them in the
+regime where the belief is well-resolved or the model gaps are real: on a cost-sensitive
+user it strictly beats all of them (every seed), and on a quality-maximising user it
+matches the provably-optimal rule. No fixed router can be admissible across profiles,
+because for k ≥ 2 models the per-user-profile optimum genuinely differs and a single
+table is the Bayes rule for at most one profile (Wald complete class). The richer the
+belief, the larger the win — and the belief gets richer *on its own*. (On reality at
+small scale the strict-dominance regime is data-bound — see "Real-model validation".)
 
 > **Two regimes, stated honestly up front.** The synthetic pillars below show the
 > mechanism's *ceiling* — strict dominance when the belief is well-resolved or model gaps
@@ -54,11 +57,13 @@ noisy data**, which is what this measures.
 | argmax-accuracy (cost-blind) | +3.224 | 100% |
 | best-fixed-table (profile-blind) | +3.224 | 100% |
 | threshold-router (RouteLLM 2-bin) | +2.018 | 100% |
-| **oracle-cascade (clairvoyant FrugalGPT)** | **+0.571** | **100%** |
+| **foresight cascade (FrugalGPT, knows each rung before paying)** | **+0.571** | **100%** |
 
-Rich even beats the *clairvoyant* cascade here — a cascade that knows each rung's
-correctness before paying still loses, because its cumulative rung cost is a penalty
-no cascade escapes on a cost-sensitive user.
+Rich beats even this *foresight* cascade on cost-hawk — but note this is **not** an upper
+bound: unlike a per-task oracle, the cascade still pays each rung's cost as it climbs, so
+beating it is expected, not a beaten ceiling (its cumulative rung cost is a penalty no
+cascade escapes on a cost-sensitive user). The genuine upper bound is the per-task oracle,
+which leads everywhere and is non-deployable (it needs each rung's correctness before paying).
 
 **Quality-max profile:** rich *matches* the accuracy-maximising Bayes rule
 (always-exp, best-fixed, argmax-accuracy, category-only all route the top model —

--- a/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
+++ b/apps/credence-pi/openclaw-plugin/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "credence-pi",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "credence-pi governance",
   "description": "Bayesian in-loop governance for the pi/OpenClaw agent — intercepts tool calls and halts/asks on low expected-value spend; logs outcomes and per-turn cost for the dollars-saved surface.",
   "activation": {

--- a/apps/credence-pi/openclaw-plugin/src/index.ts
+++ b/apps/credence-pi/openclaw-plugin/src/index.ts
@@ -288,13 +288,25 @@ export function createGovernor(
     });
 
     // Observe-only: the brain decided and the daemon logged it; the body does
-    // not enforce. This is what lets operators measure counterfactual
-    // governance on real usage without changing any run.
+    // not enforce. We also durably RECORD the counterfactual (a body-owned fact,
+    // like governance-latency above) so the dollars-saved surface can separate
+    // "would have blocked" (shadow) from "actually prevented" (enforce). Without
+    // it, the daemon's `decision` log is identical in both modes and /report
+    // would count shadow would-blocks as real prevention.
     if (shadowMode) {
       if (sig && (sig.effector === "block" || sig.effector === "ask")) {
         log(
           `credence-pi[shadow]: would ${sig.effector} \`${event.toolName}\` — proceeding (shadow mode)`,
         );
+        void client.postSensor({
+          event_type: "counterfactual-decision",
+          event_id: newEventId(),
+          in_response_to: eventId,
+          session_id: ctx.sessionId ?? ctx.sessionKey ?? "",
+          timestamp: new Date().toISOString(),
+          effector: sig.effector,
+          tool_name: event.toolName,
+        });
       }
       return undefined;
     }
@@ -544,6 +556,18 @@ const plugin: PluginEntry = {
             `blocked ${n("prevented_calls")} waste call(s) (~$${n("estimated_prevented_usd").toFixed(4)} saved, est.); ` +
             `asked ${n("decided_ask")}, you denied ${n("denied")}. Full report: GET ${daemonUrl}/report`,
         );
+        // Shadow mode: nothing was enforced, so report the counterfactual
+        // separately — what governance WOULD have blocked, and the false-block
+        // proxy split (write/edit=mutation vs not; bash ambiguous → counted as
+        // a candidate re-run). Only shown when there were would-blocks.
+        if (n("would_block_calls") > 0) {
+          log(
+            `credence-pi[shadow]: would have blocked ${n("would_block_calls")} call(s) ` +
+              `(~$${n("estimated_counterfactual_usd").toFixed(4)} would-be-saved, est.) — NOT enforced; ` +
+              `~${n("would_block_likely_waste")} look like waste, ` +
+              `${n("would_block_candidate_legitimate")} like legitimate re-runs (proxy)`,
+          );
+        }
       } catch {
         /* best-effort display; never throws on cleanup */
       }

--- a/apps/credence-pi/openclaw-plugin/tests/index.test.ts
+++ b/apps/credence-pi/openclaw-plugin/tests/index.test.ts
@@ -165,6 +165,44 @@ test("shadowMode: block signal → proceeds (undefined), but still sensed + late
   h.gov.cleanup();
 });
 
+test("shadowMode: block → posts counterfactual-decision (effector/tool/in_response_to) and proceeds", async () => {
+  const h = harness(true, true); // postOk, shadowMode
+  const p = h.gov.beforeToolCall(ev("bash"), ctx);
+  await flush();
+  const eid = h.lastProposedId();
+  h.signal("block", eid);
+  assert.equal(await p, undefined); // shadow never enforces
+  const cf = h.find("counterfactual-decision") as
+    | { effector: string; tool_name: string; in_response_to: string }
+    | undefined;
+  assert.ok(cf, "a block in shadow mode must record a counterfactual-decision");
+  assert.equal(cf?.effector, "block");
+  assert.equal(cf?.tool_name, "bash");
+  assert.equal(cf?.in_response_to, eid);
+  h.gov.cleanup();
+});
+
+test("shadowMode: ask → counterfactual-decision with effector=ask", async () => {
+  const h = harness(true, true);
+  const p = h.gov.beforeToolCall(ev("bash"), ctx);
+  await flush();
+  h.signal("ask", h.lastProposedId(), { text: "Allow?" });
+  assert.equal(await p, undefined);
+  const cf = h.find("counterfactual-decision") as { effector: string } | undefined;
+  assert.equal(cf?.effector, "ask");
+  h.gov.cleanup();
+});
+
+test("shadowMode: proceed → no counterfactual-decision (nothing would have been enforced)", async () => {
+  const h = harness(true, true);
+  const p = h.gov.beforeToolCall(ev("bash"), ctx);
+  await flush();
+  h.signal("proceed", h.lastProposedId());
+  assert.equal(await p, undefined);
+  assert.equal(h.find("counterfactual-decision"), undefined);
+  h.gov.cleanup();
+});
+
 test("after_tool_call: posts tool-completed correlated by toolCallId", async () => {
   const h = harness();
   await h.gov.afterToolCall({ toolName: "bash", toolCallId: "tc1", params: {}, durationMs: 12 }, ctx);

--- a/apps/credence-pi/savings.jl
+++ b/apps/credence-pi/savings.jl
@@ -18,15 +18,24 @@ Honesty notes baked into the report:
   - Cost is per-TURN, not per-tool-call (pi exposes no per-tool usage), so
     "prevented spend" is an ESTIMATE: denied-calls x average-turn-cost. It
     is labelled as such, never presented as a guaranteed figure.
-  - The log records inbound sensor events, not the brain's effector
-    signals, so the unambiguous governance signal is "asked -> user
-    responded yes/no". proceed/block without an ask are not distinguished
-    here (a Phase-2 enhancement would log decisions).
+  - "Prevented" counts only ENFORCED blocks. The daemon logs a `decision`
+    record per brain decision regardless of mode; in shadow mode the body
+    proceeds anyway and logs a `counterfactual-decision`. Every shadowed block
+    is therefore BOTH a decision(block) and a counterfactual(block), so we
+    subtract the latter (enforced = decided - would) — otherwise /report would
+    claim prevention that never happened in an observe-only deployment.
+  - "Would have blocked" (shadow) is reported separately, with a bounded
+    false-block PROXY: of the exact-repeat would-blocks, how many had an
+    intervening workspace mutation (a plausible legitimate re-run) vs none
+    (almost-certainly waste). write/edit = hard mutation; bash/exec = ambiguous
+    but counted (the safe direction — it over-counts "legitimate", so it never
+    under-reports false blocks). The gold rate still needs opt-in user labels.
 """
 module Savings
 
 include(joinpath(@__DIR__, "daemon", "observation_log.jl"))
 using .ObservationLog: read_log
+using JSON3   # canonical fingerprint for the exact-repeat / false-block proxy
 
 export savings_report, format_report
 
@@ -53,6 +62,8 @@ function savings_report(path::AbstractString)
 
     # governance correlation
     proposed_tool = Dict{String, String}()   # tool-proposed event_id -> tool name
+    tps = NamedTuple[]                         # tool-proposed records in log order (false-block proxy)
+    counterfactuals = Tuple{String, String}[] # shadow-mode (in_response_to, effector) — would-have-enforced
     responses = Dict{String, String}()        # in_response_to -> response
     decisions = Dict{String, Int}()           # brain decision action -> count
     n_completed = 0
@@ -83,6 +94,12 @@ function savings_report(path::AbstractString)
             pc = get(ev, "proposed_call", nothing)
             tool = pc === nothing ? "(unknown)" : string(get(pc, "tool_name", "(unknown)"))
             proposed_tool[eid] = tool
+            # Keep the input + session + order for the exact-repeat proxy below.
+            input = pc === nothing ? nothing : get(pc, "input", nothing)
+            push!(tps, (eid = eid, sid = sid === nothing ? "" : string(sid), tool = tool, input = input))
+        elseif et == "counterfactual-decision"
+            push!(counterfactuals,
+                  (string(get(ev, "in_response_to", "")), string(get(ev, "effector", ""))))
         elseif et == "user-responded"
             irt = string(get(ev, "in_response_to", ""))
             responses[irt] = string(get(ev, "response", ""))
@@ -110,11 +127,62 @@ function savings_report(path::AbstractString)
     n_block = get(decisions, "block", 0)
     n_proceed = get(decisions, "proceed", 0)
     n_ask = get(decisions, "ask", 0)
-    prevented_calls = n_block
+
+    # Shadow mode: the brain still emits a `decision`, but the body proceeds and
+    # logs a `counterfactual-decision`. Every shadowed block is BOTH a
+    # decision(block) and a counterfactual(block); enforced blocks are only the
+    # former. So enforced = decided - would, and "prevented" counts only enforced
+    # ones (else /report claims prevention that never happened in shadow mode).
+    would_block = count(c -> c[2] == "block", counterfactuals)
+    would_ask   = count(c -> c[2] == "ask", counterfactuals)
+    prevented_calls = max(0, n_block - would_block)
 
     # ESTIMATE only — see module docstring. Per-turn cost (pi exposes no
     # per-tool cost), so avoided spend ~ prevented calls x average turn cost.
     estimated_prevented_usd = prevented_calls * avg_usd_per_turn
+    # Same per-turn estimate on the shadow would-blocks: what governance WOULD
+    # have saved on this traffic if enforcing. Labelled counterfactual.
+    estimated_counterfactual_usd = would_block * avg_usd_per_turn
+
+    # False-block PROXY (display-only): of the shadow would-blocks on an
+    # exact-repeat call, how many are plausibly LEGITIMATE re-runs (the workspace
+    # changed in between) vs almost-certainly waste (nothing changed). The brain
+    # blocks on (tool, args) alone and cannot see a change; this bounded post-hoc
+    # check is the honest estimate of that false-block rate. Asymmetry is
+    # deliberate: write/edit are a HARD mutation signal; bash/exec are AMBIGUOUS
+    # but counted as possible mutations — over-counting `candidate_legitimate`,
+    # which errs toward NOT under-reporting false blocks (the safe direction).
+    # Limitation: with redactToolInputs the input is null, so identical-call
+    # matching degrades (null inputs in a session collapse together) — noted, not
+    # fatal. Read-only / unknown intervening tools are treated as non-mutating.
+    tp_by_eid = Dict{String, Int}(t.eid => i for (i, t) in enumerate(tps))
+    _fp(input) = input === nothing ? "∅" : JSON3.write(input)
+    _is_mut(tool) = lowercase(tool) in ("write", "edit", "bash", "exec")   # KNOWN_TOOLS minus read
+    wb_candidate = 0
+    wb_waste = 0
+    for (irt, eff) in counterfactuals
+        eff == "block" || continue
+        i = get(tp_by_eid, irt, 0)
+        if i == 0
+            wb_candidate += 1   # cannot locate the call ⇒ don't call it waste (safe direction)
+            continue
+        end
+        cur = tps[i]
+        jprior = 0                              # nearest prior identical (tool, args) in this session
+        for j in (i - 1):-1:1
+            t = tps[j]
+            (t.sid == cur.sid && lowercase(t.tool) == lowercase(cur.tool) &&
+                _fp(t.input) == _fp(cur.input)) || continue
+            jprior = j
+            break
+        end
+        if jprior == 0
+            wb_candidate += 1   # no prior identical ⇒ not an exact-repeat we can call pure waste
+            continue
+        end
+        mutated = any(j -> tps[j].sid == cur.sid && _is_mut(tps[j].tool), (jprior + 1):(i - 1))
+        mutated ? (wb_candidate += 1) : (wb_waste += 1)
+    end
 
     return (
         total_events = length(records),
@@ -132,6 +200,10 @@ function savings_report(path::AbstractString)
         decided_proceed = n_proceed,
         decided_ask = n_ask,
         prevented_calls = prevented_calls,
+        would_block_calls = would_block,
+        would_ask_calls = would_ask,
+        would_block_candidate_legitimate = wb_candidate,
+        would_block_likely_waste = wb_waste,
         asked = n_asked,
         approved = n_approved,
         denied = n_denied,
@@ -139,6 +211,7 @@ function savings_report(path::AbstractString)
         completed = n_completed,
         denied_tools = denied_tools,
         estimated_prevented_usd = estimated_prevented_usd,
+        estimated_counterfactual_usd = estimated_counterfactual_usd,
     )
 end
 
@@ -177,8 +250,16 @@ function format_report(io::IO, r)
         println(io, "  user-denied tools:   ", join(r.denied_tools, ", "))
     end
     println(io)
-    println(io, "Estimated prevented spend (blocked calls x avg turn cost):")
+    println(io, "Estimated prevented spend (enforced blocks x avg turn cost):")
     println(io, "  ~ $(_usd(r.estimated_prevented_usd))   [ESTIMATE — cost is per-turn, not per-tool; see savings.jl]")
+    if r.would_block_calls > 0 || r.would_ask_calls > 0
+        println(io)
+        println(io, "Shadow / counterfactual (observed only — NOT enforced):")
+        println(io, "  would-block:   $(r.would_block_calls)   (~$(_usd(r.estimated_counterfactual_usd)) would-be-saved [ESTIMATE])")
+        println(io, "  would-ask:     $(r.would_ask_calls)")
+        println(io, "  would-blocks split: likely-waste $(r.would_block_likely_waste), candidate legitimate re-run $(r.would_block_candidate_legitimate)")
+        println(io, "                      [PROXY — write/edit=mutation, bash/exec=ambiguous; gold rate needs user labels]")
+    end
     println(io, "=" ^ 60)
 end
 

--- a/apps/credence-pi/tests/julia/test_savings.jl
+++ b/apps/credence-pi/tests/julia/test_savings.jl
@@ -85,6 +85,67 @@ let path = tempname() * ".jsonl"  # never created
     isfile(path) && rm(path)
 end
 
+# Shadow-mode counterfactual + false-block proxy (Workstream B). All in session
+# s1, avg turn cost $0.20 (= ($0.10 + $0.30)/2):
+#   E0  : enforced block (decision block only, no counterfactual)
+#   P1a/P1b : exact-repeat (bash, cmd1), no intervening mutation → likely-waste
+#   P2a/W/P2b : exact-repeat (bash, cmd2) with an intervening `write` → candidate
+# So: decided_block 3, would_block 2, enforced/prevented 1, proxy split 1/1.
+let path = tempname() * ".jsonl"
+    A = Savings.ObservationLog.append_event!
+    A(path, Dict("event_type" => "turn-cost", "session_id" => "s1", "usd" => 0.10, "total_tokens" => 1000))
+    A(path, Dict("event_type" => "turn-cost", "session_id" => "s1", "usd" => 0.30, "total_tokens" => 3000))
+
+    # Enforced block — body actually blocked; no counterfactual record.
+    A(path, Dict("event_type" => "tool-proposed", "event_id" => "E0", "session_id" => "s1",
+                 "proposed_call" => Dict("tool_name" => "bash", "input" => Dict("command" => "e0"))))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "E0", "action" => "block"))
+
+    # Shadowed block, no intervening mutation between the identical pair → waste.
+    A(path, Dict("event_type" => "tool-proposed", "event_id" => "P1a", "session_id" => "s1",
+                 "proposed_call" => Dict("tool_name" => "bash", "input" => Dict("command" => "cmd1"))))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "P1a", "action" => "proceed"))
+    A(path, Dict("event_type" => "tool-proposed", "event_id" => "P1b", "session_id" => "s1",
+                 "proposed_call" => Dict("tool_name" => "bash", "input" => Dict("command" => "cmd1"))))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "P1b", "action" => "block"))
+    A(path, Dict("event_type" => "counterfactual-decision", "in_response_to" => "P1b", "effector" => "block"))
+
+    # Shadowed block with an intervening `write` between the identical pair → candidate legitimate.
+    A(path, Dict("event_type" => "tool-proposed", "event_id" => "P2a", "session_id" => "s1",
+                 "proposed_call" => Dict("tool_name" => "bash", "input" => Dict("command" => "cmd2"))))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "P2a", "action" => "proceed"))
+    A(path, Dict("event_type" => "tool-proposed", "event_id" => "W", "session_id" => "s1",
+                 "proposed_call" => Dict("tool_name" => "write", "input" => Dict("path" => "f", "content" => "x"))))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "W", "action" => "proceed"))
+    A(path, Dict("event_type" => "tool-proposed", "event_id" => "P2b", "session_id" => "s1",
+                 "proposed_call" => Dict("tool_name" => "bash", "input" => Dict("command" => "cmd2"))))
+    A(path, Dict("event_type" => "decision", "in_response_to" => "P2b", "action" => "block"))
+    A(path, Dict("event_type" => "counterfactual-decision", "in_response_to" => "P2b", "effector" => "block"))
+
+    r = savings_report(path)
+    @assert isapprox(r.avg_usd_per_turn, 0.20; atol = 1e-12)
+    @assert r.decided_block == 3                # E0 + P1b + P2b (brain decided block)
+    @assert r.would_block_calls == 2            # P1b + P2b were shadowed (counterfactual)
+    @assert r.would_ask_calls == 0
+    @assert r.prevented_calls == 1              # only E0 was actually enforced (3 - 2)
+    # Enforced estimate counts only the 1 real block; counterfactual the 2 shadowed.
+    @assert isapprox(r.estimated_prevented_usd, 0.20; atol = 1e-12)
+    @assert isapprox(r.estimated_counterfactual_usd, 0.40; atol = 1e-12)   # 2 * $0.20
+    # False-block proxy: P1b had no intervening mutation (waste); P2b had a `write` (candidate).
+    @assert r.would_block_likely_waste == 1
+    @assert r.would_block_candidate_legitimate == 1
+    ok("shadow counterfactual: prevented counts enforced-only, would-block + write/edit-vs-waste proxy split")
+
+    io = IOBuffer()
+    format_report(io, r)
+    s = String(take!(io))
+    @assert occursin("Shadow / counterfactual", s)
+    @assert occursin("PROXY", s)
+    ok("format_report renders the shadow/counterfactual block with the PROXY caveat")
+
+    rm(path)
+end
+
 println()
 println("=" ^ 60)
 println("ALL ", length(PASSED), " ASSERTIONS PASSED")


### PR DESCRIPTION
External review flagged that two credence-pi headline claims "don't survive contact with your own eval files," plus the missing causal number (false-block rate + would-save). Three Explore agents verified the claims against the repo; the two biggest overclaims turned out to **contradict credence-pi's own eval docs** (`EXPERIMENT.md`, `FINDINGS.md`), so this is largely an internal-consistency fix. Three workstreams, committed in order:

### C — cluster-bootstrap CIs on the live escalation A/B (`escalation_live.jl`)
Resamples the **17 tasks** (carrying all reps together — reps within a task are correlated; i.i.d. row resampling would be pseudo-replication that shrinks CIs), seeded, B=10000. Reports per-arm welfare CIs, the paired escalation−best_fixed welfare CI + one-sided p, and the solve-rate (capability-union) CI. K=17 percentile under-covers — flagged in-output.

**Material finding:** per-profile *welfare* margins are **under-powered at 17 tasks** — only the negligible cost-saver edge (+0.005, CI [+0.001, +0.010]) is significant; balanced (+0.012, CI [−0.10, +0.18]) and quality-first (+0.260, CI [−0.20, +0.95]) point-favour escalation but their CIs include 0. The lower-variance **solve-rate** (capability-union) signal is directionally robust (+0.078, CI [0.00, +0.22], never negative). This is sharper than the review expected and reframes the routing claim around cross-profile robustness, not per-profile dominance.

### B — shadow-mode counterfactual telemetry (fixes phantom prevention)
In shadow mode the daemon still logs a `decision(block)` but the body proceeds, so `savings.jl`'s `prevented_calls = n_block` **claimed prevention that never happened** on the observe-only adoption path. The body now records a `counterfactual-decision`; `savings.jl` nets `enforced = decided − would`, reports would-block + counterfactual USD, and a write/edit-aware **false-block proxy** (bash/exec ambiguous → counted as candidate-legitimate, the safe direction). New no-op daemon branch; session-summary shadow line.

### A — honesty pass + version bump (docs)
- "Blocking a re-run cannot, by construction, cost you anything" → rescoped to acknowledge `(tool,args)` blocking can stop a legitimate re-run after an edit (per `FINDINGS.md`); points to shadow mode.
- "Routing dominates every fixed router, per profile" → cross-profile robustness + capability-union with the live CIs; aligns README/MVP.md with `EXPERIMENT.md`'s own "NOT per-profile dominance."
- `ROUTING_DOMINANCE.md`: the clairvoyant correction (`tb_dominance_verification.md`) had **missed this file** — title/claim rescoped to Wald-admissibility, the foresight-cascade relabelled as not-an-upper-bound.
- Retire "no-brainer"/"Downside ≈ 0"; bump manifest `0.1.0 → 0.2.0` (matches published package).

### Verification
- Julia `test_savings.jl` 5/5 (exact invariants on enforced/would/proxy split), `test_server.jl` 23/23, `test_observation_log.jl` 7/7.
- TS `npm test` 55/55 (3 new shadow tests).
- credence-lint: 0 violations across 46 files.
- `escalation_live.jl` re-run reproducibly through a cold, isolated daemon.

### Out of scope
The external announcement post (`gfrm.in/posts/openclaw-cheaper-and-harder-to-fool`) repeats some of these claims; it's not in the repo, so it needs separate reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
