### PR TITLE
chore: gitignore Python build/ artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ credence-llm-state.json
 __pycache__/
 *.egg-info/
 /dist/
+build/
 
 # Eval data artefacts (outputs, not inputs)
 /data/


### PR DESCRIPTION
Adds `build/` to `.gitignore` (Python section) and removes the stray `apps/skin/clients/python/build/` directory — a setuptools/wheel staging artifact (a regenerable copy of `credence_skin_client`'s source), left behind when the client was extracted/smoke-tested during decouple Move 0/2.

Bare `build/` is safe: no tracked `build/` directories exist anywhere in the repo (`git ls-files | grep build/` is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)