### PR TITLE
answer-brain: the menu becomes data — uniform VOI transform scheduler

### DIFF
--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -31,7 +31,8 @@ import Main.Credence.Ontology: optimise, value, net_voi
 
 export Obs, ChannelParams, CANONICAL_CHANNEL,
        candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather,
-       provisional_leader, gather_decide
+       provisional_leader, gather_decide,
+       Transform, ScheduleCtx, default_registry, schedule_decide
 
 # ── Stated channel parameters (the §4.2/§4.1 priors; calibration moves them) ────────────
 # Mirror of life-agent's `lookup.py` constants and `bdsl/utility.bdsl`. A `ChannelParams`
@@ -237,24 +238,117 @@ function _corroborate_kernel(k::Int, gather_rho::Float64, cp::ChannelParams)::Ke
            likelihood_family = PushOnly())  # credence-lint: allow — precedent:declarative-construction — corroborate probe, mirrors observation_densities
 end
 
+# ── The transformation registry: the menu becomes DATA (the VOI scheduler) ───────────────
+# The owner's directive: one rule — schedule whichever transformation maximises VOI−cost on this
+# data, cheap or expensive alike. `net_voi` is the principled mechanism; hardcoding the menu (the
+# old 3-branch cascade) was the unprincipled part. A `Transform` is one menu entry; `schedule`
+# prices the whole menu in one uniform loop. The honest boundary (three named kinds — uniformity
+# claimed only where it holds): a transform is VOI-schedulable iff its OUTPUT is modelled as a
+# likelihood (a kernel) over the belief's space.
+#   :voi   — VOI-priced refine. Output is a kernel over the fixed candidate set; `net_voi` integrates
+#            it against the posterior and gathers the argmax if it clears its cost. (corroborate)
+#   :guard — mandatory non-VOI refine. Defends an OUT-OF-MODEL risk the candidate belief cannot price
+#            (the belief has no atom for "misattributed to the owner"), so VOI over it is blind and
+#            the guard must fire unconditionally. (recency-on-era_split; the owner-scoped corroborate)
+# `:grow` (discovery/recall — enlarges K) cannot be priced by VOI over a closed categorical (Plan §1);
+# it is a non-VOI action the BODY triggers (a bridge capability + re-decide), never a registry probe.
+struct Transform
+    name::String        # registry id (unique within a registry)
+    probe::String       # emitted wire-probe name (the body's capability; the `applied_probes` dedup key)
+    kind::Symbol        # :voi | :guard
+    applies::Function   # (action::String, ctx::ScheduleCtx) -> Bool — eligibility on this decision
+    kernel_fn::Function # (k::Int, cp::ChannelParams) -> Kernel — the output-likelihood model (:voi only)
+    cost::Float64       # cost-in-utility, commensurate with `value` (:voi only; guards: 0.0)
+end
+
+# Request-level gates the registry's `applies` predicates read (the per-question context). Transform
+# kernels/costs are baked into the Transform itself (so model tiers each carry their own rho/cost —
+# Slice 2); `ctx` carries only what gates eligibility and the termination set.
+struct ScheduleCtx
+    era_split::Bool
+    owner_scoped::Bool
+    gather_rho::Float64
+    gather_cost::Float64
+    applied_probes::Vector{String}
+end
+
+_no_kernel(::Int, ::ChannelParams)::Kernel = error("a :guard transform has no VOI kernel")
+
 """
-    gather_decide(state, k, u_bar; era_split=false, applied_probes=String[], cp=CANONICAL_CHANNEL)
+    default_registry(; gather_rho=0.0, gather_cost=0.0) -> Vector{Transform}
+
+The v0 menu, reproducing the validated behaviour exactly:
+- `recency` (`:guard`): rule out staleness before any terminal report — a count-led stale leader can
+  sit ABOVE the EU bar, and reporting it without the recency re-weight is a confident-wrong
+  (`gather.py` applies recency pre-decision; the daemon ports that). Fires whenever `era_split` holds.
+- `corroborate_owner` (`:guard`): the owner-scoped ATTRIBUTION guard — an owner-scoped question about
+  to REPORT an in-set leader must first corroborate with a subject-aware re-read, because the cheap
+  per-chunk extractor is owner-CENTRIC (it reports the owner's OWN value for a relative's question).
+  The risk lives outside the candidate belief, so it is mandatory, not VOI-priced.
+- `corroborate_voi` (`:voi`, only when `gather_rho > 0`): the §2-A rescue — a WITHHOLDING leader may be
+  rescued by a `net_voi`-gated re-read, gathered only if re-reading is expected to move `value` by more
+  than its cost. Omitted when `gather_rho == 0` (no re-read budget) ⇒ the default is byte-identical.
+Both corroborate entries emit the same wire probe `"corroborate"`, so `applied_probes` disables both
+once either fires (the loop terminates).
+"""
+function default_registry(; gather_rho::Float64 = 0.0, gather_cost::Float64 = 0.0)::Vector{Transform}
+    reg = Transform[
+        Transform("recency", "recency", :guard,
+                  (action, ctx) -> ctx.era_split, _no_kernel, 0.0),
+        Transform("corroborate_owner", "corroborate", :guard,
+                  (action, ctx) -> ctx.owner_scoped && action == "report", _no_kernel, 0.0),
+    ]
+    if gather_rho > 0.0
+        push!(reg, Transform("corroborate_voi", "corroborate", :voi,
+                  (action, ctx) -> action != "report",
+                  (k, cp) -> _corroborate_kernel(k, gather_rho, cp), gather_cost))
+    end
+    reg
+end
+
+"""
+    schedule(state, k, u_bar, registry, ctx; cp=CANONICAL_CHANNEL)
         -> (effector, report_index, probe, target, eu)
 
-The Move-4 feature-policy (move-4-design §2C, §5 Q2). A **cheap, class-valid re-weighting probe**
-is applied BEFORE the terminal report, not gated behind it: whenever `era_split` holds (the
-candidates span eras — the stale-vs-current precondition) and `recency` is unapplied, emit
-`gather(recency, leader)` so the body re-weights by recency and re-decides. A confident report must
-first rule out the staleness `era_split` signals — a count-led STALE value can sit ABOVE the EU
-bar, and reporting it without the recency check is a confident-wrong (`gather.py` applies recency
-pre-decision for exactly this reason; the daemon ports that). `applied_probes` (body-held, resent)
-makes recency fire at most once, so the loop terminates; afterwards the terminal decision (report /
-hedge / ask / abstain) stands. v0's only class-valid probe is `recency` on `era_split` (the
-validated lever — `master-plan.md` §"probe library": stale leader 0.605 → ~0.09). The EXPENSIVE
-gather — `corroborate` (fetch new documents), EU-gated on a below-bar leader — plus `subject` and
-dispersion-gating are the declared-but-deferred refinements (§5 Q2 named successor; their thresholds
-are the §5 Q5 params). `report_index`/`probe`/`target` are `nothing` where inapplicable (a report
-carries no probe; a gather carries no report index).
+The uniform VOI scheduler. Decide terminally once, then over the registry: every eligible, unapplied
+**guard** fires first (mandatory, registry order — it defends a risk the belief can't price); then
+every eligible, unapplied **:voi** transform is priced by `net_voi` and the argmax is gathered iff it
+clears its cost. None fire ⇒ the terminal decision stands. `applied_probes` (keyed on the emitted
+`probe`, body-held and resent) makes each probe fire at most once ⇒ the loop terminates. Parity: an
+empty / fully-applied registry returns exactly `decide_full`'s terminal tuple.
+"""
+function schedule_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict,
+                  registry::Vector{Transform}, ctx::ScheduleCtx;
+                  cp::ChannelParams = CANONICAL_CHANNEL)
+    action, report_index, eu = decide_full(state, k, u_bar; cp = cp)
+    leader() = provisional_leader(state, k, u_bar; cp = cp)
+    # Guards first: mandatory, registry order. A guard prices an out-of-model risk VOI is blind to.
+    for t in registry
+        t.kind === :guard || continue
+        t.probe in ctx.applied_probes && continue
+        t.applies(action, ctx) && return ("gather", nothing, t.probe, leader(), eu)
+    end
+    # :voi transforms: price each eligible, unapplied one; gather the argmax if its net_voi > 0.
+    best = nothing; best_nv = 0.0
+    for t in registry
+        t.kind === :voi || continue
+        t.probe in ctx.applied_probes && continue
+        t.applies(action, ctx) || continue
+        nv = voi_gather(state, k, u_bar, t.kernel_fn(k, cp), collect(Float64, 0:(k - 1)), t.cost; cp = cp)
+        nv > best_nv && (best_nv = nv; best = t)
+    end
+    best === nothing && return (action, report_index, nothing, nothing, eu)
+    ("gather", nothing, best.probe, leader(), eu)
+end
+
+"""
+    gather_decide(state, k, u_bar; era_split=false, owner_scoped=false, gather_rho=0.0,
+                  gather_cost=0.0, applied_probes=String[], cp=CANONICAL_CHANNEL)
+        -> (effector, report_index, probe, target, eu)
+
+Thin wrapper: build the `default_registry` from the request flags and run `schedule`. Kept as the
+daemon's entry point so every existing caller/test is unchanged; the menu-as-data refactor lives in
+`schedule`. `report_index`/`probe`/`target` are `nothing` where inapplicable.
 """
 function gather_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
                        era_split::Bool = false,
@@ -263,38 +357,10 @@ function gather_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
                        gather_cost::Float64 = 0.0,
                        applied_probes::AbstractVector{<:AbstractString} = String[],
                        cp::ChannelParams = CANONICAL_CHANNEL)
-    action, report_index, eu = decide_full(state, k, u_bar; cp = cp)
-    if era_split && !("recency" in applied_probes)
-        # Rule out staleness before any terminal report (even a confident one): the recency
-        # re-weight is cheap and class-valid here, so it precedes the decision rather than being
-        # gated by it — a count-led stale leader above the bar must be recency-checked first.
-        return ("gather", nothing, "recency", provisional_leader(state, k, u_bar; cp = cp), eu)
-    end
-    # The owner-scoped ATTRIBUTION guard (§5 Q2, now realized): an owner-scoped question about to
-    # REPORT an in-set leader must first corroborate it with a subject-aware re-read. The cheap
-    # per-chunk extractor is owner-CENTRIC — it will report the owner's OWN value for a relative's
-    # question (the partner's-id / mother's-passport class: a confident wrong-subject report). The
-    # body enacts `gather(corroborate, leader)` by re-extracting with the whole-document,
-    # subject-aware model and re-posting that observation; if the high-reliability read disagrees,
-    # mass moves to NONE and the re-decide withholds (disagree⇒abstain falls out of `condition` +
-    # the NONE atom — no separate "disagreement" construct). Mandatory here; the net_voi pricing of
-    # WHEN to pay for the re-read is Slice 3. `applied_probes` makes it fire once ⇒ the loop ends.
-    if owner_scoped && action == "report" && !("corroborate" in applied_probes)
-        return ("gather", nothing, "corroborate", provisional_leader(state, k, u_bar; cp = cp), eu)
-    end
-    # §2-A (Slice 3) — a WITHHOLDING leader (abstain / hedge / ask) may be rescued by a
-    # net_voi-GATED expensive re-read: price `corroborate` against the terminal decision, and gather
-    # only if re-reading is expected to move `value` by more than its cost. `gather_rho == 0` (the
-    # body sent no re-read budget) ⇒ skip, so the daemon's default is unchanged (additive). This is
-    # the "buy the cloud only when it pays" — selective, not the §2-C mandatory attribution guard.
-    if action != "report" && gather_rho > 0.0 && !("corroborate" in applied_probes)
-        kern = _corroborate_kernel(k, gather_rho, cp)
-        if voi_gather(state, k, u_bar, kern, collect(Float64, 0:(k - 1)), gather_cost) > 0.0
-            return ("gather", nothing, "corroborate",
-                    provisional_leader(state, k, u_bar; cp = cp), eu)
-        end
-    end
-    (action, report_index, nothing, nothing, eu)
+    reg = default_registry(; gather_rho = gather_rho, gather_cost = gather_cost)
+    ctx = ScheduleCtx(era_split, owner_scoped, gather_rho, gather_cost,
+                      collect(String, applied_probes))
+    schedule_decide(state, k, u_bar, reg, ctx; cp = cp)
 end
 
 end # module AnswerBrain

--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -32,7 +32,7 @@ import Main.Credence.Ontology: optimise, value, net_voi
 export Obs, ChannelParams, CANONICAL_CHANNEL,
        candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather,
        provisional_leader, gather_decide,
-       Transform, ScheduleCtx, default_registry, schedule_decide
+       Transform, ScheduleCtx, default_registry, registry_from_wire, schedule_decide
 
 # ── Stated channel parameters (the §4.2/§4.1 priors; calibration moves them) ────────────
 # Mirror of life-agent's `lookup.py` constants and `bdsl/utility.bdsl`. A `ChannelParams`
@@ -304,6 +304,39 @@ function default_registry(; gather_rho::Float64 = 0.0, gather_cost::Float64 = 0.
                   (k, cp) -> _corroborate_kernel(k, gather_rho, cp), gather_cost))
     end
     reg
+end
+
+# The built-in eligibility predicates a wire trigger names. The MENU is data (which transforms, at
+# what rho/cost — the body declares them per question), but the `applies` predicates and the kernel
+# stay in the brain: the wire ships a `trigger` STRING, not a Julia closure.
+const _TRIGGERS = Dict{String, Function}(
+    "era_split"    => (action, ctx) -> ctx.era_split,                          # recency guard
+    "owner_report" => (action, ctx) -> ctx.owner_scoped && action == "report", # attribution guard
+    "below_bar"    => (action, ctx) -> action != "report",                     # the §2-A rescue gate
+)
+
+"""
+    registry_from_wire(descriptors; cp=CANONICAL_CHANNEL) -> Vector{Transform}
+
+Build a registry from the body's declared menu (Slice 2 — model-tier escalation). Each descriptor is
+`{name, probe, kind, trigger, rho, cost}`: `kind` ∈ {"voi","guard"}, `trigger` ∈ keys(`_TRIGGERS`),
+and a `:voi` entry's `kernel_fn` is the corroborate noisy-channel at its own `rho` (so a haiku /
+sonnet / opus tier each carry their own reliability + cost, and `schedule_decide` gathers the
+net_voi ARGMAX among them — the cost-efficient tier wins; sequential escalation emerges as the loop
+re-prices the remaining tiers after the chosen one is applied). The body enacts the chosen tier by
+its `probe` name.
+"""
+function registry_from_wire(descriptors; cp::ChannelParams = CANONICAL_CHANNEL)::Vector{Transform}
+    map(descriptors) do d
+        name    = String(d["name"])
+        probe   = String(get(d, "probe", name))
+        kind    = Symbol(d["kind"])
+        applies = _TRIGGERS[String(d["trigger"])]
+        rho     = Float64(get(d, "rho", 0.0))
+        cost    = Float64(get(d, "cost", 0.0))
+        kfn     = kind === :voi ? ((k, cpp) -> _corroborate_kernel(k, rho, cpp)) : _no_kernel
+        Transform(name, probe, kind, applies, kfn, cost)
+    end
 end
 
 """

--- a/apps/answer-brain/daemon/server.jl
+++ b/apps/answer-brain/daemon/server.jl
@@ -34,7 +34,8 @@ now be `gather`, with `probe`/`target` naming the forward steer (null on a termi
 """
 module Server
 
-using Main.AnswerBrain: Obs, ChannelParams, CANONICAL_CHANNEL, candidate_posterior, gather_decide
+using Main.AnswerBrain: Obs, ChannelParams, CANONICAL_CHANNEL, candidate_posterior, gather_decide,
+                        ScheduleCtx, registry_from_wire, schedule_decide
 using Main.Credence: weights
 using HTTP
 using JSON3
@@ -103,10 +104,19 @@ function decide_response(req::AbstractDict)::Dict{String, Any}
 
     post = candidate_posterior(k, obs, rho; cp = cp)
     w = weights(post)                                  # length k+1: candidates then NONE
+    # The menu is data: when the body declares a `transforms` list (Slice 2 — e.g. the corroborate
+    # model-tier ladder), build the registry from it and run the uniform scheduler; absent ⇒ the
+    # default registry built from the flags (byte-identical to the Stage-2a path).
     effector, report_index, probe, target, eu =
-        gather_decide(post, k, u_bar; era_split = era_split, owner_scoped = owner_scoped,
-                      gather_rho = gather_rho, gather_cost = gather_cost,
-                      applied_probes = applied, cp = cp)
+        if haskey(req, "transforms")
+            reg = registry_from_wire(req["transforms"]; cp = cp)
+            ctx = ScheduleCtx(era_split, owner_scoped, gather_rho, gather_cost, applied)
+            schedule_decide(post, k, u_bar, reg, ctx; cp = cp)
+        else
+            gather_decide(post, k, u_bar; era_split = era_split, owner_scoped = owner_scoped,
+                          gather_rho = gather_rho, gather_cost = gather_cost,
+                          applied_probes = applied, cp = cp)
+        end
 
     Dict{String, Any}(
         "effector"     => effector,                    # report | hedge | ask_clarify | abstain | gather

--- a/apps/answer-brain/tests/julia/test_answer_brain.jl
+++ b/apps/answer-brain/tests/julia/test_answer_brain.jl
@@ -171,6 +171,59 @@ let k = 2,
     check("§2-A: gather_rho=0 is the unchanged terminal decision", eff3 == a0; detail = "got $eff3")
 end
 
+# ── 2d. The transform REGISTRY + uniform `schedule` (the menu-as-data refactor) ──────────
+# `gather_decide` is now a thin wrapper over `schedule(state, k, u_bar, registry, ctx)`. These
+# pin the three properties the refactor must hold: parity with the wrapper, guards fire
+# unconditionally (not VOI-priced), and the :voi loop gathers the net_voi ARGMAX among rivals.
+let k = 2,
+    ubar = Dict("u_correct" => 1.0, "u_wrong" => -4.0, "u_hedged" => -0.5,
+                "u_abstain" => 0.0, "lambda_int" => 1.0),
+    obs = Obs[Obs(0, 0, 0.9, 1.0, 1.0), Obs(1, 1, 0.9, 1.0, 1.0)]   # dispersed ⇒ withholds
+
+    post = candidate_posterior(k, obs, 0.7)
+    # (a) parity: schedule over the default registry == the gather_decide wrapper, field-for-field.
+    direct = gather_decide(post, k, ubar; gather_rho = 0.9, gather_cost = 0.0)
+    reg    = default_registry(; gather_rho = 0.9, gather_cost = 0.0)
+    ctx    = ScheduleCtx(false, false, 0.9, 0.0, String[])
+    viareg = schedule_decide(post, k, ubar, reg, ctx)
+    check("schedule: default_registry reproduces gather_decide exactly (parity)",
+          viareg == direct; detail = "got $viareg want $direct")
+
+    # (c) argmax over two rival :voi transforms: a near-useless re-read (ρ≈0 ⇒ net_voi≤0) and a
+    # strong one (ρ=0.9 ⇒ net_voi>0). The scheduler must gather the STRONG one, by name.
+    rivals = Transform[
+        Transform("corrob_weak", "corrob_weak", :voi, (a, c) -> a != "report",
+                  (kk, cp) -> AnswerBrain._corroborate_kernel(kk, 0.01, cp), 0.0),
+        Transform("corrob_strong", "corrob_strong", :voi, (a, c) -> a != "report",
+                  (kk, cp) -> AnswerBrain._corroborate_kernel(kk, 0.9, cp), 0.0),
+    ]
+    eff, _, probe, _, _ = schedule_decide(post, k, ubar, rivals, ctx)
+    check("schedule: gathers the net_voi ARGMAX among rival :voi transforms",
+          eff == "gather" && probe == "corrob_strong"; detail = "got $eff/$probe")
+    # the weak rival ALONE does not clear its (zero) cost ⇒ no gather, terminal stands.
+    effw, _, _, _, _ = schedule_decide(post, k, ubar, rivals[1:1], ctx)
+    check("schedule: a useless :voi transform (ρ≈0) does not gather",
+          effw != "gather"; detail = "got $effw")
+end
+
+# (b) a :guard fires UNCONDITIONALLY (no VOI pricing): an owner-scoped in-set report must
+# corroborate even though the guard carries no kernel and is never net_voi-priced.
+let k = 1,
+    ubar = Dict("u_correct" => 1.0, "u_wrong" => -2.0, "u_hedged" => -0.5,
+                "u_abstain" => 0.0, "lambda_int" => 1.0),
+    obs = Obs[Obs(0, 0, 0.95, 1.0, 1.0), Obs(0, 1, 0.95, 1.0, 1.0)]   # sharp single-candidate ⇒ reports
+
+    post = candidate_posterior(k, obs, 0.9)
+    base, _, _, _, _ = schedule_decide(post, k, ubar, default_registry(),
+                                ScheduleCtx(false, false, 0.0, 0.0, String[]))
+    check("schedule: a confident in-set leader reports when no guard applies", base == "report";
+          detail = "got $base")
+    eff, _, probe, _, _ = schedule_decide(post, k, ubar, default_registry(),
+                                   ScheduleCtx(false, true, 0.0, 0.0, String[]))   # owner_scoped
+    check("schedule: the owner-scoped :guard fires unconditionally before the report",
+          eff == "gather" && probe == "corroborate"; detail = "got $eff/$probe")
+end
+
 # ── 3. Observation-log replay reconstructs the posterior exactly ────────────────────────
 let case = first(data.cases),
     k = Int(case.k), rho = Float64(case.rho)

--- a/apps/answer-brain/tests/julia/test_answer_brain.jl
+++ b/apps/answer-brain/tests/julia/test_answer_brain.jl
@@ -224,6 +224,41 @@ let k = 1,
           eff == "gather" && probe == "corroborate"; detail = "got $eff/$probe")
 end
 
+# ── 2e. registry_from_wire: the data-driven menu (Slice 2 — model-tier escalation) ───────
+# The body declares a corroborate tier ladder over the wire; `schedule_decide` gathers the net_voi
+# ARGMAX tier (the cost-efficient one), enacted by its probe name. Cost-monotone tiers ⇒ the cheap
+# tier wins when the dear tier's marginal VOI doesn't justify its marginal cost.
+let k = 2,
+    ubar = Dict("u_correct" => 1.0, "u_wrong" => -4.0, "u_hedged" => -0.5,
+                "u_abstain" => 0.0, "lambda_int" => 1.0),
+    obs = Obs[Obs(0, 0, 0.9, 1.0, 1.0), Obs(1, 1, 0.9, 1.0, 1.0)]   # dispersed ⇒ withholds
+
+    post = candidate_posterior(k, obs, 0.7)
+    ctx  = ScheduleCtx(false, false, 0.0, 0.0, String[])
+    ladder = Any[
+        Dict("name" => "corroborate_haiku", "probe" => "corroborate_haiku", "kind" => "voi",
+             "trigger" => "below_bar", "rho" => 0.80, "cost" => 0.0),
+        Dict("name" => "corroborate_opus", "probe" => "corroborate_opus", "kind" => "voi",
+             "trigger" => "below_bar", "rho" => 0.95, "cost" => 0.0),
+    ]
+    reg = registry_from_wire(ladder)
+    check("registry_from_wire: one Transform per descriptor", length(reg) == 2;
+          detail = "got $(length(reg))")
+    eff, _, probe, _, _ = schedule_decide(post, k, ubar, reg, ctx)
+    check("escalation: free tiers ⇒ gather the highest-rho (argmax net_voi) tier",
+          eff == "gather" && probe == "corroborate_opus"; detail = "got $probe")
+    # price the opus tier above its marginal VOI ⇒ the cheaper haiku tier wins (cost-efficient argmax)
+    l2 = deepcopy(ladder); l2[2]["cost"] = 100.0
+    _, _, probe2, _, _ = schedule_decide(post, k, ubar, registry_from_wire(l2), ctx)
+    check("escalation: a tier priced above its VOI yields to the cheaper effective tier",
+          probe2 == "corroborate_haiku"; detail = "got $probe2")
+    # both tiers priced out ⇒ no gather, the terminal withholds (cost-gated, uniformly)
+    l3 = deepcopy(ladder); l3[1]["cost"] = 100.0; l3[2]["cost"] = 100.0
+    eff3, _, _, _, _ = schedule_decide(post, k, ubar, registry_from_wire(l3), ctx)
+    check("escalation: all tiers priced out ⇒ terminal withholds", eff3 != "gather";
+          detail = "got $eff3")
+end
+
 # ── 3. Observation-log replay reconstructs the posterior exactly ────────────────────────
 let case = first(data.cases),
     k = Int(case.k), rho = Float64(case.rho)

--- a/apps/answer-brain/tests/julia/test_server.jl
+++ b/apps/answer-brain/tests/julia/test_server.jl
@@ -213,6 +213,21 @@ let r = Server.decide_response(gather_request(; era_split = false, gather_rho = 
           r["effector"] != "gather"; detail = "got $(r["effector"])")
 end
 
+# Slice 2 — the data-driven `transforms` menu over the wire: a below-bar leader with a corroborate
+# tier LADDER gathers the net_voi-argmax tier, named by its probe (the body enacts that model).
+let req = gather_request(; era_split = false)
+    req["transforms"] = Any[
+        Dict{String, Any}("name" => "corroborate_haiku", "probe" => "corroborate_haiku",
+                          "kind" => "voi", "trigger" => "below_bar", "rho" => 0.80, "cost" => 0.0),
+        Dict{String, Any}("name" => "corroborate_opus", "probe" => "corroborate_opus",
+                          "kind" => "voi", "trigger" => "below_bar", "rho" => 0.95, "cost" => 0.0),
+    ]
+    r = Server.decide_response(req)
+    check("wire Slice-2: a tier ladder ⇒ gather the argmax tier by probe name",
+          r["effector"] == "gather" && r["probe"] == "corroborate_opus";
+          detail = "got effector=$(r["effector"]) probe=$(get(r, "probe", "∅"))")
+end
+
 println("\n", "="^64)
 println("answer-brain Stage-2a: $(length(PASSED)) checks PASSED · $(length(data.cases)) wire-parity cases")
 println("="^64)


### PR DESCRIPTION
Straggling branch swept up during a branch review. Two commits, no prior PR; rebased cleanly onto current master (master's intervening commits are all decouple work — none touch `apps/answer-brain`).

## What this does

Refactors answer-brain's `gather_decide` from a hardcoded 3-branch probe cascade into a uniform VOI scheduler, then makes the menu data-driven over the wire.

- **`schedule_decide(state, k, u_bar, registry, ctx)`** — one uniform loop over a `Vector{Transform}` registry. `:guard` transforms fire unconditionally (they price an out-of-model risk VOI is blind to); `:voi` transforms are priced by `net_voi` and the argmax is gathered iff it clears its cost. None fire ⇒ the terminal decision stands.
- **`registry_from_wire(descriptors)`** — the body declares a corroborate model-tier ladder (`{name, probe, kind, trigger, rho, cost}`); the scheduler gathers the cost-efficient (argmax `net_voi`) tier, so sequential model-tier escalation emerges from re-pricing the remaining tiers (Slice 2).
- **`gather_decide` kept as a thin wrapper** over `schedule_decide` built from the request flags → parity preserved field-for-field (pinned by test). `server.jl` uses the wire registry only when `req["transforms"]` is present; absent ⇒ byte-identical to the prior path.

## de Finettian discipline

Stays on the canalised path (`net_voi` / `voi_gather` / `decide_full`); `Transform` is a declarative struct (no opaque routing); the corroborate kernel keeps its existing `declarative-construction` lint pragma. No new learning or decision mechanism — `net_voi`-max selects, as before.

## Verification

- `julia --project=. apps/answer-brain/tests/julia/test_answer_brain.jl` — green (parity, guard-unconditional, voi-argmax, escalation tiers, all-priced-out)
- `julia --project=. apps/answer-brain/tests/julia/test_server.jl` — green
- 133 PASSED across both, zero failures
- `credence-lint check apps/` — clean (226 files, 0 violations)

(Answer-brain Julia tests are not CI-gated, so the above were run locally before opening this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)