### PR TITLE
chore: restore issue #39 audit linkage on the 6 live mixture-EU pragmas

### DIFF
--- a/apps/julia/email_agent/host.jl
+++ b/apps/julia/email_agent/host.jl
@@ -138,7 +138,7 @@ function build_predictive(
         r_j = rec_cache[j]
         for a in action_space
             p = a == r_j ? θ_mean : (1.0 - θ_mean) / max(n_actions - 1, 1)
-            action_probs[a] += w[j] * p  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch; no stdlib Functional covers this pattern
+            action_probs[a] += w[j] * p  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch; no stdlib Functional covers this pattern — tracked in issue #39
         end
     end
 

--- a/apps/julia/grid_world/host.jl
+++ b/apps/julia/grid_world/host.jl
@@ -114,7 +114,7 @@ function compute_eu_interact(
         mean_j = mean(comp.beta)
         # If program recommends :enemy and is correct (mean_j), entity is enemy
         # If program recommends :food and is correct (mean_j), entity is food → P(enemy) = 1-mean_j
-        p_enemy += w[j] * (rec == :enemy ? mean_j : 1.0 - mean_j)  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch
+        p_enemy += w[j] * (rec == :enemy ? mean_j : 1.0 - mean_j)  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch — tracked in issue #39
     end
     energy_enemy = -5.0
     energy_food = 5.0
@@ -394,7 +394,7 @@ function run_agent(;
                     ck = state.compiled_kernels[j]
                     rec = ck.evaluate(features, temporal_state)
                     mean_j = mean(comp.beta)
-                    p_enemy_val += w[j] * (rec == :enemy ? mean_j : 1.0 - mean_j)  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch
+                    p_enemy_val += w[j] * (rec == :enemy ? mean_j : 1.0 - mean_j)  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch — tracked in issue #39
                 end
                 p_obs = is_enemy ? p_enemy_val : (1.0 - p_enemy_val)
                 surprise = -log(max(p_obs, 1e-300))

--- a/apps/julia/rss/host.jl
+++ b/apps/julia/rss/host.jl
@@ -280,7 +280,7 @@ function rank_articles(
             tbm = comp::TaggedBetaPrevision
             fires = state.compiled_kernels[j].evaluate(features, temporal_state) == :match
             p = mean(tbm.beta)
-            score += w[j] * (fires ? p : 0.5)  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch
+            score += w[j] * (fires ? p : 0.5)  # credence-lint: allow — precedent:posterior-iteration — mixture EU requires per-component compiled-kernel dispatch — tracked in issue #39
         end
         scores[entry_id] = score
     end

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -1208,10 +1208,10 @@ function handle_eu_interact(params)
         # p(rec is correct) = mean_j, p(rec is wrong) = 1 - mean_j
         for (label, _) in rewards
             p_label = if rec == label
-                w[j] * mean_j  # credence-lint: allow — precedent:posterior-iteration — per-component compiled-kernel dispatch; reducible via per-component-dispatch Functional (post-Posture-4)
+                w[j] * mean_j  # credence-lint: allow — precedent:posterior-iteration — per-component compiled-kernel dispatch; reducible via per-component-dispatch Functional (post-Posture-4) — tracked in issue #39
             else
                 # If there are only 2 labels, the other gets 1-mean_j
-                w[j] * (1.0 - mean_j) / max(length(rewards) - 1, 1)  # credence-lint: allow — precedent:posterior-iteration — per-component compiled-kernel dispatch; reducible via per-component-dispatch Functional (post-Posture-4)
+                w[j] * (1.0 - mean_j) / max(length(rewards) - 1, 1)  # credence-lint: allow — precedent:posterior-iteration — per-component compiled-kernel dispatch; reducible via per-component-dispatch Functional (post-Posture-4) — tracked in issue #39
             end
             label_probs[label] = get(label_probs, label, 0.0) + p_label
         end


### PR DESCRIPTION
Re-link the 6 outstanding `posterior-iteration` mixture-EU aggregation pragmas to **#39**, which is rescoped (this PR's companion edit) to its one remaining deliverable: a per-component-dispatch `Functional` that collapses these sites to `expect(...)`.

The `tracked in issue #39` suffix was dropped from these pragmas when they were reworded during Posture-4 Moves 5/7, leaving #39 orphaned from its sites — `grep -rn 'posterior-iteration.*tracked in issue' apps/` returned empty. This restores the audit surface so each pragma names its tracking issue per the `posterior-iteration` last-resort-escape clause.

### Sites re-linked
- `apps/skin/server.jl` ×2 (label-probability mixture)
- `apps/julia/grid_world/host.jl` ×2 (`p_enemy` mixture EU)
- `apps/julia/email_agent/host.jl` ×1 (`action_probs` mixture EU)
- `apps/julia/rss/host.jl` ×1 (`score` mixture EU; `rss/` is reference-only — falls out if the dir is retired)

### Verification
- `grep -rn 'posterior-iteration.*tracked in issue #39' apps/` → exactly 6
- `credence-lint check apps/` → clean (226 files, 0 violations)
- Comment-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)