### PR TITLE
Exact linear-Gaussian conjugate (decouple Move-2 family extension)

### DIFF
--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -20,6 +20,7 @@ using Credence: weights, mean, variance, prune, truncate, logsumexp
 using Credence: CategoricalMeasure, ProductMeasure, MixtureMeasure
 using Credence: Prevision, Measure, params
 using Credence: BetaPrevision, TaggedBetaPrevision, GaussianPrevision
+using Credence: MvGaussianPrevision, MvGaussianMeasure, LinearGaussian, GaussianMeasure
 using Credence: GammaPrevision, DirichletPrevision, NormalGammaPrevision
 using Credence: ProductPrevision, MixturePrevision, CategoricalPrevision
 using Credence: Finite, Interval, ProductSpace, Euclidean, PositiveReals, Simplex
@@ -159,6 +160,10 @@ end
 # State construction from spec
 # ═══════════════════════════════════════
 
+# Rebuild a dense covariance Matrix from the wire's vector-of-rows (the shape
+# `params(::MvGaussianPrevision)` emits — a bare matrix flattens on JSON).
+_cov_from_rows(rows) = mapreduce(r -> permutedims(collect(Float64, r)), vcat, rows)
+
 function build_prevision(spec)
     t = spec["type"]
     if t == "categorical"
@@ -175,6 +180,8 @@ function build_prevision(spec)
                             BetaPrevision(Float64(spec["alpha"]), Float64(spec["beta"])))
     elseif t == "gaussian"
         GaussianPrevision(Float64(spec["mu"]), Float64(spec["sigma"]))
+    elseif t == "mv_gaussian"
+        MvGaussianPrevision(collect(Float64, spec["mu"]), _cov_from_rows(spec["sigma"]))
     elseif t == "gamma"
         GammaPrevision(Float64(spec["alpha"]), Float64(spec["beta"]))
     elseif t == "dirichlet"
@@ -210,6 +217,10 @@ function build_measure(spec)
                           BetaMeasure(Float64(spec["alpha"]), Float64(spec["beta"])))
     elseif t == "gaussian"
         GaussianMeasure(Euclidean(1), Float64(spec["mu"]), Float64(spec["sigma"]))
+    elseif t == "mv_gaussian"
+        mu = collect(Float64, spec["mu"])
+        MvGaussianMeasure(Euclidean(length(mu)),
+                          MvGaussianPrevision(mu, _cov_from_rows(spec["sigma"])))
     elseif t == "gamma"
         GammaMeasure(Float64(spec["alpha"]), Float64(spec["beta"]))
     elseif t == "dirichlet"
@@ -255,6 +266,18 @@ function build_kernel(spec, state_id::Union{String, Nothing}=nothing)
             (μ, o) -> -0.5 * (o - μ)^2 / variance;
             params = Dict{Symbol, Any}(:sigma_obs => sqrt(variance)),
             likelihood_family = PushOnly())
+
+    elseif t == "linear_gaussian"
+        # y ~ N(aᵀw, σ²): joint linear-Gaussian observation of a multivariate
+        # Gaussian state. The conjugate update (exact Kalman) is keyed off the
+        # LinearGaussian family; log_density is the predictive at a concrete w.
+        coeffs = collect(Float64, spec["coeffs"])
+        variance = Float64(spec["variance"])
+        d = length(coeffs)
+        Kernel(Euclidean(d), Euclidean(1),
+            w -> error("generate not used"),
+            (w, o) -> -0.5 * (o - sum(coeffs[i] * w[i] for i in 1:d))^2 / variance;
+            likelihood_family = LinearGaussian(coeffs, sqrt(variance)))
 
     elseif t == "quality"
         # (θ, k) → Beta(θk, (1-θ)k) continuous quality observation

--- a/docs/linear-gaussian-conjugate.md
+++ b/docs/linear-gaussian-conjugate.md
@@ -1,0 +1,179 @@
+# Design doc — the linear-Gaussian (Bayesian-linear-regression) conjugate
+
+> Engine response to `docs/rssfeed-linear-gaussian-conjugate-request.md`. Adds one
+> domain-agnostic conjugate pair so a *joint* linear-Gaussian update happens inside
+> `condition`, in closed form. No RSS vocabulary in the engine.
+>
+> **Positioning: this is a decouple Move-2 family extension.** Move 2 (rssfeed MAUT
+> ranker enablement; `docs/decouple/move-2-design.md`) established the `FAMILY_REGISTRY`
+> reflected by the BDSL `:family` surface (`:normal/:soft/:weighted`) and the thin-brain
+> consumption pattern (ship BDSL as `dsl_sources`, drive via `call_dsl`, beliefs cross
+> back as `{type, params}` specs — the `read_params` verb was deliberately deferred there
+> in favour of that round-trip). `linear-gaussian` is the *joint* generalisation of
+> Move 2's per-weight `:family normal`: it conditions all active weights together, fixing
+> the independent-update double-counting `maut_demo.bdsl` currently has.
+
+## Why
+
+A consumer (rssfeed) ranks with a parametric linear model: an article's score is
+`aᵀw` over feature weights `w`, each a Gaussian belief; one engagement is one noisy
+measurement of the sum, `y ~ N(aᵀw, σ²)`. The engine's only Gaussian conjugate is
+scalar `(GaussianPrevision, NormalNormal)` — a direct measurement of a *single*
+weight. Updating each active weight independently on the same scalar double-counts
+co-occurring features and cannot explain away. The correct model is Bayesian linear
+regression with a **joint** conjugate update (the Kalman measurement update).
+
+Today the consumer hand-rolls that update with `+ - * /` on raw means/variances in
+its BDSL model, because BDSL can't read a belief's variance. That arithmetic, living
+outside `src/` and feeding decisions, is an Invariant-1 violation. Granting the
+conjugate moves it back inside `condition`, where it belongs.
+
+## The decision: exact, not diagonal mean-field
+
+The request asks for a *diagonal* (mean-field / assumed-density) update that discards
+the off-diagonal covariance the joint update induces. **We implement the exact
+full-covariance update instead.** The ontology is always exact — exactness is not a
+knob to weigh. Reasons:
+
+1. **The off-diagonal covariance is the explaining-away signal.** The exact posterior
+   `Σ' = Σ − (Σa)(Σa)ᵀ/s` induces anti-correlation between co-firing weights — the
+   memory of "these competed to explain the evidence." Discarding it re-creates a
+   cross-observation version of the very double-counting the request is fixing —
+   worst in the consumer's stated worst case (a feed and its sole author always
+   co-occur).
+2. **Exact is cheap.** Closed form, O(d³) with d ≈ 5–8 active features. No performance
+   problem exists, so the constitution's "don't substitute an approximation for cheap
+   exact inference" applies with no escape hatch.
+3. **`condition` stays exact.** A diagonal update would bake mean-field into an
+   axiom-constrained function. If the consumer chooses to persist only per-feature
+   marginals, that lossy projection is *its* explicit choice in *its* storage layer —
+   the constitutionally correct home for an approximation.
+4. **Zero cost to the consumer today.** The diagonal `vᵢ' = vᵢ − (aᵢvᵢ)²/s` is exactly
+   `diag(Σ')`; after a single update the per-feature `{mu, sigma}` marginals are
+   identical either way. The consumer reads the same numbers; the engine additionally
+   retains `Σ'` off-diagonal for any future batched/correlated use.
+
+## Surface
+
+New multivariate Gaussian **Prevision** (a product of independent scalars cannot hold a
+dense `Σ'`, so a genuine type is required — `prevision-not-measure`):
+
+```julia
+struct MvGaussianPrevision <: Prevision   # src/prevision.jl, module Previsions
+    mu::Vector{Float64}
+    Sigma::Matrix{Float64}                 # dense covariance
+end
+```
+
+New leaf likelihood family (carries the per-observation coefficient vector + noise):
+
+```julia
+struct LinearGaussian <: LeafFamily        # src/kernels.jl
+    coeffs::Vector{Float64}                 # a  (the article's feature values)
+    sigma_obs::Float64                      # σ
+end
+```
+
+Conjugate pair `(MvGaussianPrevision, LinearGaussian) → MvGaussianPrevision` —
+**conditioning a genuine multivariate belief, returning a genuine multivariate
+posterior.** This sidesteps the awkward "joint likelihood over a `ProductMeasure`"
+path: `ProductMeasure` conditioning stays per-factor-independent as it is; the consumer
+builds an `MvGaussianPrevision` (diagonal on step 1) from its stored marginals.
+
+Exact update (`src/conjugate.jl`):
+
+```
+Σa = Σ·a ;  ŷ = aᵀm ;  s = σ² + aᵀΣa ;  k = Σa/s
+m' = m + k·(y − ŷ) ;  Σ' = Σ − (Σa)(Σa)ᵀ/s
+```
+
+Read surface: `mean(p) = mu`, `variance(p) = diag(Σ)`, `marginal(p, i) =
+GaussianPrevision(mu[i], √Σ[i,i])` (the exact per-feature marginal the consumer
+persists), `draw(p)` via Cholesky, `expect(p, Identity) = mu`.
+
+Wire (`apps/skin/server.jl`), mirroring `gaussian_known_var`:
+
+```json
+{ "type": "mv_gaussian", "mu": [...], "sigma": [[...],[...]] }   // prevision spec (Σ as rows)
+{ "type": "linear_gaussian", "coeffs": [...], "variance": 1.0 }  // kernel spec
+```
+
+`params(p::MvGaussianPrevision) = (type=:mv_gaussian, mu=copy(mu), sigma=rows(Σ))` —
+`Σ` emitted as a vector-of-rows so it round-trips through JSON (a bare Julia matrix
+flattens column-major on the wire, losing shape).
+
+**BDSL `:family` surface (the thin-brain authoring path).** `linear-gaussian`
+self-registers in `FAMILY_REGISTRY` like every Move-2 family, so the consumer's pure
+BDSL declares the kernel as data and the engine supplies the math:
+
+```lisp
+(define observe
+  (lambda (weights xs y sigma)              ; weights: a joint MvGaussian belief
+    (condition weights                       ; xs: the article's feature values (= a)
+      (kernel (space :euclidean d) (space :euclidean 1)
+              (lambda (w) (lambda (o) o))    ; placeholder generator; conjugate drives condition
+              :family linear-gaussian xs sigma)
+      y)))
+```
+
+The one generalisation Move 2 didn't need: `linear-gaussian`'s coefficients are a
+**runtime vector** (`xs`, per article), whereas every prior family took 0–1 literal
+scalars. So `_build_family` (`src/eval.jl`) now **evaluates** each `:family` argument in
+the environment (a literal `0.5` evaluates to itself — backward-compatible) instead of
+reading literal numbers. Read-back is the Move-2 `call_dsl` belief-spec round-trip:
+`observe` returns the conditioned `MvGaussianMeasure`, which `serialize_value → params`
+emits as `{type:mv_gaussian, mu, sigma}`; the consumer marginalises client-side. No new
+wire method (the deferred `read_params` verb stays deferred — rssfeed is a stateless
+thin body that persists its own marginals).
+
+The JSON skin kernel spec `{"type":"linear_gaussian", …}` is *also* wired (for the
+stateful `create_state`+`condition` wire pattern), but the thin-body path above is the
+decouple-preferred one.
+
+## Out of scope (v1)
+
+- **Unknown σ² (Normal-Gamma regression).** Known σ² only.
+- **Batched design matrix.** One `(a, y)` per call; observations folded one at a time.
+- **Full `MvNormal` `expect` over arbitrary functionals.** `Identity` + marginals cover
+  the consumer's need; richer functional dispatch (e.g. the linear score `aᵀw` as a
+  `LinearCombination`) can accrete when a caller needs it.
+
+## Resolved decisions
+
+- **Read-back over the wire — RESOLVED: the Move-2 `call_dsl` belief-spec round-trip.**
+  Earlier draft framed this as open; it is settled by `docs/decouple/move-2-design.md`.
+  The consumer's `observe` returns the conditioned belief and `serialize_value → params`
+  emits a readable `{type:mv_gaussian, mu, sigma}` spec (the scalar `mean` wire method and
+  the opaque `snapshot` blob are *not* the consumer's path). No new wire method — the
+  deferred `read_params` verb stays deferred.
+- **BDSL authoring surface — RESOLVED: `:family linear-gaussian` (extend `:family` to
+  evaluate args).** Chosen over a new `(linear-gaussian …)` builtin because the
+  frozen-type-constructor rule keeps the kernel surface to `(kernel … :family …)`, and
+  over a wire read method because that would add a second consumption surface against the
+  one-surface decouple commitment. The `:family`-arg evaluation generalisation is the
+  minimal change that admits the runtime coeffs vector.
+
+## Open design questions
+
+- **Should `marginal(p, indices)` return a `ProductMeasure` of the selected marginals**
+  (dropping cross-covariance, an explicit consumer-side projection) rather than only the
+  per-index `GaussianPrevision`? Deferred until a caller needs the multi-index form; the
+  per-index accessor is exact and sufficient for the persist-marginals use.
+- **Should the skin accept a diagonal convenience spec** (`"sigma": [v1, v2, ...]` as a
+  diagonal) so the consumer need not send a full matrix on step 1? Minor ergonomics;
+  left out of v1 (the consumer sends a diagonal matrix).
+
+## Verification
+
+- `test/test_linear_gaussian_conjugate.jl` — the conjugate at the prevision level: the
+  confident-vs-diffuse explaining-away check, exact posterior `mu`/`Σ` against an
+  independent Kalman oracle at rtol 1e-12, the off-diagonal-is-nonzero exactness
+  assertion, the `diag(Σ') == diagonal-form` zero-cost identity, `condition≡update`,
+  error paths, two-step folding.
+- `test/test_linear_gaussian_dsl.jl` — the thin-brain BDSL path end-to-end: a pure
+  `observe` conditions a joint `MvGaussian` via `:family linear-gaussian xs sigma` (runtime
+  coeffs), asserts the posterior against the oracle, checks the `params` belief-spec
+  read-back, and confirms `:family normal 0.5` (literal args) still parses.
+- `test/test_prevision_params.jl` — `mv_gaussian` `params` round-trip (Σ as rows).
+- `test/test_family_registry.jl` — updated for the evaluated-args `:family` surface +
+  `linear-gaussian` in the roster.

--- a/src/conjugate.jl
+++ b/src/conjugate.jl
@@ -94,6 +94,40 @@ function update(cp::ConjugatePrevision{GaussianPrevision, NormalNormal}, obs)
     ConjugatePrevision(GaussianPrevision(μ_post, σ_post), cp.likelihood)
 end
 
+# ── Pair: (MvGaussianPrevision, LinearGaussian) ──
+# Exact Bayesian-linear-regression / Kalman measurement update. Prior
+# w ~ N(m, Σ), observation y ~ N(aᵀw, σ²). The posterior is the closed-form
+#   Σa = Σ·a ;  ŷ = aᵀm ;  s = σ² + aᵀΣa ;  k = Σa/s
+#   m' = m + k·(y − ŷ) ;  Σ' = Σ − (Σa)(Σa)ᵀ/s.
+# The off-diagonal of the rank-1 correction (Σa)(Σa)ᵀ/s is the explaining-away
+# signal (anti-correlation between co-firing weights) and is kept in full — the
+# ontology is exact, no mean-field collapse. Per-feature marginals (the
+# consumer's persisted view) are read off diag(Σ') via `variance`. See
+# docs/linear-gaussian-conjugate.md.
+
+function maybe_conjugate(p::MvGaussianPrevision, k::Kernel)
+    if k.likelihood_family isa LinearGaussian
+        return ConjugatePrevision(p, k.likelihood_family)
+    end
+    nothing
+end
+
+function update(cp::ConjugatePrevision{MvGaussianPrevision, LinearGaussian}, obs)
+    a = cp.likelihood.coeffs
+    m = cp.prior.mu
+    Σ = cp.prior.Sigma
+    length(a) == length(m) ||
+        error("LinearGaussian update: coeffs length $(length(a)) ≠ state dim $(length(m))")
+    σ² = cp.likelihood.sigma_obs^2
+    Σa = Σ * a
+    ŷ = dot(a, m)
+    s = σ² + dot(a, Σa)
+    k = Σa ./ s
+    m′ = m .+ k .* (Float64(obs) - ŷ)
+    Σ′ = Σ .- (Σa * Σa') ./ s
+    ConjugatePrevision(MvGaussianPrevision(m′, Σ′), cp.likelihood)
+end
+
 # ── Pair: (DirichletPrevision, Categorical) ──
 
 function maybe_conjugate(p::DirichletPrevision, k::Kernel)

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -559,7 +559,7 @@ function _eval_kernel(args, env)
             fam_atom = args[i+1]
             (fam_atom isa Atom && fam_atom.value isa Symbol) ||
                 error(":family value must be a symbol (one of: $(_family_keywords())), got $(args[i+1])")
-            family, consumed = _build_family(fam_atom.value, args, i + 2)
+            family, consumed = _build_family(fam_atom.value, args, i + 2, env)
             family_set = true
             i += 2 + consumed
         else
@@ -574,21 +574,22 @@ end
 # Build a LikelihoodFamily for the BDSL `:family <kw> <args…>` form by dispatching
 # through the Ontology FAMILY_REGISTRY (families self-register there, so this
 # parser needs no edit when the roster grows). Consumes the family's declared
-# `arity` of trailing numeric args starting at `start`; returns (family, n_consumed).
-function _build_family(kw::Symbol, args, start::Int)
+# `arity` of trailing argument expressions starting at `start`, each EVALUATED in
+# `env` (so a literal `0.5` and a runtime symbol `xs` are both admissible — the
+# latter is what `:family linear-gaussian xs sigma` needs for its per-observation
+# coefficient vector). The registered constructor coerces the evaluated values to
+# the family's field types. Returns (family, n_consumed).
+function _build_family(kw::Symbol, args, start::Int, env)
     haskey(FAMILY_REGISTRY, kw) ||
         error(":family value :$kw unknown (one of: $(_family_keywords()))")
     ctor, arity = FAMILY_REGISTRY[kw]
-    nums = Float64[]
+    vals = Any[]
     for j in start:(start + arity - 1)
         j <= length(args) ||
-            error(":family $kw requires $arity numeric argument(s)")
-        a = args[j]
-        (a isa Atom && a.value isa Number) ||
-            error(":family $kw argument $(j - start + 1) must be a number, got $(args[j])")
-        push!(nums, Float64(a.value))
+            error(":family $kw requires $arity argument(s)")
+        push!(vals, eval_dsl(args[j], env))
     end
-    return ctor(nums...), arity
+    return ctor(vals...), arity
 end
 
 _family_keywords() = join(sort(string.(collect(keys(FAMILY_REGISTRY)))), ", ")

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -45,6 +45,20 @@ struct NormalNormal <: LeafFamily
     sigma_obs::Float64
 end
 
+# Linear-Gaussian (Bayesian-linear-regression) likelihood: one scalar
+# observation `y ~ N(aᵀw, σ²)` of a linear combination of a multivariate
+# Gaussian state `w`. `coeffs` is the per-observation coefficient vector `a`
+# (the article's feature values); `sigma_obs` is σ. Conjugate to a dense
+# `MvGaussianPrevision` prior via the exact Kalman measurement update
+# (src/conjugate.jl). Unlike NormalNormal's single scalar, the coefficient
+# vector is observation-specific and variable-length, so this family is built
+# per-observation (skin kernel spec / in-Julia), NOT via the fixed-arity
+# `FAMILY_REGISTRY`. See docs/linear-gaussian-conjugate.md.
+struct LinearGaussian <: LeafFamily
+    coeffs::Vector{Float64}
+    sigma_obs::Float64
+end
+
 struct Categorical{T} <: LeafFamily
     categories::Finite{T}
 end
@@ -89,6 +103,10 @@ register_family!(:flat,      () -> Flat(), 0)
 register_family!(:soft,      () -> SoftBernoulli(), 0)
 register_family!(:weighted,  () -> WeightedBernoulli(), 0)
 register_family!(:normal,    (sigma) -> NormalNormal(Float64(sigma)), 1)
+# Two args: `xs` (the per-observation coefficient vector — a runtime list, hence
+# the `:family` arg-evaluation generalisation) and `sigma` (observation noise).
+register_family!(Symbol("linear-gaussian"),
+                 (xs, sigma) -> LinearGaussian(collect(Float64, xs), Float64(sigma)), 2)
 
 struct Kernel
     source::Space

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -16,13 +16,13 @@ condition, push_measure, draw, prune, truncate, log_marginal.
 """
 module Ontology
 
-using LinearAlgebra: SymTridiagonal, eigen
+using LinearAlgebra: SymTridiagonal, eigen, dot, cholesky, Symmetric
 
 # ── Move 2: unify Functional hierarchy onto Previsions.TestFunction ──
 import ..Previsions: Prevision
 import ..Previsions: TestFunction, Identity, Projection, NestedProjection,
                      Tabular, LinearCombination, OpaqueClosure, FiringChoice, expect
-import ..Previsions: BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision
+import ..Previsions: BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision
 import ..Previsions: ExchangeablePrevision, decompose
 import ..Previsions: ParticlePrevision, QuadraturePrevision
 import ..Previsions: ConditionalPrevision
@@ -33,11 +33,11 @@ import ..Previsions: CenteredPower, CenteredSquare, GeometricTail
 import ..Previsions: Indicator, apply
 
 export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals, support
-export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, EnumerationMeasure, ProductMeasure, MixtureMeasure
+export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, MvGaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, EnumerationMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target, kernel_params
 export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, WeightedBernoulli, SoftBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
 export FAMILY_REGISTRY, register_family!
-export NormalNormal, Categorical, NormalGammaLikelihood, Exponential, Poisson
+export NormalNormal, LinearGaussian, Categorical, NormalGammaLikelihood, Exponential, Poisson
 export Event, TagSet, FeatureEquals, FeatureInterval, Conjunction, Disjunction, Complement
 export indicator_kernel, feature_value, BOOLEAN_SPACE
 export Functional, Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure
@@ -243,6 +243,38 @@ Base.propertynames(::GaussianMeasure) = (:mu, :sigma, :space, :prevision)
 
 mean(m::GaussianMeasure) = m.mu
 variance(m::GaussianMeasure) = m.sigma^2
+
+# ── Multivariate Gaussian: dense-covariance belief over Euclidean(d) ──
+
+struct MvGaussianMeasure <: Measure
+    prevision::MvGaussianPrevision
+    space::Euclidean
+
+    function MvGaussianMeasure(space::Euclidean, prevision::MvGaussianPrevision)
+        space.dim == length(prevision.mu) ||
+            error("MvGaussianMeasure: space dim $(space.dim) ≠ length(mu) $(length(prevision.mu))")
+        new(prevision, space)
+    end
+end
+
+MvGaussianMeasure(mu::Vector{Float64}, Sigma::Matrix{Float64}) =
+    MvGaussianMeasure(Euclidean(length(mu)), MvGaussianPrevision(mu, Sigma))
+
+function Base.getproperty(m::MvGaussianMeasure, s::Symbol)
+    if s === :mu || s === :Sigma
+        return getproperty(getfield(m, :prevision), s)
+    else
+        return getfield(m, s)
+    end
+end
+
+Base.propertynames(::MvGaussianMeasure) = (:mu, :Sigma, :space, :prevision)
+
+# `mean` is the vector μ; `variance` is the per-coordinate marginal variances
+# diag(Σ) — the exact marginals (a Gaussian's marginals are read off Σ's
+# diagonal). Cross-covariance lives in `m.Sigma`.
+mean(m::MvGaussianMeasure) = copy(m.mu)
+variance(m::MvGaussianMeasure) = [m.Sigma[i, i] for i in 1:m.space.dim]
 
 # ── Dirichlet: distribution over the probability simplex ──
 
@@ -451,6 +483,7 @@ function wrap_in_measure(p::TaggedBetaPrevision)
 end
 
 wrap_in_measure(p::GaussianPrevision) = GaussianMeasure(Euclidean(1), p.mu, p.sigma)
+wrap_in_measure(p::MvGaussianPrevision) = MvGaussianMeasure(Euclidean(length(p.mu)), p)
 wrap_in_measure(p::GammaPrevision) = GammaMeasure(PositiveReals(), p.alpha, p.beta)
 
 function wrap_in_measure(p::ProductPrevision)
@@ -740,6 +773,7 @@ function expect(p::BetaPrevision, ::GeometricTail)
     p.alpha / (p.beta - 1.0)
 end
 expect(p::GaussianPrevision, ::Identity) = p.mu
+expect(p::MvGaussianPrevision, ::Identity) = copy(p.mu)
 expect(p::GammaPrevision, ::Identity) = p.alpha / p.beta
 expect(p::DirichletPrevision, ::Identity) = p.alpha ./ sum(p.alpha)
 expect(p::NormalGammaPrevision, ::Identity) = p.μ
@@ -962,6 +996,19 @@ function condition(m::GaussianMeasure, k::Kernel, observation)
     _condition_by_grid(m, k, observation)
 end
 
+# Measure-facade for the exact LinearGaussian conjugate. Without this the generic
+# particle fallback (condition(::Measure, …)) would shadow the conjugate when the
+# DSL passes a Measure (it speaks Measures, not Previsions). No grid/particle
+# fallback for a dense-covariance state — an unrecognised kernel is an error.
+function condition(m::MvGaussianMeasure, k::Kernel, observation)
+    cp = maybe_conjugate(m.prevision, k)
+    cp !== nothing || error(
+        "condition(::MvGaussianMeasure, ...) supports only the LinearGaussian conjugate; " *
+        "got likelihood_family $(typeof(k.likelihood_family)).")
+    updated = update(cp, observation).prior
+    return MvGaussianMeasure(m.space, updated)
+end
+
 function condition(m::DirichletMeasure, k::Kernel, observation)
     cp = maybe_conjugate(m.prevision, k)
     if cp !== nothing
@@ -1019,6 +1066,18 @@ function condition(p::GaussianPrevision, k::Kernel, observation)
     end
     conditioned = condition(wrap_in_measure(p), k, observation)
     conditioned.prevision
+end
+
+# A multivariate Gaussian is conditioned only through its LinearGaussian
+# conjugate (the exact Kalman update). There is no generic grid/particle
+# fallback for the dense-covariance state — an unrecognised kernel is a
+# construction error, surfaced with remediation (mirrors NormalGamma).
+function condition(p::MvGaussianPrevision, k::Kernel, observation)
+    cp = maybe_conjugate(p, k)
+    cp !== nothing && return update(cp, observation).prior
+    error("condition(::MvGaussianPrevision, ...) supports only the LinearGaussian " *
+          "conjugate; got likelihood_family $(typeof(k.likelihood_family)). Construct " *
+          "the kernel with likelihood_family = LinearGaussian(coeffs, sigma_obs).")
 end
 
 function condition(p::GammaPrevision, k::Kernel, observation)
@@ -1547,6 +1606,10 @@ end
 draw(p::TaggedBetaPrevision) = draw(p.beta)
 
 draw(p::GaussianPrevision) = p.mu + p.sigma * randn()
+
+# Multivariate normal sample: μ + L·z with L the lower Cholesky factor of Σ
+# (Σ = L·Lᵀ) and z ~ N(0, I). `draw` is the host-side randomness boundary.
+draw(p::MvGaussianPrevision) = p.mu .+ cholesky(Symmetric(p.Sigma)).L * randn(length(p.mu))
 
 draw(p::GammaPrevision) = _draw_gamma(p.alpha) / p.beta
 

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -30,7 +30,7 @@ module Previsions
 
 export Prevision, TestFunction, Indicator, apply, expect
 export Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure, FiringChoice
-export BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision
+export BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision
 export ExchangeablePrevision, decompose
 export ParticlePrevision, QuadraturePrevision
 export ConditionalPrevision
@@ -325,6 +325,29 @@ The `GaussianMeasure` view wraps a `GaussianPrevision` and forwards
 struct GaussianPrevision <: Prevision
     mu::Float64
     sigma::Float64
+end
+
+"""
+    MvGaussianPrevision(mu::Vector{Float64}, Sigma::Matrix{Float64}) <: Prevision
+
+Prevision whose representing measure is a multivariate Gaussian N(μ, Σ) on
+Euclidean space, with a *dense* covariance Σ. Distinct from a product of scalar
+`GaussianPrevision`s (which is diagonal by construction and cannot carry the
+off-diagonal correlation a joint linear-Gaussian update induces). The conjugate
+pair `(MvGaussianPrevision, LinearGaussian)` realises the exact Bayesian-linear-
+regression / Kalman measurement update — see docs/linear-gaussian-conjugate.md.
+The `MvGaussianMeasure` view wraps it and forwards `m.mu`, `m.Sigma`.
+"""
+struct MvGaussianPrevision <: Prevision
+    mu::Vector{Float64}
+    Sigma::Matrix{Float64}
+
+    function MvGaussianPrevision(mu::Vector{Float64}, Sigma::Matrix{Float64})
+        d = length(mu)
+        size(Sigma) == (d, d) ||
+            error("MvGaussianPrevision: Sigma must be $d×$d to match mu (got $(size(Sigma)))")
+        new(mu, Sigma)
+    end
 end
 
 """
@@ -831,6 +854,11 @@ end
 # copied so the snapshot never aliases the shared-reference internal store.
 params(p::BetaPrevision)        = (type = :beta,        alpha = p.alpha, beta = p.beta)
 params(p::GaussianPrevision)    = (type = :gaussian,    mu = p.mu,       sigma = p.sigma)
+# Σ is emitted as a vector-of-rows so it round-trips through JSON; a bare Julia
+# matrix flattens column-major on the wire, losing shape. The skin reads the
+# nested arrays back into a Matrix (see build_prevision / build_measure).
+params(p::MvGaussianPrevision)  = (type = :mv_gaussian, mu = copy(p.mu),
+                                   sigma = [collect(Float64, r) for r in eachrow(p.Sigma)])
 params(p::GammaPrevision)       = (type = :gamma,       alpha = p.alpha, beta = p.beta)
 params(p::DirichletPrevision)   = (type = :dirichlet,   alpha = copy(p.alpha))
 params(p::CategoricalPrevision) = (type = :categorical, log_weights = copy(p.log_weights))

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -28,6 +28,16 @@ end
 
 variance(p::BetaPrevision) = p.alpha * p.beta / ((p.alpha + p.beta)^2 * (p.alpha + p.beta + 1))
 variance(p::GaussianPrevision) = p.sigma^2
+# Per-coordinate marginal variances diag(Σ) — exact (a Gaussian's marginals are
+# read off the covariance diagonal). Cross-covariance is in `p.Sigma`.
+variance(p::MvGaussianPrevision) = [p.Sigma[i, i] for i in 1:length(p.mu)]
+
+# The exact i-th marginal of a multivariate Gaussian is the scalar Gaussian
+# N(μᵢ, Σᵢᵢ) — what a consumer persisting per-feature {mu, sigma} reads back.
+# Marginalisation drops cross-covariance by construction; that projection is the
+# consumer's explicit choice (the joint Σ stays available on `p`).
+marginal(p::MvGaussianPrevision, i::Int) =
+    GaussianPrevision(p.mu[i], sqrt(p.Sigma[i, i]))
 
 probability(p::Prevision, e::Event) = expect(p, Indicator(e))
 
@@ -62,6 +72,7 @@ end
 weights(p::BetaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 weights(p::TaggedBetaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 weights(p::GaussianPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
+weights(p::MvGaussianPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 weights(p::GammaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))
 weights(p::DirichletPrevision) = p.alpha ./ sum(p.alpha)
 weights(p::NormalGammaPrevision) = throw(WeightsDomainError(_WEIGHTS_DOMAIN_MSG))

--- a/test/test_family_registry.jl
+++ b/test/test_family_registry.jl
@@ -38,14 +38,16 @@ kn = mk(":family normal 0.3")
 check("normal → NormalNormal(σ)", kn isa NormalNormal && kn.sigma_obs == 0.3, "got $kn")  # credence-lint: allow — precedent:test-oracle — declared σ flows verbatim
 
 # ── the registry is the single source of truth ──
-check("registry holds all five", all(haskey(FAMILY_REGISTRY, k)
-    for k in (:bernoulli, :flat, :soft, :weighted, :normal)))
+check("registry holds the roster", all(haskey(FAMILY_REGISTRY, k)
+    for k in (:bernoulli, :flat, :soft, :weighted, :normal, Symbol("linear-gaussian"))))
 
 # ── errors are clear and list the roster ──
 throws_with(f, substr) =
     try; f(); false; catch e; occursin(substr, sprint(showerror, e)); end
 check("unknown family errors with roster", throws_with(() -> mk(":family bogus"), "unknown"))
-check(":normal without σ errors", throws_with(() -> mk(":family normal"), "numeric"))
+# `:family` args are now EVALUATED (not literal-numeric) so the linear-gaussian
+# coeffs vector is admissible; a missing arg still errors on arity.
+check(":normal without σ errors", throws_with(() -> mk(":family normal"), "argument"))
 
 # ── the exposed family actually drives its conjugate update (NormalNormal) ──
 # This is the wire path: build_prevision yields a raw GaussianPrevision, which

--- a/test/test_linear_gaussian_conjugate.jl
+++ b/test/test_linear_gaussian_conjugate.jl
@@ -1,0 +1,112 @@
+# test_linear_gaussian_conjugate.jl — the (MvGaussianPrevision, LinearGaussian)
+# conjugate: the exact Bayesian-linear-regression / Kalman measurement update.
+#
+# Tolerances (mirroring docs/posture-3/move-4-design.md §3):
+#   - the diagonal-form identity vᵢ' = vᵢ − (aᵢvᵢ)²/s holds by exact algebra: `==`
+#   - the full posterior μ/Σ vs an independent hand oracle: `rtol=1e-12`
+#
+# Each conjugate-path test asserts `_dispatch_path(p, k) == :conjugate` BEFORE
+# the value assertion — the tripwire for a silent registry miss (without it a
+# miss would error in `condition` and the value test never runs).
+#
+# The headline property is exactness: conditioning two independent weights on a
+# noisy measurement of their sum induces a NONZERO off-diagonal covariance (the
+# explaining-away signal). A diagonal/mean-field collapse would zero it; we keep
+# it. See docs/linear-gaussian-conjugate.md.
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: MvGaussianPrevision, LinearGaussian, Kernel, Euclidean,
+                maybe_conjugate, update, ConjugatePrevision, _dispatch_path
+
+function check(name, cond, detail="")
+    if cond
+        println("  ✓ $name")
+    else
+        println("  ✗ $name  $detail")
+        error("FAILED: $name")
+    end
+end
+
+approx(a, b; rtol=1e-12) = abs(a - b) <= rtol * max(abs(a), abs(b), 1.0)
+throws(f) = try; f(); false; catch; true; end
+
+println("test_linear_gaussian_conjugate:")
+
+# ── Fixture: one diffuse weight (v=1.0), one confident weight (v=0.25) ──
+# observed jointly through y ~ N(a'w, σ²), a = [1,1], σ² = 0.5, y = −1.
+m  = [0.0, 0.0]
+Σ  = [1.0 0.0; 0.0 0.25]
+a  = [1.0, 1.0]
+σ²  = 0.5
+y  = -1.0
+prior = MvGaussianPrevision(copy(m), copy(Σ))
+k = Kernel(Euclidean(2), Euclidean(1),
+           w -> error("generate not used"),
+           (w, o) -> -0.5 * (o - (a[1]*w[1] + a[2]*w[2]))^2 / σ²;
+           likelihood_family = LinearGaussian(a, sqrt(σ²)))
+
+# ── Independent hand oracle (scalar arithmetic, d = 2) ──
+Σa1, Σa2 = Σ[1,1]*a[1], Σ[2,2]*a[2]          # Σ is diagonal here: Σa = [v1·a1, v2·a2]
+ŷ  = a[1]*m[1] + a[2]*m[2]
+s  = σ² + a[1]*Σa1 + a[2]*Σa2
+k1, k2 = Σa1/s, Σa2/s
+m1ʹ, m2ʹ = m[1] + k1*(y - ŷ), m[2] + k2*(y - ŷ)
+Σ11ʹ = Σ[1,1] - Σa1*Σa1/s
+Σ22ʹ = Σ[2,2] - Σa2*Σa2/s
+Σ12ʹ = Σ[1,2] - Σa1*Σa2/s
+
+# ── dispatch tripwire ──
+check("dispatch is :conjugate", _dispatch_path(prior, k) == :conjugate,
+      "got $(_dispatch_path(prior, k)) — registry miss")
+
+# ── update() matches the oracle (rtol 1e-12) ──
+post = update(ConjugatePrevision(prior, k.likelihood_family), y).prior
+check("post.mu[1]", approx(post.mu[1], m1ʹ), "$(post.mu[1]) vs $m1ʹ")
+check("post.mu[2]", approx(post.mu[2], m2ʹ), "$(post.mu[2]) vs $m2ʹ")
+check("post.Sigma[1,1]", approx(post.Sigma[1,1], Σ11ʹ))
+check("post.Sigma[2,2]", approx(post.Sigma[2,2], Σ22ʹ))
+check("post.Sigma[1,2]", approx(post.Sigma[1,2], Σ12ʹ))
+check("post.Sigma symmetric", post.Sigma[1,2] == post.Sigma[2,1])
+
+# ── EXACTNESS: induced off-diagonal is nonzero and negative (explaining away) ──
+check("off-diagonal induced (nonzero)", post.Sigma[1,2] != 0.0,
+      "a diagonal/mean-field collapse would zero this")
+check("off-diagonal negative (anti-correlation)", post.Sigma[1,2] < 0.0)
+
+# ── explaining-away: the confident weight (idx 2) moves LESS than diffuse (idx 1) ──
+check("confident weight moves less", abs(post.mu[2]) < abs(post.mu[1]),
+      "confident $(post.mu[2]) vs diffuse $(post.mu[1])")
+
+# ── ZERO COST to a marginals-only consumer: diag(Σ') equals the diagonal form ──
+# vᵢ' = vᵢ − (aᵢ·vᵢ)²/s   (the request's "diagonal" update) is EXACTLY diag(Σ').
+check("diag matches diagonal-form v1'", post.Sigma[1,1] == Σ[1,1] - (a[1]*Σ[1,1])^2/s)
+check("diag matches diagonal-form v2'", post.Sigma[2,2] == Σ[2,2] - (a[2]*Σ[2,2])^2/s)
+
+# ── public condition() path matches update() path ──
+post2 = condition(prior, k, y)
+check("condition == update (mu)", post2.mu == post.mu)
+check("condition == update (Sigma)", post2.Sigma == post.Sigma)
+
+# ── read surface: mean / variance / marginal / draw ──
+check("mean is mu", mean(post) == post.mu)
+check("variance is diag(Sigma)", variance(post) == [post.Sigma[1,1], post.Sigma[2,2]])
+mg1 = Credence.marginal(post, 1)
+check("marginal(1) mu", mg1.mu == post.mu[1])
+check("marginal(1) sigma", mg1.sigma == sqrt(post.Sigma[1,1]))
+d = draw(post)
+check("draw length", length(d) == 2)
+
+# ── error paths ──
+bad_k = Kernel(Euclidean(2), Euclidean(1), w -> 0.0, (w, o) -> 0.0;
+               likelihood_family = Credence.NormalNormal(1.0))
+check("wrong family errors", throws(() -> condition(prior, bad_k, y)))
+check("dim mismatch errors",
+      throws(() -> MvGaussianPrevision([0.0, 0.0], [1.0 0.0 0.0; 0.0 1.0 0.0])))
+
+# ── multi-step: fold a second observation; off-diagonal carries forward ──
+post3 = condition(post, k, 0.5)
+check("two-step stays symmetric", post3.Sigma[1,2] == post3.Sigma[2,1])
+check("two-step variances shrink further", post3.Sigma[1,1] < post.Sigma[1,1])
+
+println("test_linear_gaussian_conjugate: all passed")

--- a/test/test_linear_gaussian_dsl.jl
+++ b/test/test_linear_gaussian_dsl.jl
@@ -1,0 +1,78 @@
+# test_linear_gaussian_dsl.jl — the BDSL `:family linear-gaussian` surface.
+#
+# The thin-brain (decouple Move 2) shape: the consumer's pure BDSL `observe`
+# conditions a JOINT MvGaussian weight belief on a noisy measurement of aᵀw via a
+# declared `:family linear-gaussian xs sigma` kernel — the joint generalisation of
+# maut_demo.bdsl's per-weight `:family normal`. The coefficient vector `xs` is a
+# RUNTIME list (per article), which is why the `:family` parser now evaluates its
+# args. The belief crosses back as a {type:mv_gaussian, mu, sigma} spec (params),
+# exactly as the wire serialises it. Asserts the posterior against an independent
+# Kalman oracle at rtol 1e-12. See docs/linear-gaussian-conjugate.md.
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: MvGaussianMeasure, MvGaussianPrevision, Euclidean
+
+function check(name, cond, detail="")
+    cond ? println("  ✓ $name") : (println("  ✗ $name  $detail"); error("FAILED: $name"))
+end
+approx(a, b; rtol=1e-12) = abs(a - b) <= rtol * max(abs(a), abs(b), 1.0)
+
+println("test_linear_gaussian_dsl:")
+
+# The consumer's pure BDSL model: weights in, joint-conditioned weights out.
+# `xs` is the article's feature values (the LinearGaussian coefficients).
+src = """
+(define observe
+  (lambda (weights xs y sigma)
+    (condition weights
+      (kernel (space :euclidean 2) (space :euclidean 1)
+              (lambda (w) (lambda (o) o))
+              :family linear-gaussian xs sigma)
+      y)))
+"""
+env = load_dsl(src)
+observe = env[Symbol("observe")]
+
+# Prior: one diffuse weight (v=1.0), one confident (v=0.25). The wire would
+# reconstruct this MvGaussianMeasure from a {type:mv_gaussian, ...} spec.
+prior = MvGaussianMeasure(Euclidean(2), MvGaussianPrevision([0.0, 0.0], [1.0 0.0; 0.0 0.25]))
+xs = [1.0, 1.0]
+y  = -1.0
+sigma = sqrt(0.5)
+
+post = observe(prior, xs, y, sigma)
+check("observe returns MvGaussianMeasure", post isa MvGaussianMeasure)
+
+# Independent Kalman oracle (Σ diagonal here).
+Σa1, Σa2 = 1.0, 0.25
+s = 0.5 + (1.0*Σa1 + 1.0*Σa2)
+m1ʹ, m2ʹ = (Σa1/s)*(y), (Σa2/s)*(y)
+check("dsl post.mu[1]", approx(post.mu[1], m1ʹ), "$(post.mu[1]) vs $m1ʹ")
+check("dsl post.mu[2]", approx(post.mu[2], m2ʹ), "$(post.mu[2]) vs $m2ʹ")
+check("dsl off-diagonal induced", post.Sigma[1,2] != 0.0 && post.Sigma[1,2] < 0.0,
+      "joint update keeps the explaining-away covariance")
+check("dsl confident moves less", abs(post.mu[2]) < abs(post.mu[1]))
+
+# Read-back: the conditioned belief serialises to a readable belief-spec — the
+# decouple Move-2 call_dsl path (no read_params verb needed).
+spec = params(post)
+check("belief-spec is mv_gaussian", spec.type == :mv_gaussian)
+check("belief-spec mu matches", spec.mu == post.mu)
+check("belief-spec sigma is rows", spec.sigma == [[post.Sigma[1,1], post.Sigma[1,2]],
+                                                   [post.Sigma[2,1], post.Sigma[2,2]]])
+
+# Backward-compat: a literal-arg family (`:family normal 0.5`) still parses.
+env2 = load_dsl("""
+(define obs1
+  (lambda (w y)
+    (condition w
+      (kernel (space :euclidean 1) (space :euclidean 1)
+              (lambda (mu) (lambda (o) o))
+              :family normal 0.5)
+      y)))
+""")
+g = env2[Symbol("obs1")](Credence.GaussianMeasure(Euclidean(1), 0.0, 1.0), 1.0)
+check(":family normal still works", g isa Credence.GaussianMeasure)
+
+println("test_linear_gaussian_dsl: all passed")

--- a/test/test_prevision_params.jl
+++ b/test/test_prevision_params.jl
@@ -6,9 +6,9 @@
 
 push!(LOAD_PATH, "src")
 using Credence
-using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, DirichletPrevision,
-                CategoricalPrevision
-using Credence: BetaMeasure, GaussianMeasure, GammaMeasure
+using Credence: BetaPrevision, GaussianPrevision, MvGaussianPrevision, GammaPrevision,
+                DirichletPrevision, CategoricalPrevision
+using Credence: BetaMeasure, GaussianMeasure, GammaMeasure, MvGaussianMeasure
 
 function check(name, cond, detail="")
     if cond
@@ -27,6 +27,10 @@ check("gaussian", params(GaussianPrevision(0.5, 1.5)) == (type=:gaussian, mu=0.5
 check("gamma", params(GammaPrevision(4.0, 0.5)) == (type=:gamma, alpha=4.0, beta=0.5))  # credence-lint: allow — precedent:test-oracle — sufficient statistics emitted verbatim
 check("dirichlet", params(DirichletPrevision([1.0, 2.0, 3.0])) == (type=:dirichlet, alpha=[1.0, 2.0, 3.0]))  # credence-lint: allow — precedent:test-oracle — sufficient statistics emitted verbatim
 check("categorical", params(CategoricalPrevision([0.0, -1.0])).type == :categorical)
+let nt = params(MvGaussianPrevision([0.5, -1.0], [2.0 0.3; 0.3 0.5]))
+    check("mv_gaussian", nt == (type=:mv_gaussian, mu=[0.5, -1.0],
+                                sigma=[[2.0, 0.3], [0.3, 0.5]]))  # credence-lint: allow — precedent:test-oracle — sufficient statistics emitted verbatim (Σ as rows)
+end
 
 # ── vectors are copied, not aliased (snapshot, not shared-reference) ──
 α = [1.0, 2.0]
@@ -42,10 +46,19 @@ check("beta round-trip", params(BetaPrevision(nt.alpha, nt.beta)) == nt)  # cred
 g = GaussianPrevision(0.25, 0.8)
 ntg = params(g)
 check("gaussian round-trip", params(GaussianPrevision(ntg.mu, ntg.sigma)) == ntg)  # credence-lint: allow — precedent:test-oracle — reconstruct∘serialize is identity
+# mv_gaussian round-trip: rebuild the Matrix from the vector-of-rows (the same
+# stacking the skin's build_prevision does).
+let mv = MvGaussianPrevision([0.5, -1.0], [2.0 0.3; 0.3 0.5]), ntm = params(mv)
+    Σ = mapreduce(r -> permutedims(collect(Float64, r)), vcat, ntm.sigma)
+    check("mv_gaussian round-trip", params(MvGaussianPrevision(ntm.mu, Σ)) == ntm)  # credence-lint: allow — precedent:test-oracle — reconstruct∘serialize is identity
+end
 
 # ── Measure facade forwards to its wrapped Prevision ──
 check("BetaMeasure forwards", params(BetaMeasure(2.0, 3.0)) == (type=:beta, alpha=2.0, beta=3.0))  # credence-lint: allow — precedent:test-oracle — facade serializes via its prevision
 check("GaussianMeasure forwards",
       params(GaussianMeasure(Credence.Euclidean(1), 0.5, 1.5)) == (type=:gaussian, mu=0.5, sigma=1.5))  # credence-lint: allow — precedent:test-oracle — facade serializes via its prevision
+check("MvGaussianMeasure forwards",
+      params(MvGaussianMeasure([0.5, -1.0], [2.0 0.3; 0.3 0.5])) ==
+          (type=:mv_gaussian, mu=[0.5, -1.0], sigma=[[2.0, 0.3], [0.3, 0.5]]))  # credence-lint: allow — precedent:test-oracle — facade serializes via its prevision
 
 println("test_prevision_params: all passed")


### PR DESCRIPTION
Engine response to `docs/rssfeed-linear-gaussian-conjugate-request.md`: adds one domain-agnostic conjugate pair so a **joint** linear-Gaussian (Bayesian-linear-regression / Kalman) update happens inside `condition`, in closed form. No RSS vocabulary in the engine. Positioned as a **decouple Move-2 family extension** — the joint generalisation of Move 2's per-weight `:family normal`.

## Two decisions
1. **Exact, not diagonal mean-field.** The request asked for a diagonal (assumed-density) update that drops the off-diagonal covariance. The ontology is always exact, so we keep the full `Σ' = Σ − (Σa)(Σa)ᵀ/s` — the off-diagonal *is* the explaining-away signal. Exact is closed-form and cheap (d≈5–8), so there's no performance ground to approximate. Single-update marginals are byte-identical to the diagonal form, so the consumer loses nothing.
2. **`:family linear-gaussian` (evaluate args), not a new builtin or wire method.** The frozen-type-constructor rule keeps the kernel surface to `(kernel … :family …)`; read-back is the Move-2 `call_dsl` belief-spec round-trip (`params(MvGaussianMeasure)` → `{type:mv_gaussian, mu, sigma}`), so the deferred `read_params` verb stays deferred.

## What's in it
- **Engine:** `MvGaussianPrevision{mu, Sigma}` (dense cov) + `MvGaussianMeasure`; `LinearGaussian` leaf family; the exact conjugate `update`; Measure-level `condition` (so the DSL Measure path hits the conjugate, not the particle fallback); read surface (`mean`/`variance`=diag/`marginal`/`draw`/`expect`/`params`).
- **BDSL:** `linear-gaussian` self-registers in `FAMILY_REGISTRY`; `:family` arg parsing generalised to **evaluate** args (admits the runtime coeffs vector `xs`; literals still evaluate to themselves — backward-compatible).
- **Skin:** `mv_gaussian` prevision/measure specs + `linear_gaussian` kernel spec (Σ as JSON rows).

## Verification
- `test_linear_gaussian_conjugate.jl` — exact posterior `mu`/`Σ` vs an independent Kalman oracle at rtol 1e-12, nonzero induced off-diagonal, `diag(Σ')`==diagonal-form identity, `condition≡update`, error paths, two-step.
- `test_linear_gaussian_dsl.jl` — full thin-brain BDSL path end-to-end (`:family linear-gaussian` runtime coeffs) + belief-spec read-back + `:family normal` backward-compat.
- Extended `test_prevision_params` (mv_gaussian round-trip) and `test_family_registry` (evaluated-args surface).
- **26/27 Julia suite passes.** The one failure (`test_rss.jl`) is **pre-existing on clean master** (reference-only rss domain, superseded per the decouple master plan) — not introduced here. Julia tests are not CI-gated; lint clean (226 files, 0 violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)