### PR TITLE
docs(decouple): Move 3 design — credence-pi separable refit

### DIFF
--- a/apps/credence-pi/brain/feature_brain.jl
+++ b/apps/credence-pi/brain/feature_brain.jl
@@ -1,43 +1,26 @@
-# Role: brain
+# Role: brain (thin shim)
 """
-    feature_brain.jl — the credence-pi feature-conditioned brain (Pass 2, Move 3).
+    feature_brain.jl — credence-pi's thin domain shim over the engine's structure-BMA stdlib.
 
-Structure-BMA over Bayesian-network edges (feature → approval). Replaces the
-Pass-1 global `Beta(2,2)` with `P(approve | X)`, X = the declared features, so the
-governor can block a *repeated* wasteful call while still approving a *novel* one —
-impossible for one global Beta.
-
-ROUTE B (docs/credence-pi-pass-2/move-3-design.md). This is typed Julia
-brain-side code that DECLARES the structure family + readout Functionals and CALLS
-the Tier-1 axiom ops — the constitution's "applications declare data and call
-primitives" pattern. It reimplements NO axiom-constrained op: every belief change
-goes through `condition`; every decision through the typed stdlib `optimise`/`voi`.
-The `.bdsl` files keep the DECLARED DATA (feature spaces in features.bdsl, the
-capability manifest, the utility constants in utility.bdsl).
-
-Two representations, kept separate (Invariant 3):
-  * `top`         — the persistent belief: a `MixturePrevision` over the 2ⁿ edge
-                    structures, each a `ProductPrevision` of `TaggedBeta` cells.
-                    Learning conditions THIS (`observe`).
-  * `belief_at_X` — a transient per-decision view: a mixture of each structure's
-                    cell-for-X carrying the same structure weights. Decisions read
-                    THIS (`decide`). Equivalence lemma (design doc §"decision side"):
-                    conditioning the view reweights structures identically to
-                    conditioning `top`, so `voi`/`value` on the view are exact.
-
-No raw probability arithmetic lives here — the `credence-lint` brain/ rule
-enforces it. EU is closed-form via typed `LinearCombination` over `Identity`; the
-action argmax is the single canonical `optimise`.
+After decouple Move 3 the structure-BMA builder + observe + readout live in the engine
+(`src/structure_bma.jl`: `build_structure_model` / `build_structure_prior` /
+`structure_observe` / `belief_at_context` / …). This module re-exports them under the
+names credence-pi's daemon and tests use, and keeps the genuinely credence-pi-specific
+wiring: reading the declared feature env, the harm/tail/latency opt-in plumbing, the
+per-context EU decision (`decide`/`decide_multi`), the counts-JSON reconstruction, the
+effector policy, and `wire_brain!`. It reimplements NO axiom op — every belief change is
+`condition` (inside the lifted `structure_observe`); every decision is the canonical
+`optimise`. The `.bdsl` files keep the DECLARED DATA (feature spaces, capabilities,
+utility constants).
 """
 module FeatureBrain
 
-using Main.Credence: BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision,
-    ProductPrevision, MixturePrevision, GammaPrevision,
-    Prevision, Kernel, Interval, Finite, BetaBernoulli, SoftBernoulli, Flat, FiringByTag, Identity,
-    Projection, LinearCombination, TestFunction, GeometricTail, mean, FeatureDecl, condition, expect,
-    cell_at, wrap_in_measure
-import Main.Credence.Ontology: optimise, value, voi, net_voi, with_components,
-    ProductMeasure, Measure
+using Main.Credence: StructureBMA, build_structure_model, build_structure_prior,
+    build_structure_prior_dense, structure_observe, structure_observe_soft,
+    structure_firing_tags, belief_at_context, context_from_features, structure_decision_kernel,
+    MixturePrevision, GammaPrevision, Identity, LinearCombination, TestFunction, Projection,
+    GeometricTail, FeatureDecl, Finite, expect, wrap_in_measure
+import Main.Credence.Ontology: optimise, net_voi, ProductMeasure, Measure
 using JSON3
 
 export StructureBMA, build_model, build_model_from_env, build_model_from_decls,
@@ -45,82 +28,24 @@ export StructureBMA, build_model, build_model_from_env, build_model_from_decls,
        belief_at_context, observe, observe_soft, decide, decide_multi,
        reconstruct_posterior, reconstruct_harm_posterior
 
-# ── The model: feature spec + structure enumeration + tag bookkeeping ──
-#
-# A `structure` is a subset of feature indices — the parents of the approval leaf
-# A (edges INTO A; feature-feature edges describe P(X) and cancel, design doc
-# §"The model"). Each structure has one cell per element of the cross-product of
-# its parents' value-sets; every cell carries a GLOBALLY-UNIQUE integer tag so a
-# single per-context `FiringByTag` kernel routes correctly through the whole nested
-# object (within each structure exactly one cell's tag fires).
+# ── The structure-BMA core now lives in the engine; alias the names this app's daemon
+#    and tests use to the lifted `Credence` functions (decouple Move 3). ──
+const build_model       = build_structure_model
+const build_prior       = build_structure_prior
+const build_prior_dense = build_structure_prior_dense
+const observe           = structure_observe
+const observe_soft      = structure_observe_soft
+const firing_tags       = structure_firing_tags
 
-struct StructureBMA
-    feature_names::Vector{String}
-    feature_values::Vector{Vector{String}}     # per feature, its value-set as strings
-    structures::Vector{Vector{Int}}            # the 2ⁿ parent-index subsets
-    cell_tag::Vector{Dict{Tuple, Int}}         # per structure: cell-key (parent values) -> tag
-    tag_lo::Vector{Int}                        # per structure: lowest cell tag (contiguous)
-    tag_hi::Vector{Int}                        # per structure: highest cell tag
-    n_features::Int
-    alpha0::Float64
-    beta0::Float64
-    p_edge::Float64
-end
-
-# The cell key for context X under a structure = the tuple of X's values at the
-# structure's parents, in parent order. Empty parents ⇒ `()` (the global cell).
-cell_key(parents::Vector{Int}, X::AbstractVector) = Tuple(X[f] for f in parents)
-
-# Enumerate the cell-context keys (tuples of parent values) for a structure, in a
-# deterministic order (matches `cell_key`'s parent ordering).
-function _cell_contexts(parents::Vector{Int}, feature_values::Vector{Vector{String}})
-    isempty(parents) && return Tuple[()]
-    keys = Tuple[()]
-    for f in parents
-        keys = Tuple[(k..., v) for k in keys for v in feature_values[f]]
-    end
-    keys
-end
-
-"""
-    build_model(feature_names, feature_values; alpha0, beta0, p_edge) -> StructureBMA
-
-Enumerate all 2ⁿ edge structures, allocate a globally-unique tag per cell. Pure
-construction of the declared structure family; no beliefs yet.
-"""
-function build_model(feature_names::Vector{String}, feature_values::Vector{Vector{String}};
-                     alpha0::Float64 = 2.0, beta0::Float64 = 2.0, p_edge::Float64 = 0.5)
-    n = length(feature_names)
-    length(feature_values) == n || error("build_model: names/values length mismatch")
-    structures = Vector{Int}[]
-    for mask in 0:(2^n - 1)
-        push!(structures, [i for i in 1:n if (mask >> (i - 1)) & 1 == 1])
-    end
-    cell_tag = Dict{Tuple, Int}[]
-    tag_lo = Int[]
-    tag_hi = Int[]
-    tag = 0
-    for parents in structures
-        d = Dict{Tuple, Int}()
-        lo = tag + 1                  # tags are contiguous per structure
-        for cell in _cell_contexts(parents, feature_values)
-            tag += 1
-            d[cell] = tag
-        end
-        push!(cell_tag, d)
-        push!(tag_lo, lo)
-        push!(tag_hi, tag)
-    end
-    StructureBMA(feature_names, feature_values, structures, cell_tag, tag_lo, tag_hi,
-                 n, alpha0, beta0, p_edge)
-end
+# ── Declared-feature → model construction (env/eval-layer plumbing — stays consumer-side:
+#    `FeatureDecl` is an eval-layer type included after the engine's Ontology module, and
+#    reading a BDSL env is body wiring, not engine machinery). ──
 
 """
     build_model_from_env(env; ...) -> StructureBMA
 
 Read the declared feature spaces from `env[:features]` (a `Vector{FeatureDecl}`
-populated by features.bdsl). The features are declared DATA; this turns them into
-the typed structure family.
+populated by features.bdsl) and build the typed structure family.
 """
 function build_model_from_env(env; alpha0::Float64 = 2.0, beta0::Float64 = 2.0,
                               p_edge::Float64 = 0.5)
@@ -156,164 +81,6 @@ end
 function _has_features(model::StructureBMA, features)
     fd = Dict{String, String}(string(k) => string(v) for (k, v) in features)
     all(haskey(fd, n) for n in model.feature_names)
-end
-
-# Structure-inclusion log-weights (independent edge-inclusion at p_edge; uniform
-# when p_edge = 0.5). Shared by the sparse and dense priors.
-_structure_logweights(model::StructureBMA) =
-    Float64[length(parents) * log(model.p_edge) +
-            (model.n_features - length(parents)) * log(1.0 - model.p_edge)
-            for parents in model.structures]
-
-"""
-    build_prior(model) -> MixturePrevision
-
-The structure-BMA prior: a mixture over structures, each a SPARSE product of
-`Beta(alpha0, beta0)` cells (`SparseStructurePrevision` — only observed cells are
-materialised). Bit-identical to `build_prior_dense` but O(structures) to build and
-to condition, so the brain scales to many features. This is the daemon `make-prior`.
-"""
-function build_prior(model::StructureBMA)
-    comps = Prevision[SparseStructurePrevision(model.alpha0, model.beta0,
-                                               model.tag_lo[s], model.tag_hi[s],
-                                               Dict{Int, BetaPrevision}())
-                      for s in eachindex(model.structures)]
-    MixturePrevision(comps, _structure_logweights(model))
-end
-
-"""
-    build_prior_dense(model) -> MixturePrevision
-
-The DENSE reference prior: each structure a full `ProductPrevision` of
-`TaggedBetaPrevision` cells. Materialises the entire cross-product (exponential),
-so it is used only as the exactness reference for `build_prior`
-(see test/test_sparse_structure_equivalence.jl) and by tests that inspect cell
-internals via `.factors`.
-"""
-function build_prior_dense(model::StructureBMA)
-    comps = Prevision[]
-    for (s, parents) in enumerate(model.structures)
-        factors = TaggedBetaPrevision[]
-        for cell in _cell_contexts(parents, model.feature_values)
-            push!(factors, TaggedBetaPrevision(model.cell_tag[s][cell],
-                                               BetaPrevision(model.alpha0, model.beta0)))
-        end
-        push!(comps, ProductPrevision(factors))
-    end
-    MixturePrevision(comps, _structure_logweights(model))
-end
-
-# ── Context plumbing ──
-
-"""
-    context_from_features(model, features) -> Vector{String}
-
-Map a body-sent feature dict (string→bucket-string) to X, indexed by the model's
-feature order. Validates each value is a declared bucket (a body/brain contract
-violation fails loud rather than `KeyError`-ing deep in routing).
-"""
-function context_from_features(model::StructureBMA, features)
-    fd = Dict{String, String}(string(k) => string(v) for (k, v) in features)
-    X = String[]
-    for (i, name) in enumerate(model.feature_names)
-        haskey(fd, name) || error("feature brain: event missing declared feature '$name'")
-        v = fd[name]
-        v in model.feature_values[i] ||
-            error("feature brain: feature '$name' value '$v' is not a declared bucket " *
-                  "($(model.feature_values[i])) — body/brain vocabulary drift")
-        push!(X, v)
-    end
-    X
-end
-
-# F(X): one matching cell-tag per structure (globally unique ⇒ a single Set routes
-# the whole nested object).
-firing_tags(model::StructureBMA, X::AbstractVector) =
-    Set{Int}(model.cell_tag[s][cell_key(parents, X)] for (s, parents) in enumerate(model.structures))
-
-# Measure-aware Bernoulli log-density (mirrors kernel.bdsl + the oracle test): takes
-# the cell MEASURE and returns the cell's marginal log-predictive.
-_approve_logdensity(m, o) = (a = mean(m.beta); o == 1 ? log(a) : log(1.0 - a))
-
-# Per-context LEARNING kernel: BetaBernoulli on the cells in F(X), Flat (no-op)
-# elsewhere. `condition(top, this, obs)` updates each structure's cell-for-X and
-# reweights structures by the firing cell's predictive = the chain-rule marginal
-# likelihood (Code-1; verified by test_product_bma_routing.jl).
-_learn_kernel(fires::Set{Int}) =
-    Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta, _approve_logdensity;
-           likelihood_family = FiringByTag(fires, BetaBernoulli(), Flat()))
-
-# DECISION kernel: a plain BetaBernoulli (every component of `belief_at_X` IS the
-# relevant cell, so all fire). Used only inside `voi`.
-_decision_kernel() =
-    Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta, _approve_logdensity;
-           likelihood_family = BetaBernoulli())
-
-"""
-    observe(model, top, X, obs) -> MixturePrevision
-
-Bayesian update of the persistent belief on one `(context, response)`: a single
-`condition` through the canalised path. `obs` is 1 (approve) or 0 (deny).
-"""
-observe(model::StructureBMA, top::MixturePrevision, X::AbstractVector, obs) =
-    condition(top, _learn_kernel(firing_tags(model, X)), obs)
-
-# Soft-evidence log-density: the firing cell's predictive marginal under virtual
-# evidence with likelihoods (r, w) = (P(S|label=1), P(S|label=0)) — the chain-rule
-# term the BMA reweights structures by. Generalises `_approve_logdensity`: the hard
-# label o=1 is (r,w)=(1,0) ⇒ log(mean), o=0 is (0,1) ⇒ log(1-mean).
-_soft_logdensity(m, obs) = (a = mean(m.beta); r = obs[1]; w = obs[2];
-                            log(max(r * a + w * (1.0 - a), 1e-300)))
-
-# Per-context SOFT-EVIDENCE learning kernel: SoftBernoulli on the cells in F(X),
-# Flat elsewhere. The cell update is the mean-exact ADF collapse (α += π, β += 1-π,
-# π = r·θ̄/(r·θ̄+w·(1-θ̄))); structures reweight by `_soft_logdensity`.
-_soft_learn_kernel(fires::Set{Int}) =
-    Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta, _soft_logdensity;
-           likelihood_family = FiringByTag(fires, SoftBernoulli(), Flat()))
-
-"""
-    observe_soft(model, top, X, r, w) -> MixturePrevision
-
-Bayesian update on INDIRECT evidence about the (latent) label at context X: `r`
-and `w` are the likelihoods of the observed signal under label = 1 / label = 0
-(P(S|1), P(S|0)). A single `condition` through the canalised path with a
-`SoftBernoulli` kernel — the firing cell's mean-exact soft-count, the BMA
-structure-reweight by the signal's predictive marginal. Reduces EXACTLY to
-`observe(model, top, X, 1)` at (r,w)=(1,0) and `observe(…, 0)` at (0,1) — the
-hard label is the degenerate certain-signal corner.
-"""
-observe_soft(model::StructureBMA, top::MixturePrevision, X::AbstractVector,
-             r::Real, w::Real) =
-    condition(top, _soft_learn_kernel(firing_tags(model, X)), (Float64(r), Float64(w)))
-
-# Select a structure component's cell-for-X by tag. Two representations:
-# sparse (O(1) dict-backed cell_at) and dense (linear scan of factors). Both
-# return the same TaggedBetaPrevision, so the decision sees identical beliefs.
-_cell_for(comp::SparseStructurePrevision, tag::Int) = cell_at(comp, tag)
-function _cell_for(comp::ProductPrevision, tag::Int)
-    idx = findfirst(f -> f isa TaggedBetaPrevision && f.tag == tag, comp.factors)
-    idx === nothing && error("feature brain: cell tag $tag not found")
-    comp.factors[idx]
-end
-
-"""
-    belief_at_context(model, top, X) -> MixturePrevision
-
-The transient per-decision view: each structure's cell-for-X, carrying the
-structure posterior weights verbatim. Pure construction — selects sub-beliefs and
-copies weights; no arithmetic on probabilities.
-"""
-function belief_at_context(model::StructureBMA, top::MixturePrevision, X::AbstractVector)
-    cells = Prevision[]
-    for (s, parents) in enumerate(model.structures)
-        tag = model.cell_tag[s][cell_key(parents, X)]
-        push!(cells, _cell_for(top.components[s], tag))
-    end
-    # Carry the structure posterior verbatim onto the per-context cells (the
-    # weight-carry lives in the `with_components` stdlib op, not here — so the
-    # brain reads no private `log_weights`).
-    with_components(top, cells)
 end
 
 # ── Decision: per-context EU-max with the (tail-aware) linear-cost utility ──
@@ -369,7 +136,7 @@ function decide(model::StructureBMA, top::MixturePrevision, X::AbstractVector, c
     # cost subtraction lives in stdlib, not as host arithmetic here) and entered
     # into `optimise` as a constant Functional so all three actions compare
     # through the ONE argmax.
-    eu_ask = net_voi(bx, _decision_kernel(), [:proceed, :block], fpa_pb, [0, 1], interrupt_cost)
+    eu_ask = net_voi(bx, structure_decision_kernel(), [:proceed, :block], fpa_pb, [0, 1], interrupt_cost)
     fpa = Dict{Symbol, LinearCombination}(:proceed => _const(0.0),
                                           :block => block_fn,
                                           :ask => _const(eu_ask))
@@ -416,7 +183,7 @@ function decide_multi(waste_model::StructureBMA, top_waste::MixturePrevision,
     # EU(ask): VOI of the user resolving approve, against the SAME tail+time-aware block payoff so
     # asking about a likely-long loop inherits the (1+m)× value; a constant so all three
     # actions compare through one optimise.
-    eu_ask = net_voi(bxa, _decision_kernel(), [:proceed, :block],
+    eu_ask = net_voi(bxa, structure_decision_kernel(), [:proceed, :block],
                      Dict(:proceed => _const(0.0), :block => _lin(-cost * (tf + aversion), cost * tf + tcost)),
                      [0, 1], interrupt_cost)
     fpa = Dict(:proceed => _const(0.0), :block => block_fn, :ask => _const(eu_ask))

--- a/apps/credence-pi/brain/feature_brain.jl
+++ b/apps/credence-pi/brain/feature_brain.jl
@@ -7,20 +7,26 @@ After decouple Move 3 the structure-BMA builder + observe + readout live in the 
 `structure_observe` / `belief_at_context` / …). This module re-exports them under the
 names credence-pi's daemon and tests use, and keeps the genuinely credence-pi-specific
 wiring: reading the declared feature env, the harm/tail/latency opt-in plumbing, the
-per-context EU decision (`decide`/`decide_multi`), the counts-JSON reconstruction, the
-effector policy, and `wire_brain!`. It reimplements NO axiom op — every belief change is
-`condition` (inside the lifted `structure_observe`); every decision is the canonical
-`optimise`. The `.bdsl` files keep the DECLARED DATA (feature spaces, capabilities,
-utility constants).
+per-context EU decision (`decide`/`decide_multi`, which select belief views and delegate
+the EU math to the engine's `decide_with_voi`), the counts-JSON reconstruction, the
+effector policy, and `wire_brain!`. It reimplements NO axiom op and assembles NO EU
+coefficients — every belief change is `condition` (inside the lifted `structure_observe`);
+every decision delegates to the engine's `decide_with_voi` (which maximises through the
+canonical typed `optimise`). The `.bdsl` files keep the DECLARED DATA (feature spaces,
+capabilities, utility constants).
 """
 module FeatureBrain
 
 using Main.Credence: StructureBMA, build_structure_model, build_structure_prior,
     build_structure_prior_dense, structure_observe, structure_observe_soft,
     structure_firing_tags, belief_at_context, context_from_features, structure_decision_kernel,
-    MixturePrevision, GammaPrevision, Identity, LinearCombination, TestFunction, Projection,
-    GeometricTail, FeatureDecl, Finite, expect, wrap_in_measure
-import Main.Credence.Ontology: optimise, net_voi, ProductMeasure, Measure
+    MixturePrevision, GammaPrevision, Identity,
+    GeometricTail, FeatureDecl, Finite, expect
+# The EU-max template lives in the engine stdlib (decouple Move 3): the app ships utility
+# scalars and SELECTS belief views, it does not assemble coefficients. No `optimise`/
+# `net_voi`/`LinearCombination`/`Projection`/`ProductMeasure` import remains — a grep of
+# this shim for those primitives is now empty, the leak-closed witness.
+import Main.Credence.Ontology: decide_with_voi
 using JSON3
 
 export StructureBMA, build_model, build_model_from_env, build_model_from_decls,
@@ -83,28 +89,16 @@ function _has_features(model::StructureBMA, features)
     all(haskey(fd, n) for n in model.feature_names)
 end
 
-# ── Decision: per-context EU-max with the (tail-aware) linear-cost utility ──
+# ── Decision: per-context EU-max via the engine's `decide_with_voi` template ──
 #
-# With θ = P(approve|X), per-call cost c (dollars), false-block aversion λ
-# (unitless: how many wrongly-blocked wanted-calls equal one allowed wasteful
-# call), interruption cost q (dollars), and m = `expected_repeats` (the posterior-
-# expected number of FURTHER identical calls a block prevents — the multi-turn
-# look-ahead; m=0 ⇒ the myopic per-call form), against a proceed baseline:
-#     EU(proceed) = 0
-#     EU(block)   = c·(1+m)·(1−θ) − λ·c·θ = c·(1+m) − c·[(1+m)+λ]·θ   (LinearCombination/Identity)
-#     EU(ask)     = voi − q                              (constant Functional)
-# Blocking a WASTE call saves the whole expected tail — (1+m) calls: this one plus m
-# more — whereas a wrongly-blocked WANTED call is not a loop, so its penalty stays λ·c
-# (one call's friction). Block wins iff θ < (1+m)/((1+m)+λ): m=0 recovers the λ-only
-# threshold 1/(1+λ) (c only scales the stakes); a large detected tail drives the cutoff
-# toward 1. The `ask` VOI is computed against the SAME tail-aware block payoff, so
-# resolving a likely-long loop is worth (1+m)× — an attention-precious (high-q) profile
-# asks about a loop it would myopically wave through. m enters ONLY as a Functional
-# coefficient; all three actions compare through the ONE canonical `optimise` (Invariant 1).
-
-const _ID = Identity()
-_lin(coeff::Float64, off::Float64) = LinearCombination(Tuple{Float64, TestFunction}[(coeff, _ID)], off)
-_const(off::Float64) = LinearCombination(Tuple{Float64, TestFunction}[], off)
+# The proceed/block/ask EU math — tail-aware linear-cost waste utility, optional harm
+# coordinate, VOI ask-gate — lives in the engine stdlib (`decide_with_voi`, src/stdlib.jl)
+# so it is byte-identical in-process and over the skin wire. The app's job here is only to
+# SELECT the per-context belief view(s) and pass the utility scalars; it assembles no
+# coefficients and calls no `optimise`/`net_voi` itself (the decouple Move-3 leak-close).
+# θ = P(approve|X); c = per-call cost; λ = false-block aversion; q = interrupt cost;
+# m = expected_repeats (the multi-turn look-ahead, `expect(continuation, GeometricTail())`,
+# m=0 ⇒ myopic). The coefficient algebra and its block-cutoff proof now live with the math.
 
 # Per-request profile override (the user's utility weights, shipped by the body PER REQUEST so a
 # user switches their trade-off with no daemon restart): the value for `key` if present, else the
@@ -114,57 +108,41 @@ _pget(profile, key::AbstractString, default::Float64)::Float64 =
         Float64(profile[key]) : default
 
 """
-    decide(model, top, X, cost; aversion, interrupt_cost, expected_repeats=0.0) -> Symbol
+    decide(model, top, X, cost; aversion, interrupt_cost, expected_repeats=0.0,
+           w_time=0.0, exp_time=0.0) -> Symbol
 
-Return `:proceed`, `:block`, or `:ask`. `cost` is the per-call USD estimate;
-`aversion` is λ (false-block aversion, unitless); `interrupt_cost` is q (dollars);
-`expected_repeats` is m — the posterior-expected number of further identical calls a
-block prevents (0 ⇒ the myopic per-call decision; supplied by the tail brain as
-`expect(continuation_belief, GeometricTail())`).
+Return `:proceed`, `:block`, or `:ask`. Selects the structure-BMA per-context belief
+view and delegates the EU-max to the engine's single-outcome `decide_with_voi` (no harm
+coordinate). `cost` is the per-call USD estimate; `aversion` is λ; `interrupt_cost` is q;
+`expected_repeats` is m — the tail a block prevents (0 ⇒ myopic; supplied by the tail
+brain as `expect(continuation_belief, GeometricTail())`).
 """
 function decide(model::StructureBMA, top::MixturePrevision, X::AbstractVector, cost::Float64;
                 aversion::Float64, interrupt_cost::Float64, expected_repeats::Float64 = 0.0,
                 w_time::Float64 = 0.0, exp_time::Float64 = 0.0)
     bx = belief_at_context(model, top, X)
-    tf = 1.0 + expected_repeats                       # expected calls a block prevents: this one + the tail
-    # TIME coordinate: a block also SAVES the call's wall-clock (E[time]·tf seconds), valued at
-    # w_time $/sec. Folds into the block offset next to the money saving c·tf. 0 ⇒ bit-identical.
-    tcost = w_time * exp_time * tf
-    block_fn = _lin(-cost * (tf + aversion), cost * tf + tcost)   # c·(1+m) + w_time·E[time]·(1+m) − c·[(1+m)+λ]·θ
-    fpa_pb = Dict{Symbol, LinearCombination}(:proceed => _const(0.0), :block => block_fn)
-    # EU(ask) = voi − q, computed through the canonical `net_voi` stdlib op (the
-    # cost subtraction lives in stdlib, not as host arithmetic here) and entered
-    # into `optimise` as a constant Functional so all three actions compare
-    # through the ONE argmax.
-    eu_ask = net_voi(bx, structure_decision_kernel(), [:proceed, :block], fpa_pb, [0, 1], interrupt_cost)
-    fpa = Dict{Symbol, LinearCombination}(:proceed => _const(0.0),
-                                          :block => block_fn,
-                                          :ask => _const(eu_ask))
-    optimise(bx, [:proceed, :block, :ask], fpa)
+    decide_with_voi(bx, structure_decision_kernel(); cost = cost, aversion = aversion,
+                    interrupt_cost = interrupt_cost, expected_repeats = expected_repeats,
+                    w_time = w_time, exp_time = exp_time)
 end
 
 # ── Multi-outcome decision: one EU integrating waste AND harm in one currency ──
 #
 # Two posteriors at decision time: θ_a = P(approve|Xw) (waste brain, live-learned) and
-# θ_u = P(unsafe|Xh) (harm brain, warm-frozen). With m = `expected_repeats` (the tail-aware
-# look-ahead — waste only; a harmful action is one-shot, not a repeated loop), proceed = 0
-# baseline (harm_cost H=0 AND m=0 recovers the single-outcome `decide` exactly):
-#     EU(proceed) = 0
-#     EU(block)   = c·(1+m)·[1 − θ_a] − cλθ_a + H·θ_u   (block avoids the waste TAIL and the harm)
-#     EU(ask)     = voi − q                              (VOI of the user resolving approve)
-# expressed as a LinearCombination over Projections of the JOINT belief (the constitution-
-# clean "one expect over the joint"; ProductMeasure + Projection are existing Tier-1 ops),
-# maximised by the ONE canonical `optimise`. Block beats proceed iff
-#     θ_a < (1+m)/((1+m)+λ) + H·θ_u/(c·[(1+m)+λ]) — the waste cutoff SLIDES with BOTH the harm
-# belief and the detected tail; no OR-of-thresholds can express it (eval/multi_outcome.jl +
-# REGEX_IMPOSSIBLE.md).
+# θ_u = P(unsafe|Xh) (harm brain, warm-frozen). A block avoids the waste TAIL ((1+m) calls)
+# and the harm (H·θ_u, one-shot). The waste cutoff θ_a < (1+m)/((1+m)+λ) + H·θ_u/(c·[(1+m)+λ])
+# SLIDES with BOTH the harm belief and the detected tail — no OR-of-thresholds can express it
+# (eval/multi_outcome.jl + REGEX_IMPOSSIBLE.md). The joint-belief EU assembly lives in the
+# engine's `decide_with_voi` (harm coordinate); here we only select the two views and pass H.
 """
     decide_multi(waste_model, top_waste, harm_model, harm_top, Xw, Xh, cost;
-                 aversion, interrupt_cost, harm_cost, expected_repeats=0.0) -> Symbol
+                 aversion, interrupt_cost, harm_cost, expected_repeats=0.0,
+                 w_time=0.0, exp_time=0.0) -> Symbol
 
-Multi-outcome EU decision over the joint of the approve-belief and the unsafe-belief, via
-the single canonical `optimise`. `harm_cost = 0` AND `expected_repeats = 0` reduce it to
-the single-outcome myopic `decide`. `expected_repeats` (m) scales only the waste tail.
+Multi-outcome EU decision over the joint of the approve-belief and the unsafe-belief.
+Delegates to the engine's `decide_with_voi` with the harm coordinate (`harm_belief`,
+`harm_cost = H`). `harm_cost = 0` AND `expected_repeats = 0` reduce it to the
+single-outcome `decide`. `expected_repeats` (m) scales only the waste tail.
 """
 function decide_multi(waste_model::StructureBMA, top_waste::MixturePrevision,
                       harm_model::StructureBMA, harm_top::MixturePrevision,
@@ -174,20 +152,9 @@ function decide_multi(waste_model::StructureBMA, top_waste::MixturePrevision,
                       w_time::Float64 = 0.0, exp_time::Float64 = 0.0)
     bxa = belief_at_context(waste_model, top_waste, Xw)   # P(approve|Xw)
     bxu = belief_at_context(harm_model, harm_top, Xh)     # P(unsafe|Xh)
-    joint = ProductMeasure(Measure[wrap_in_measure(bxa), wrap_in_measure(bxu)])
-    tf = 1.0 + expected_repeats        # expected calls a block prevents (waste tail; harm is one-shot)
-    tcost = w_time * exp_time * tf      # time a block saves (w_time $/sec × E[time]·tf); 0 ⇒ bit-identical
-    # EU(block) = c·(1+m)·[1−θ_a] + w_time·E[time]·(1+m) − cλθ_a + H·θ_u over the joint
-    block_fn = LinearCombination(Tuple{Float64, TestFunction}[
-        (-cost * (tf + aversion), Projection(1)), (harm_cost, Projection(2))], cost * tf + tcost)
-    # EU(ask): VOI of the user resolving approve, against the SAME tail+time-aware block payoff so
-    # asking about a likely-long loop inherits the (1+m)× value; a constant so all three
-    # actions compare through one optimise.
-    eu_ask = net_voi(bxa, structure_decision_kernel(), [:proceed, :block],
-                     Dict(:proceed => _const(0.0), :block => _lin(-cost * (tf + aversion), cost * tf + tcost)),
-                     [0, 1], interrupt_cost)
-    fpa = Dict(:proceed => _const(0.0), :block => block_fn, :ask => _const(eu_ask))
-    optimise(joint, [:proceed, :block, :ask], fpa)
+    decide_with_voi(bxa, structure_decision_kernel(); cost = cost, aversion = aversion,
+                    interrupt_cost = interrupt_cost, expected_repeats = expected_repeats,
+                    w_time = w_time, exp_time = exp_time, harm_belief = bxu, harm_cost = harm_cost)
 end
 
 # ── harm posterior persistence: version-stable per-context COUNTS ──

--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -1,6 +1,6 @@
 # Credence Skin Protocol
 
-Protocol-Version: 1.1
+Protocol-Version: 1.2
 
 JSON-RPC 2.0 over stdio. Skin reads newline-delimited JSON from stdin,
 writes newline-delimited JSON to stdout, logs to stderr.
@@ -13,6 +13,13 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
 
 ### Changelog
 
+- **1.2** — structure-BMA verbs: `structure_bma` (build the 2ⁿ-edge model + prior,
+  returning a separate `model_id` descriptor handle and a belief `state_id`),
+  `structure_observe` (learn per (context, response), in-place), and `structure_decide`
+  (the proceed/block/ask EU decision with an optional harm coordinate). All coefficient
+  arithmetic stays engine-side; the client ships only feature buckets and utility scalars.
+  Additive; no existing verb changes shape. See `structure_bma`/`structure_observe`/
+  `structure_decide` below.
 - **1.1** — `call_dsl` becomes a pure belief-function evaluator: a belief crosses
   the wire as a declarative `{type, params}` spec — reconstructed from a `call_dsl`
   arg (never registered) and emitted as a `call_dsl` return (no `state_id`). See
@@ -326,6 +333,81 @@ Sample from the measure. The only source of randomness.
 ```json
 {"result": {"value": 2}}
 ```
+
+## Structure-BMA (protocol 1.2)
+
+A non-embedding consumer drives Bayesian-model-averaged structure inference over
+feature→Bernoulli edges entirely through these verbs — no probability arithmetic
+client-side. The descriptor (feature vocabulary + the 2ⁿ structure enumeration) gets a
+**separate `model_id` handle** from the belief `state_id`: the descriptor carries no
+beliefs (Invariant 3). Contexts are sent as feature dicts `{name: bucket}`, validated
+against the declared buckets server-side (vocabulary drift fails loud).
+
+### structure_bma
+
+Build the 2ⁿ-edge model and its prior (a mixture over structures of `Beta(alpha0, beta0)`
+cells). Returns the descriptor handle and the prior belief handle.
+
+```json
+{"method": "structure_bma", "params": {
+  "feature_names": ["tool", "rep"],
+  "feature_values": [["bash", "read"], ["rep0", "rep3"]],
+  "alpha0": 2.0, "beta0": 2.0, "p_edge": 0.5
+}}
+```
+
+```json
+{"result": {"model_id": "m_1", "state_id": "s_1"}}
+```
+
+`alpha0`/`beta0`/`p_edge` are optional (default `2.0`/`2.0`/`0.5`).
+
+### structure_observe
+
+Learn one `(context, response)`: a single `condition` through the canalised path that
+reweights structures by the firing cell's chain-rule marginal likelihood. In-place — the
+belief `state_id` is unchanged.
+
+```json
+{"method": "structure_observe", "params": {
+  "model_id": "m_1", "state_id": "s_1",
+  "features": {"tool": "bash", "rep": "rep3"}, "observation": 1
+}}
+```
+
+```json
+{"result": {"state_id": "s_1"}}
+```
+
+`observation` is `1` (approve) or `0` (refuse).
+
+### structure_decide
+
+The proceed/block/ask EU decision at a context (engine stdlib `decide_with_voi`). The
+client ships only utility scalars; the engine assembles all coefficients, the VOI ask-gate,
+and the argmax. An optional `harm` object adds a second outcome (a separate harm model +
+belief + context) integrated in one EU.
+
+```json
+{"method": "structure_decide", "params": {
+  "model_id": "m_1", "state_id": "s_1",
+  "features": {"tool": "bash", "rep": "rep3"},
+  "cost": 1.0, "aversion": 1.0, "interrupt_cost": 0.5,
+  "expected_repeats": 0.0, "w_time": 0.0, "exp_time": 0.0,
+  "harm": {"model_id": "m_2", "state_id": "s_2",
+           "features": {"tool": "bash", "rep": "rep3"}, "harm_cost": 2.0}
+}}
+```
+
+```json
+{"result": {"action": "proceed"}}
+```
+
+`action` is `"proceed"`, `"block"`, or `"ask"`. `expected_repeats` (m, the multi-turn
+tail), `w_time`/`exp_time` (the wall-clock saving), and `harm` are optional; omitting all
+of them gives the myopic single-outcome decision. `belief_at_context` is intentionally not
+a verb — `structure_decide` consumes the per-context view internally and no consumer reads
+it across the wire.
 
 ## Program-Space Operations (Tier 2)
 

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -35,6 +35,9 @@ using Credence: aggregate_grammar_weights, top_k_grammar_ids, add_programs_to_st
 using Credence: next_grammar_id, reset_grammar_counter!
 using Credence: show_expr
 using Credence: log_density_at
+using Credence: StructureBMA, build_structure_model, build_structure_prior, structure_observe,
+                belief_at_context, context_from_features, structure_decision_kernel
+using Credence.Ontology: decide_with_voi
 
 using JSON3
 using Serialization
@@ -61,6 +64,28 @@ end
 function get_state(id::String)
     haskey(STATE_REGISTRY, id) || throw(StateNotFound(id))
     STATE_REGISTRY[id]
+end
+
+# Model registry: structural-analysis DESCRIPTORS (e.g. a `StructureBMA`) held under a
+# SEPARATE `m_*` handle from the `s_*` belief states (Invariant 3 / decouple Move-3 Q1 —
+# a descriptor carries no beliefs; conflating the two would let one mutate the other).
+const MODEL_REGISTRY = Dict{String, Any}()
+let counter = Ref(0)
+    global function next_model_id()
+        counter[] += 1
+        "m_$(counter[])"
+    end
+end
+
+function register_model(obj)
+    id = next_model_id()
+    MODEL_REGISTRY[id] = obj
+    id
+end
+
+function get_model(id::String)
+    haskey(MODEL_REGISTRY, id) || throw(StateNotFound(id))
+    MODEL_REGISTRY[id]
 end
 
 # ═══════════════════════════════════════
@@ -579,7 +604,7 @@ end
 # rides the `credence-skin` image tag). MAJOR bumps on a breaking protocol
 # change; MINOR on additive. Apps pin the major in code and `initialize`
 # rejects a mismatching major with -32010. See docs/decouple/master-plan.md.
-const PROTOCOL_VERSION = "1.1"
+const PROTOCOL_VERSION = "1.2"
 protocol_major(v) = String(first(split(String(v), ".")))
 
 # Advertised method set, returned by `initialize` for client capability
@@ -592,6 +617,7 @@ const SKIN_METHODS = [
     "perturb_grammar", "add_programs", "sync_prune", "sync_truncate",
     "top_grammars", "belief_summary", "condition_and_prune", "eu_interact",
     "call_dsl", "factor", "replace_factor", "n_factors",
+    "structure_bma", "structure_observe", "structure_decide",
 ]
 
 function handle_request(method::String, params, id)
@@ -621,6 +647,12 @@ function handle_request(method::String, params, id)
         handle_optimise(params)
     elseif method == "value"
         handle_value(params)
+    elseif method == "structure_bma"
+        handle_structure_bma(params)
+    elseif method == "structure_observe"
+        handle_structure_observe(params)
+    elseif method == "structure_decide"
+        handle_structure_decide(params)
     elseif method == "draw"
         handle_draw(params)
     elseif method == "enumerate"
@@ -1047,6 +1079,92 @@ function handle_value(params)
         best_eu = max(best_eu, eu)
     end
     Dict("value" => best_eu)
+end
+
+# ═══════════════════════════════════════
+# Structure-BMA verbs (decouple Move 3)
+#
+# A non-embedding consumer drives structure-BMA inference over the wire: build the
+# 2ⁿ-edge model + prior (`structure_bma`), learn per (context, response)
+# (`structure_observe`), and take the proceed/block/ask EU decision (`structure_decide`).
+# The descriptor gets a SEPARATE `model_id` handle from the belief `state_id` (Move-3 Q1).
+# ALL arithmetic — the chain-rule reweight, the EU coefficient assembly — is engine-side
+# (src/structure_bma.jl, src/stdlib.jl `decide_with_voi`); the verbs only marshal JSON,
+# so Invariant 1 holds across the wire by construction. `belief_at_context` is deliberately
+# NOT a verb: no consumer reads the per-context belief across the wire (Move-3 Q2).
+# ═══════════════════════════════════════
+
+# A features dict {name: bucket} → X (positional, validated against the model's declared
+# buckets; vocabulary drift fails loud rather than mis-routing).
+_structure_X(model, features) =
+    context_from_features(model, Dict(string(k) => string(v) for (k, v) in pairs(features)))
+
+function handle_structure_bma(params)
+    names = String[string(n) for n in params["feature_names"]]
+    values = Vector{String}[String[string(v) for v in vs] for vs in params["feature_values"]]
+    model = try
+        build_structure_model(names, values;
+                              alpha0 = Float64(get(params, "alpha0", 2.0)),
+                              beta0 = Float64(get(params, "beta0", 2.0)),
+                              p_edge = Float64(get(params, "p_edge", 0.5)))
+    catch e
+        _wrap_dsl("build_structure_model failed")(e)
+    end
+    Dict{String, Any}("model_id" => register_model(model),
+                      "state_id" => register_state(build_structure_prior(model)))
+end
+
+function handle_structure_observe(params)
+    model = get_model(string(params["model_id"]))
+    sid = string(params["state_id"])
+    top = get_state(sid)
+    X = try
+        _structure_X(model, params["features"])
+    catch e
+        _wrap_dsl("structure context build failed")(e)
+    end
+    obs = Int(params["observation"])
+    new_top = try
+        structure_observe(model, top, X, obs)
+    catch e
+        _wrap_inf("structure_observe failed")(e)
+    end
+    STATE_REGISTRY[sid] = new_top
+    Dict{String, Any}("state_id" => sid)
+end
+
+function handle_structure_decide(params)
+    model = get_model(string(params["model_id"]))
+    top = get_state(string(params["state_id"]))
+    # Belief view + optional harm coordinate (a second model+belief+context for the unsafe
+    # outcome). Context build is a protocol concern (vocabulary), so wrap as DSLError.
+    bx, harm_belief, harm_cost = try
+        bx0 = belief_at_context(model, top, _structure_X(model, params["features"]))
+        hb, hc = nothing, 0.0
+        if get(params, "harm", nothing) !== nothing
+            h = params["harm"]
+            hmodel = get_model(string(h["model_id"]))
+            htop = get_state(string(h["state_id"]))
+            hb = belief_at_context(hmodel, htop, _structure_X(hmodel, h["features"]))
+            hc = Float64(get(h, "harm_cost", 0.0))
+        end
+        (bx0, hb, hc)
+    catch e
+        _wrap_dsl("structure decision context build failed")(e)
+    end
+    action = try
+        decide_with_voi(bx, structure_decision_kernel();
+                        cost = Float64(params["cost"]),
+                        aversion = Float64(params["aversion"]),
+                        interrupt_cost = Float64(params["interrupt_cost"]),
+                        expected_repeats = Float64(get(params, "expected_repeats", 0.0)),
+                        w_time = Float64(get(params, "w_time", 0.0)),
+                        exp_time = Float64(get(params, "exp_time", 0.0)),
+                        harm_belief = harm_belief, harm_cost = harm_cost)
+    catch e
+        _wrap_inf("decide_with_voi failed")(e)
+    end
+    Dict{String, Any}("action" => string(action))
 end
 
 function handle_draw(params)

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -952,6 +952,87 @@ def test_replace_factor_identity_pin():
         skin.shutdown()
 
 
+# ── Structure-BMA verbs (decouple Move 3) ──
+
+
+def test_structure_bma_roundtrip():
+    """A non-embedding consumer drives structure-BMA inference over the wire only:
+    build model+prior (`structure_bma` → separate model_id/state_id), learn per
+    (context, response) (`structure_observe`, in-place), and decide proceed/block/ask
+    (`structure_decide`). Asserts the EU decision flips with the evidence, the ask-gate
+    responds to the interrupt cost, and the optional harm coordinate flips proceed→block —
+    all with ZERO probability arithmetic client-side (Invariant 1 across the wire)."""
+    skin = SkinClient()
+    try:
+        skin.initialize()
+
+        # 2 features (tool, rep) ⇒ 4 edge structures; Beta(2,2) cells ⇒ prior mean 0.5.
+        bma = skin._call("structure_bma", {
+            "feature_names": ["tool", "rep"],
+            "feature_values": [["bash", "read"], ["rep0", "rep3"]],
+            "alpha0": 2.0, "beta0": 2.0, "p_edge": 0.5,
+        })
+        mid, sid = bma["model_id"], bma["state_id"]
+        assert mid.startswith("m_") and sid.startswith("s_"), bma  # separate handles (Q1)
+
+        ctx = {"tool": "bash", "rep": "rep3"}
+        HUGE = 1.0e9   # interrupt cost that removes :ask from contention
+
+        def decide(state, c=1.0, lam=1.0, q=HUGE, harm=None):
+            p = {"model_id": mid, "state_id": state, "features": ctx,
+                 "cost": c, "aversion": lam, "interrupt_cost": q}
+            if harm is not None:
+                p["harm"] = harm
+            return skin._call("structure_decide", p)["action"]
+
+        # Fresh prior: θ = 0.5 ⇒ EU(block)=EU(proceed)=0 ⇒ :proceed wins the tie (first action).
+        assert decide(sid) == "proceed", "fresh prior should proceed at the tie"
+        # Free ask gate on the same uncertain belief ⇒ VOI > 0 ⇒ :ask.
+        assert decide(sid, q=0.0) == "ask", "uncertain belief + free gate should ask"
+
+        # Learn three refusals at this context ⇒ θ drops below 0.5 ⇒ :block. In-place: same sid.
+        for _ in range(3):
+            r = skin._call("structure_observe",
+                           {"model_id": mid, "state_id": sid, "features": ctx, "observation": 0})
+            assert r["state_id"] == sid, "structure_observe is in-place"
+        assert decide(sid) == "block", "after refusals θ < 0.5 should block"
+
+        # A FRESH model learning three approvals ⇒ θ > 0.5 ⇒ :proceed.
+        bma2 = skin._call("structure_bma", {
+            "feature_names": ["tool", "rep"],
+            "feature_values": [["bash", "read"], ["rep0", "rep3"]],
+        })
+        mid2, sid2 = bma2["model_id"], bma2["state_id"]
+        for _ in range(3):
+            skin._call("structure_observe",
+                       {"model_id": mid2, "state_id": sid2, "features": ctx, "observation": 1})
+        a2 = skin._call("structure_decide", {
+            "model_id": mid2, "state_id": sid2, "features": ctx,
+            "cost": 1.0, "aversion": 1.0, "interrupt_cost": HUGE})["action"]
+        assert a2 == "proceed", "after approvals θ > 0.5 should proceed"
+
+        # Optional harm coordinate: a separate harm model whose context is likely-unsafe
+        # (three "unsafe" labels ⇒ θ_u > 0.5) flips the would-be :proceed to :block.
+        harm = skin._call("structure_bma", {
+            "feature_names": ["tool", "rep"],
+            "feature_values": [["bash", "read"], ["rep0", "rep3"]],
+        })
+        hmid, hsid = harm["model_id"], harm["state_id"]
+        for _ in range(3):
+            skin._call("structure_observe",
+                       {"model_id": hmid, "state_id": hsid, "features": ctx, "observation": 1})
+        a3 = skin._call("structure_decide", {
+            "model_id": mid2, "state_id": sid2, "features": ctx,
+            "cost": 1.0, "aversion": 1.0, "interrupt_cost": HUGE,
+            "harm": {"model_id": hmid, "state_id": hsid, "features": ctx, "harm_cost": 5.0},
+        })["action"]
+        assert a3 == "block", "high harm belief should flip proceed→block"
+
+        print("PASS: structure-BMA verbs roundtrip (build / observe / decide + harm)")
+    finally:
+        skin.shutdown()
+
+
 # ── Wire-contract tests (decouple Move 0) ──
 
 
@@ -960,11 +1041,12 @@ def test_initialize_returns_contract():
     skin = SkinClient()
     try:
         result = skin.initialize()
-        assert result["protocol"] == "1.1", f"protocol: {result.get('protocol')}"
+        assert result["protocol"] == "1.2", f"protocol: {result.get('protocol')}"
         assert "version" in result, "engine version missing"
         methods = result["methods"]
-        # Core canalised verbs must be advertised for client capability discovery.
-        for verb in ("create_state", "condition", "expect", "optimise", "draw"):
+        # Core canalised verbs + the Move-3 structure-BMA verbs must be advertised.
+        for verb in ("create_state", "condition", "expect", "optimise", "draw",
+                     "structure_bma", "structure_observe", "structure_decide"):
             assert verb in methods, f"{verb} missing from advertised methods"
         print("PASS: initialize returns {protocol, version, methods}")
     finally:
@@ -1005,7 +1087,7 @@ def test_dsl_sources_inline_equivalent_to_path():
         # a subsequent call_dsl against the loaded env resolves (the path-based
         # test_router_roundtrip already covers the path branch).
         result = skin.initialize(dsl_sources={"router": source})
-        assert result["protocol"] == "1.1"
+        assert result["protocol"] == "1.2"
         print("PASS: inline dsl_sources loads equivalently to a path load")
     finally:
         skin.shutdown()
@@ -1109,5 +1191,7 @@ if __name__ == "__main__":
     test_dsl_sources_inline_equivalent_to_path()
     print()
     test_call_dsl_belief_roundtrip()
+    print()
+    test_structure_bma_roundtrip()
     print()
     print("All tests passed!")

--- a/docs/decouple/move-3-design.md
+++ b/docs/decouple/move-3-design.md
@@ -1,0 +1,244 @@
+# Decouple Move 3 — credence-pi separable refit
+
+Design doc per `docs/posture-4/DESIGN-DOC-TEMPLATE.md` (adapted for `decouple`, as
+Move 2 did). Goal: make credence-pi **able to live in a separate repo** by moving its
+brain math behind the skin wire.
+
+## 0. Final-state alignment
+
+Converges the tip toward `docs/decouple/master-plan.md` §"Final-state architecture":
+credence-pi becomes *data + a thin body* that drives the engine over the wire, rather
+than a co-released image that embeds Credence in-process. The substrate is already
+right — `SparseStructurePrevision` and its conditioning (FiringByTag routing + 2ⁿ
+mixture reweight) are Tier-1 today (`src/prevision.jl:310`, `src/sparse_structure.jl`,
+exported `src/ontology.jl:45`); `apps/credence-pi/brain/feature_brain.jl` reimplements
+no axiom op. This move lifts the **builder/wrapper + decision** layer (StructureBMA,
+`build_prior`, `observe`, `belief_at_context`, the EU template) from the app into
+engine stdlib and exposes it over the wire, so a non-embedding client can run the
+full brain.
+
+**Transient state left explicit (not drift):** (a) the daemon still *embeds*
+(`apps/credence-pi/daemon/main.jl` `using Credence`) after this move — the move makes
+embedding *optional* by giving a wire path; the literal repo extraction is a
+follow-on (named in §6). (b) `feature_brain.jl` does **not** dissolve here — it
+becomes a thin shim that keeps genuine credence-pi *domain* wiring (the harm/tail/
+latency opt-in plumbing, the ask-vs-block effector policy, the per-request profile
+override) and delegates the model/decision math to the lifted stdlib. (c) The
+decision verb owns `net_voi` because no `voi`/`net_voi` verb exists on the wire today
+(`apps/skin/server.jl:588` `SKIN_METHODS`); this is the only place the EU is assembled.
+
+## 1. Purpose
+
+Promote credence-pi's structure-BMA brain into engine stdlib (`src/structure_bma.jl`)
+and a typed EU decision template (`src/stdlib.jl`), then expose both over the skin
+wire as `structure_bma` / `structure_observe` / `belief_at_context` / `structure_decide`,
+so the credence-pi daemon can drive every belief update and decision through JSON-RPC
+with **zero probability/utility arithmetic in the body** — the precondition for
+credence-pi living in its own repo.
+
+## 2. Files touched
+
+### Created
+- `docs/decouple/move-3-design.md` — this doc.
+- `src/structure_bma.jl` — the lifted builder: `StructureBMA` descriptor,
+  `build_model`/`build_model_from_decls`, `build_prior`/`build_prior_dense`,
+  `context_from_features`, `firing_tags`, `structure_observe` (today's `observe`),
+  `belief_at_context`. Compositions over existing `SparseStructurePrevision` /
+  `condition` / `with_components` (`src/stdlib.jl:98`); **no new frozen type, no new
+  axiom-constrained function.** Included after `stdlib.jl` (`src/ontology.jl:1696`).
+- `test/test_structure_bma.jl` — exact-oracle: lifted `build_prior`/`structure_observe`
+  reproduce the in-app values bit-for-bit; sparse≡dense (mirrors
+  `test/test_sparse_structure_equivalence.jl`); per-context routing
+  (mirrors `test/test_product_bma_routing.jl`).
+- `test/test_decision_template.jl` — exact-oracle for the EU template: the assembled
+  block/ask/proceed EUs equal the hand-computed `c·(1+m)−c·[(1+m)+λ]·θ` / `voi−q` /
+  multi-outcome `+H·θ_u` at rtol ~1e-12; reduces to single-outcome at `H=0,m=0`.
+- `apps/skin/tests` smoke case (in `apps/skin/test_skin.py`): the §4 wire trace.
+
+### Modified
+- `src/stdlib.jl` — the typed EU decision template `decide_with_voi(...)` (peer of
+  `voi`:154 / `net_voi`:167), taking typed utility slots (cost, λ, q, H, m, time) +
+  the belief view, assembling the `LinearCombination`/`Projection` Functionals,
+  folding `net_voi` as the `ask` action, and returning the `optimise` argmax. One op
+  with an **optional harm coordinate** (multi-outcome when present); `H=0,m=0` reduces
+  to the myopic single-outcome form (see §5 Q3).
+- `src/ontology.jl:1696` (+1) — `include("structure_bma.jl")`; export the lifted names.
+- `src/Credence.jl` — re-export `StructureBMA`, `build_model`, `build_prior`,
+  `structure_observe`, `belief_at_context`, `decide_with_voi`.
+- `apps/skin/server.jl` — four verbs in `SKIN_METHODS` (:588) + handlers: a
+  **model registry** (descriptor handle, §5 Q1) keyed separately from `STATE_REGISTRY`;
+  `structure_bma` (build_model + build_prior → `{model_id, state_id}`);
+  `structure_observe` (`{model_id, state_id, context, observation}` → in-place
+  `condition`, returns `{state_id, log_marginal}`); `belief_at_context`
+  (`{model_id, state_id, context}` → `with_components` view → `{state_id}`);
+  `structure_decide` (`{model_id, state_id, context, utility:{cost,lambda,q,harm,...},
+  harm_model_id?, harm_state_id?, harm_context?}` → `decide_with_voi` → `{action}`).
+  `PROTOCOL_VERSION` (:582) `1.1`→`1.2`.
+- `apps/skin/protocol.md` — `Protocol-Version: 1.2` + changelog; document the four
+  verbs, the model-handle lifecycle, and the typed utility-slot shape.
+- `apps/credence-pi/brain/feature_brain.jl` — becomes a **thin shim**: `build_model`/
+  `build_prior`/`observe`/`belief_at_context`/the structure types re-export from the
+  engine; `wire_brain!`, the harm/tail/latency opt-in plumbing (:484-570), the
+  effector policy (:590-606), and the per-request profile override (:345-347) stay.
+  `decide`/`decide_multi` (:358-424) call `decide_with_voi` instead of assembling
+  coefficients inline.
+- `apps/credence-pi/daemon/server.jl` — `decide-action`/`observe-response` route
+  through the wire verbs (or the lifted stdlib for the embedded co-released path);
+  no behavioural change.
+- `docs/decouple/master-plan.md` — Move-3 row: mark lift + verbs done; note the
+  separate-repo extraction as the enabled follow-on.
+
+### Not touched (explicit non-goals)
+- No actual extraction of credence-pi to a separate git repo (this move *enables* it).
+- No `serve_http` for the skin (stdio engine wire stands; the daemon's own HTTP/SSE is
+  the co-released product surface, unchanged).
+- No new frozen type; `SparseStructurePrevision` already exists.
+- No TS wire-client change (`openclaw-plugin/src/daemon-client.ts` already speaks the
+  daemon's HTTP/SSE and carries no math; it is unaffected by the skin-verb additions).
+
+## 3. Behaviour preserved
+
+- **`structure_observe` ≡ `feature_brain.observe` bit-for-bit.** The lifted function
+  is the same `condition(top, FiringByTag(BetaBernoulli,Flat), obs)` call; the
+  warm-posterior reconstruction from `apps/credence-pi/brain/warm_brain.counts.json`
+  (and `harm_brain.counts.json`) via `reconstruct_posterior` must yield identical
+  weights to the pre-lift path. `test/test_structure_bma.jl` pins this.
+- **Sparse ≡ dense** preserved (`test/test_sparse_structure_equivalence.jl` extended
+  to the lifted builders).
+- **`decide_with_voi` ≡ inline `decide`/`decide_multi`.** The template assembles the
+  identical `block_fn`/`eu_ask`/`fpa` and calls the same `optimise`; the multi-outcome
+  joint is the same `ProductMeasure[wrap_in_measure(bxa), wrap_in_measure(bxu)]`.
+  `apps/credence-pi/tests/julia/test_feature_brain.jl` +
+  `apps/credence-pi/tests/julia/test_harm_governance.jl` must pass unmodified; the
+  ClawsBench decisions (`apps/credence-pi/eval/`) are unchanged through the new path.
+- **Skin backward-compat:** the four verbs are additive; existing verbs and
+  `test_skin.py` cases are unchanged except the `1.1`→`1.2` protocol assertion.
+
+## 4. Worked end-to-end example
+
+Wire trace (stdio; the body holds no math, no belief state):
+
+```
+-> {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol":"1","dsl_sources":{"pi":"<features.bdsl + utility.bdsl>"}}}
+<- {"jsonrpc":"2.0","id":1,"result":{"version":"0.1.0","protocol":"1.2","methods":[...]}}
+
+; build the structure-BMA model + prior from declared features
+-> {"jsonrpc":"2.0","id":2,"method":"structure_bma","params":{"features":[{"name":"tool","values":["bash","read"]},{"name":"repeat","values":["novel","repeated"]}],"p_edge":0.5,"alpha0":2.0,"beta0":2.0}}
+<- {"jsonrpc":"2.0","id":2,"result":{"model_id":"m_1","state_id":"s_1","n_components":4}}   ; 2^2 structures
+
+; learn on one (context, approve/deny)
+-> {"jsonrpc":"2.0","id":3,"method":"structure_observe","params":{"model_id":"m_1","state_id":"s_1","context":["bash","repeated"],"observation":0}}
+<- {"jsonrpc":"2.0","id":3,"result":{"state_id":"s_1","log_marginal":-0.69}}               ; in-place; structures reweighted
+
+; decide on a context, shipping ONLY utility data
+-> {"jsonrpc":"2.0","id":4,"method":"structure_decide","params":{"model_id":"m_1","state_id":"s_1","context":["bash","repeated"],"utility":{"cost":0.5,"lambda":1.0,"q":0.02,"expected_repeats":0.0}}}
+<- {"jsonrpc":"2.0","id":4,"result":{"action":"block"}}
+```
+
+Module ownership of id:4:
+1. `server.jl` `structure_decide` handler looks up descriptor `m_1` + belief `s_1`.
+2. `belief_at_context(model, top, X)` (`src/structure_bma.jl`) → the transient view via
+   `with_components` (`src/stdlib.jl:98`). No arithmetic.
+3. `decide_with_voi(view, utility…)` (`src/stdlib.jl`) assembles `block_fn =
+   LinearCombination([(-cost·(1+m+λ), Identity)], cost·(1+m))`, folds `net_voi`
+   (`src/stdlib.jl:167`) as the `ask` constant, and returns `optimise(view,
+   [:proceed,:block,:ask], fpa)`.
+4. `:block` symbol serialises out. The body never saw θ, a coefficient, or a Functional.
+
+## 5. Open design questions
+
+1. **Descriptor handle vs. self-describing state.** `structure_observe` needs the
+   `StructureBMA` descriptor (2ⁿ structures + `cell_tag`/`tag_lo`/`tag_hi`) to compute
+   `firing_tags(X)` and the per-cell tags; the belief itself is the `MixturePrevision`.
+   These are the *two Invariant-3 representations* (structural-analysis vs. belief). Do
+   we (i) return a **separate `model_id`** (a model registry) alongside the belief
+   `state_id` — clean separation, but the wire carries two handles per call — or (ii)
+   fold routing metadata into the prevision so the state self-describes — one handle,
+   but conflates the two representations? *Lean (i): the Invariant-3 separation is the
+   whole reason `CompiledKernel`/`Program` are split; the wire should reflect it. The
+   two-handle ergonomic cost is small and the body never inspects either.*
+
+2. **`belief_at_context` as a verb at all.** `structure_decide` builds the view
+   *server-side* (no wire round-trip). Is a separate `belief_at_context` *verb* worth
+   it? *Lean: yes, but only for read-back* — shadow-mode logging and calibration want
+   the per-context approval belief (`weights`/`mean`), and exposing the view as a
+   `state_id` lets the existing `weights`/`expect` verbs read it. The hot decision path
+   does **not** route through the wire-level verb (avoids a round-trip). Confirm we're
+   not paying for a verb only telemetry uses — alternative: fold it into a
+   `belief_summary`-style read.
+
+3. **One decision template or two.** `decide`/`decide_multi` are two functions today;
+   `decide_multi` provably reduces to `decide` at `H=0, m=0`
+   (`feature_brain.jl:399-401`). Should `decide_with_voi` be **one** op with an optional
+   harm coordinate (build the `ProductMeasure` joint only when harm features are
+   present), or two ops? *Lean: one op.* The reduction is exact, the harm term is one
+   extra `Projection(2)` in the same `LinearCombination`, and one op is one verb. Risk:
+   the single-outcome path must stay bit-identical (the joint is *not* constructed when
+   harm is absent) — pinned by the `H=0,m=0` reduction test.
+
+4. **Where the EU template lives.** `decide_with_voi` as a typed `src/stdlib.jl` op
+   (peer of `voi`/`net_voi`) vs. a skin-only helper. *Lean: stdlib op* — it is reusable
+   decision machinery (any consumer with a linear-block-EU + VOI-ask shape wants it),
+   and the constitution puts decision composition in the canalised stdlib, not in the
+   wire layer. The skin verb is then a thin adapter, mirroring how `optimise` is.
+
+## 6. Risk + mitigation
+
+- **Lift drift.** The lifted `build_prior`/`structure_observe` must equal the in-app
+  versions exactly. Mitigation: `test/test_structure_bma.jl` asserts bit-for-bit warm-
+  posterior reconstruction from the committed `*.counts.json`; the app shim re-exports
+  the engine functions (single source), so there is no second copy to drift.
+- **Single-outcome regression via the merged template.** Q3's one-op design risks
+  perturbing the single-outcome decision. Mitigation: the `H=0,m=0` reduction test +
+  unmodified `test_feature_brain.jl`/`test_harm_governance.jl` + ClawsBench decision
+  parity.
+- **Model-handle lifecycle.** A `model_id` registry adds a second server-side lifetime
+  to manage (create/destroy) beside `STATE_REGISTRY`. Mitigation: tie `model_id`
+  destruction to `shutdown`/explicit `destroy`; the descriptor is immutable (built
+  once), so no mutation hazard.
+- **Protocol bump.** `1.1`→`1.2`; the smoke-build version grep is already version-
+  agnostic (Move 2 fix), and the header==const unit invariant pins the exact value.
+- **Review-process.** The named-template decision (Q2 in the plan) was settled with
+  Guy; this doc records it and opens the genuinely-undecided tactics above.
+
+## 7. Verification cadence
+
+`julia test/test_structure_bma.jl` + `test/test_decision_template.jl` +
+`test/test_sparse_structure_equivalence.jl` + `test/test_product_bma_routing.jl`;
+`julia apps/credence-pi/tests/julia/test_feature_brain.jl` +
+`test_harm_governance.jl` + `test_server.jl` (unchanged through the lift);
+`python -m apps.skin.test_skin` (four-verb smoke + `1.2` + backward compat);
+`credence-lint` corpus + `check apps/` (the shim + daemon read no accessor / do no
+arithmetic — they call lifted ops); the ClawsBench eval (`apps/credence-pi/eval/`)
+decisions unchanged; `docker build -f apps/credence-pi/daemon/Dockerfile` boots and a
+stdio `structure_bma`→`structure_observe`→`structure_decide` round-trip succeeds.
+
+## 8. de Finettian discipline self-audit
+
+1. **Every numerical query through `expect`?** Yes. `structure_observe` →
+   `condition`; `belief_at_context` → `with_components` (no arithmetic);
+   `decide_with_voi` → `net_voi`/`optimise` (both route through `expect`). The
+   `_structure_logweights` prior is declarative *construction* of log-weights (data),
+   not a query of a prevision.
+2. **Prevision-in-Measure / Measure-in-Prevision?** The multi-outcome path builds
+   `ProductMeasure[wrap_in_measure(bxa), wrap_in_measure(bxu)]` — a Measure holding the
+   sanctioned Measure *view* over each Prevision (the existing `decide_multi` shape);
+   no Prevision holds a Measure. **Yes.**
+3. **Opaque closure where declared structure fits?** No. The template takes typed
+   utility slots and builds declared `LinearCombination`/`Projection` Functionals;
+   `StructureBMA` is a declared descriptor, the kernels are `FiringByTag(BetaBernoulli,
+   Flat)`. **Yes.**
+4. **`getproperty` override on a Prevision subtype?** No. `StructureBMA` is a plain
+   descriptor struct, not a Prevision; no shield added. **Yes.**
+
+---
+
+## Reviewer checklist
+- [ ] §0 names the still-embedding daemon, the thin-shim `feature_brain.jl`, and the
+      net_voi-in-decision-verb as explicit transient state.
+- [ ] §5 questions are tactical (handle shape, verb surface, one-vs-two template), not
+      master-plan re-litigation.
+- [ ] §8 returns yes-or-justified on all four.
+- [ ] file:line citations resolve against the `decouple/credence-pi` tip.
+- [ ] No follow-up move needed to retract this one (the repo extraction is *enabled*,
+      not *required-to-fix*).

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -55,6 +55,7 @@ export push_component!, replace_component!, FrozenVectorView
 export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal, wrap_in_measure
 export ConjugatePrevision, maybe_conjugate, update
+export StructureBMA, build_structure_model, build_structure_prior, build_structure_prior_dense, structure_observe, structure_observe_soft, belief_at_context, context_from_features, structure_firing_tags, structure_decision_kernel
 export draw
 export weights, mean, variance, probability, marginal, prune, truncate, logsumexp
 export WeightsDomainError

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1695,4 +1695,15 @@ include("sparse_structure.jl")
 # ================================================================
 include("stdlib.jl")
 
+# ================================================================
+# Structure-BMA builder + observe + readout (lifted from the credence-pi app brain —
+# decouple Move 3). Compositions over the above (SparseStructurePrevision / condition /
+# with_components); no new frozen type, no new axiom-constrained function.
+# ================================================================
+include("structure_bma.jl")
+export StructureBMA, build_structure_model, build_structure_prior,
+       build_structure_prior_dense, structure_observe, structure_observe_soft,
+       belief_at_context, context_from_features, structure_firing_tags,
+       structure_decision_kernel
+
 end # module Ontology

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -166,3 +166,56 @@ end
 # net-voi: VOI minus the cost of observing — the `ask`-gate EU.
 net_voi(belief, k::Kernel, actions, fpa::AbstractDict, possible_obs, cost) =
     voi(belief, k, actions, fpa, possible_obs) - cost
+
+# ── decide_with_voi: the proceed/block/ask EU decision template ──
+#
+# One typed decision primitive over the canonical three actions (proceed/block/ask),
+# parameterised by utility DATA. It is the engine-side home of the EU coefficient
+# assembly that used to live in the credence-pi app brain (`decide`/`decide_multi`);
+# lifting it here is what lets a non-embedding consumer drive the decision over the
+# wire (a wire client ships the scalars, the engine does all the arithmetic —
+# Invariant 1 by construction). The math:
+#
+#   tf = 1 + m   (expected calls a block prevents: this one + the look-ahead tail m)
+#   EU(proceed) = 0                                                  (the baseline)
+#   EU(block)   = c·tf − c·[tf+λ]·θ_a + w_time·E[time]·tf  [+ H·θ_u] (waste tail [+ harm])
+#   EU(ask)     = net_voi(θ_a) − q                       (EVPI of the user resolving θ_a)
+#
+# expressed as `LinearCombination` Functionals maximised by the ONE canonical
+# `optimise`. With no harm coordinate the block payoff is `Identity` over the approve
+# belief; with one, it is `Projection`s over the `ProductMeasure` joint (approve, unsafe).
+# `harm_belief === nothing` AND `expected_repeats == 0` AND `w_time == 0` reduce it
+# bit-for-bit to the single-outcome myopic decision (asserted in test_decide_with_voi.jl).
+# `decision_kernel` is the consumer's Bernoulli decision kernel (e.g. the structure-BMA
+# `structure_decision_kernel()`); the template carries no domain specifics.
+
+const _ID = Identity()
+_lin(coeff::Float64, off::Float64) = LinearCombination(Tuple{Float64, TestFunction}[(coeff, _ID)], off)
+_const(off::Float64) = LinearCombination(Tuple{Float64, TestFunction}[], off)
+
+function decide_with_voi(approve_belief, decision_kernel::Kernel;
+                         cost::Float64, aversion::Float64, interrupt_cost::Float64,
+                         expected_repeats::Float64 = 0.0,
+                         w_time::Float64 = 0.0, exp_time::Float64 = 0.0,
+                         harm_belief = nothing, harm_cost::Float64 = 0.0)
+    tf = 1.0 + expected_repeats                       # calls a block prevents: this one + the tail m
+    tcost = w_time * exp_time * tf                    # wall-clock a block saves (w_time $/sec × E[time]·tf)
+    # EU(ask) = net_voi − q against the SAME tail+time-aware block payoff, so resolving a
+    # likely-long loop inherits the (1+m)× value. The VOI is always over the approve belief
+    # alone — a harmful action is one-shot, so "should I let this through?" is the EVPI question.
+    ask_block = _lin(-cost * (tf + aversion), cost * tf + tcost)
+    eu_ask = net_voi(approve_belief, decision_kernel, [:proceed, :block],
+                     Dict(:proceed => _const(0.0), :block => ask_block), [0, 1], interrupt_cost)
+    if harm_belief === nothing
+        # Single-outcome: block payoff is the Identity-based ask_block over the approve belief.
+        fpa = Dict(:proceed => _const(0.0), :block => ask_block, :ask => _const(eu_ask))
+        return optimise(approve_belief, [:proceed, :block, :ask], fpa)
+    end
+    # Multi-outcome: one EU integrating waste AND harm in one currency, over the joint
+    # (approve, unsafe). The waste cutoff slides with the harm belief AND the detected tail.
+    joint = ProductMeasure(Measure[wrap_in_measure(approve_belief), wrap_in_measure(harm_belief)])
+    block_fn = LinearCombination(Tuple{Float64, TestFunction}[
+        (-cost * (tf + aversion), Projection(1)), (harm_cost, Projection(2))], cost * tf + tcost)
+    fpa = Dict(:proceed => _const(0.0), :block => block_fn, :ask => _const(eu_ask))
+    optimise(joint, [:proceed, :block, :ask], fpa)
+end

--- a/src/structure_bma.jl
+++ b/src/structure_bma.jl
@@ -1,0 +1,239 @@
+# structure_bma.jl — the structure-BMA builder + observe + readout, lifted into
+# engine stdlib (decouple Move 3). Compositions over existing Tier-1 objects
+# (`SparseStructurePrevision`/`condition`/`with_components`); NO new frozen type and
+# NO new axiom-constrained function. Previously lived in
+# apps/credence-pi/brain/feature_brain.jl (a co-released app brain); promoted here so
+# a separable, non-embedding consumer can drive structure inference over the skin wire.
+#
+# Structure-BMA over Bayesian-network edges (feature → a Bernoulli leaf): a mixture over
+# the 2ⁿ parent subsets, each a sparse product of Beta cells. Conditioning reweights
+# the structures by the firing cell's chain-rule marginal likelihood (the Occam work),
+# learns the firing cell, and leaves the rest untouched.
+#
+# Two representations kept separate (Invariant 3):
+#   * the persistent belief — a `MixturePrevision` over the 2ⁿ structures, each a
+#     `SparseStructurePrevision` of `TaggedBeta` cells; learning conditions THIS.
+#   * the `StructureBMA` descriptor — the structural-analysis representation (feature
+#     vocabulary, the 2ⁿ enumeration, the per-cell tag bookkeeping) used to build the
+#     prior, route observations, and select the per-context decision view. It is NOT a
+#     Prevision; it carries no beliefs.
+
+# ── The descriptor: feature spec + structure enumeration + tag bookkeeping ──
+#
+# A `structure` is a subset of feature indices — the parents of the leaf (edges INTO
+# the leaf). Each structure has one cell per element of the cross-product of its
+# parents' value-sets; every cell carries a GLOBALLY-UNIQUE integer tag so a single
+# per-context `FiringByTag` kernel routes correctly through the whole nested object
+# (within each structure exactly one cell's tag fires).
+
+struct StructureBMA
+    feature_names::Vector{String}
+    feature_values::Vector{Vector{String}}     # per feature, its value-set as strings
+    structures::Vector{Vector{Int}}            # the 2ⁿ parent-index subsets
+    cell_tag::Vector{Dict{Tuple, Int}}         # per structure: cell-key (parent values) -> tag
+    tag_lo::Vector{Int}                        # per structure: lowest cell tag (contiguous)
+    tag_hi::Vector{Int}                        # per structure: highest cell tag
+    n_features::Int
+    alpha0::Float64
+    beta0::Float64
+    p_edge::Float64
+end
+
+# The cell key for context X under a structure = the tuple of X's values at the
+# structure's parents, in parent order. Empty parents ⇒ `()` (the global cell).
+cell_key(parents::Vector{Int}, X::AbstractVector) = Tuple(X[f] for f in parents)
+
+# Enumerate the cell-context keys (tuples of parent values) for a structure, in a
+# deterministic order (matches `cell_key`'s parent ordering).
+function _cell_contexts(parents::Vector{Int}, feature_values::Vector{Vector{String}})
+    isempty(parents) && return Tuple[()]
+    keys = Tuple[()]
+    for f in parents
+        keys = Tuple[(k..., v) for k in keys for v in feature_values[f]]
+    end
+    keys
+end
+
+"""
+    build_structure_model(feature_names, feature_values; alpha0, beta0, p_edge) -> StructureBMA
+
+Enumerate all 2ⁿ edge structures, allocate a globally-unique tag per cell. Pure
+construction of the declared structure family; no beliefs yet.
+"""
+function build_structure_model(feature_names::Vector{String}, feature_values::Vector{Vector{String}};
+                               alpha0::Float64 = 2.0, beta0::Float64 = 2.0, p_edge::Float64 = 0.5)
+    n = length(feature_names)
+    length(feature_values) == n || error("build_structure_model: names/values length mismatch")
+    structures = Vector{Int}[]
+    for mask in 0:(2^n - 1)
+        push!(structures, [i for i in 1:n if (mask >> (i - 1)) & 1 == 1])
+    end
+    cell_tag = Dict{Tuple, Int}[]
+    tag_lo = Int[]
+    tag_hi = Int[]
+    tag = 0
+    for parents in structures
+        d = Dict{Tuple, Int}()
+        lo = tag + 1                  # tags are contiguous per structure
+        for cell in _cell_contexts(parents, feature_values)
+            tag += 1
+            d[cell] = tag
+        end
+        push!(cell_tag, d)
+        push!(tag_lo, lo)
+        push!(tag_hi, tag)
+    end
+    StructureBMA(feature_names, feature_values, structures, cell_tag, tag_lo, tag_hi,
+                 n, alpha0, beta0, p_edge)
+end
+
+# (The `FeatureDecl`-reading constructor `build_model_from_decls` stays app-side in the
+# credence-pi shim: `FeatureDecl` is an eval-layer type included after this module, and
+# reading a BDSL env is consumer wiring, not engine machinery.)
+
+# Structure-inclusion log-weights (independent edge-inclusion at p_edge; uniform when
+# p_edge = 0.5). Shared by the sparse and dense priors.
+_structure_logweights(model::StructureBMA) =
+    Float64[length(parents) * log(model.p_edge) +
+            (model.n_features - length(parents)) * log(1.0 - model.p_edge)
+            for parents in model.structures]
+
+"""
+    build_structure_prior(model) -> MixturePrevision
+
+The structure-BMA prior: a mixture over structures, each a SPARSE product of
+`Beta(alpha0, beta0)` cells (`SparseStructurePrevision` — only observed cells are
+materialised). Bit-identical to `build_structure_prior_dense` but O(structures) to
+build and to condition, so the brain scales to many features.
+"""
+function build_structure_prior(model::StructureBMA)
+    comps = Prevision[SparseStructurePrevision(model.alpha0, model.beta0,
+                                               model.tag_lo[s], model.tag_hi[s],
+                                               Dict{Int, BetaPrevision}())
+                      for s in eachindex(model.structures)]
+    MixturePrevision(comps, _structure_logweights(model))
+end
+
+"""
+    build_structure_prior_dense(model) -> MixturePrevision
+
+The DENSE reference prior: each structure a full `ProductPrevision` of
+`TaggedBetaPrevision` cells. Materialises the entire cross-product (exponential), so it
+is used only as the exactness reference for `build_structure_prior` and by tests that
+inspect cell internals via `.factors`.
+"""
+function build_structure_prior_dense(model::StructureBMA)
+    comps = Prevision[]
+    for (s, parents) in enumerate(model.structures)
+        factors = TaggedBetaPrevision[]
+        for cell in _cell_contexts(parents, model.feature_values)
+            push!(factors, TaggedBetaPrevision(model.cell_tag[s][cell],
+                                               BetaPrevision(model.alpha0, model.beta0)))
+        end
+        push!(comps, ProductPrevision(factors))
+    end
+    MixturePrevision(comps, _structure_logweights(model))
+end
+
+# ── Context plumbing ──
+
+"""
+    context_from_features(model, features) -> Vector{String}
+
+Map a feature dict (string→bucket-string) to X, indexed by the model's feature order.
+Validates each value is a declared bucket (a contract violation fails loud rather than
+`KeyError`-ing deep in routing).
+"""
+function context_from_features(model::StructureBMA, features)
+    fd = Dict{String, String}(string(k) => string(v) for (k, v) in features)
+    X = String[]
+    for (i, name) in enumerate(model.feature_names)
+        haskey(fd, name) || error("structure-bma: event missing declared feature '$name'")
+        v = fd[name]
+        v in model.feature_values[i] ||
+            error("structure-bma: feature '$name' value '$v' is not a declared bucket " *
+                  "($(model.feature_values[i])) — vocabulary drift")
+        push!(X, v)
+    end
+    X
+end
+
+# F(X): one matching cell-tag per structure (globally unique ⇒ a single Set routes the
+# whole nested object).
+structure_firing_tags(model::StructureBMA, X::AbstractVector) =
+    Set{Int}(model.cell_tag[s][cell_key(parents, X)] for (s, parents) in enumerate(model.structures))
+
+# Measure-aware Bernoulli log-density: takes the cell MEASURE and returns the cell's
+# marginal log-predictive.
+_approve_logdensity(m, o) = (a = mean(m.beta); o == 1 ? log(a) : log(1.0 - a))
+
+# Per-context LEARNING kernel: BetaBernoulli on the cells in F(X), Flat (no-op)
+# elsewhere. `condition(top, this, obs)` updates each structure's cell-for-X and
+# reweights structures by the firing cell's predictive = the chain-rule marginal
+# likelihood.
+_learn_kernel(fires::Set{Int}) =
+    Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta, _approve_logdensity;
+           likelihood_family = FiringByTag(fires, BetaBernoulli(), Flat()))
+
+# DECISION kernel: a plain BetaBernoulli (every component of the per-context view IS the
+# relevant cell, so all fire). Used only inside `voi`/`net_voi` on a `belief_at_context`
+# view. Exported so a consumer's decision path can reach it without re-deriving it.
+structure_decision_kernel() =
+    Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta, _approve_logdensity;
+           likelihood_family = BetaBernoulli())
+
+"""
+    structure_observe(model, top, X, obs) -> MixturePrevision
+
+Bayesian update of the persistent belief on one `(context, response)`: a single
+`condition` through the canalised path. `obs` is 1 or 0.
+"""
+structure_observe(model::StructureBMA, top::MixturePrevision, X::AbstractVector, obs) =
+    condition(top, _learn_kernel(structure_firing_tags(model, X)), obs)
+
+# Soft-evidence log-density: the firing cell's predictive marginal under virtual
+# evidence with likelihoods (r, w) = (P(S|label=1), P(S|label=0)).
+_soft_logdensity(m, obs) = (a = mean(m.beta); r = obs[1]; w = obs[2];
+                            log(max(r * a + w * (1.0 - a), 1e-300)))
+
+# Per-context SOFT-EVIDENCE learning kernel: SoftBernoulli on the cells in F(X), Flat
+# elsewhere (the mean-exact ADF collapse).
+_soft_learn_kernel(fires::Set{Int}) =
+    Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta, _soft_logdensity;
+           likelihood_family = FiringByTag(fires, SoftBernoulli(), Flat()))
+
+"""
+    structure_observe_soft(model, top, X, r, w) -> MixturePrevision
+
+Bayesian update on INDIRECT evidence about the (latent) label at context X: `r`, `w`
+are the likelihoods of the observed signal under label = 1 / label = 0. Reduces EXACTLY
+to `structure_observe(model, top, X, 1)` at (r,w)=(1,0) and `…, 0` at (0,1).
+"""
+structure_observe_soft(model::StructureBMA, top::MixturePrevision, X::AbstractVector,
+                       r::Real, w::Real) =
+    condition(top, _soft_learn_kernel(structure_firing_tags(model, X)), (Float64(r), Float64(w)))
+
+# Select a structure component's cell-for-X by tag. Sparse (O(1) dict-backed cell_at)
+# and dense (linear scan of factors) both return the same TaggedBetaPrevision.
+_cell_for(comp::SparseStructurePrevision, tag::Int) = cell_at(comp, tag)
+function _cell_for(comp::ProductPrevision, tag::Int)
+    idx = findfirst(f -> f isa TaggedBetaPrevision && f.tag == tag, comp.factors)
+    idx === nothing && error("structure-bma: cell tag $tag not found")
+    comp.factors[idx]
+end
+
+"""
+    belief_at_context(model, top, X) -> MixturePrevision
+
+The transient per-decision view: each structure's cell-for-X, carrying the structure
+posterior weights verbatim. Pure construction — selects sub-beliefs and copies weights
+(via the `with_components` stdlib op); no arithmetic on probabilities.
+"""
+function belief_at_context(model::StructureBMA, top::MixturePrevision, X::AbstractVector)
+    cells = Prevision[]
+    for (s, parents) in enumerate(model.structures)
+        tag = model.cell_tag[s][cell_key(parents, X)]
+        push!(cells, _cell_for(top.components[s], tag))
+    end
+    with_components(top, cells)
+end

--- a/test/test_decide_with_voi.jl
+++ b/test/test_decide_with_voi.jl
@@ -1,0 +1,79 @@
+# test_decide_with_voi.jl — the proceed/block/ask EU decision template lifted into engine
+# stdlib (decouple Move 3, src/stdlib.jl `decide_with_voi`). It is the engine-side home of
+# the EU coefficient assembly that used to live in the credence-pi app brain (`decide`/
+# `decide_multi`); lifting it here is what lets a non-embedding consumer drive the decision
+# over the wire (the body ships utility scalars, the engine does all the arithmetic).
+# Asserts:
+#   (1) the single-outcome block/proceed cutoff against an independent hand oracle (`:ask`
+#       suppressed by a huge interrupt cost), AND that VOI actually flows — `:ask` wins when a
+#       maximally-uncertain belief makes one observation worth more than a free gate;
+#   (2) the OPTIONAL harm coordinate is additive (a high-harm belief flips a would-be
+#       `:proceed` to `:block`) AND degenerate-reduces: `harm_cost = 0` collapses bit-for-bit
+#       to the single-outcome decision for ANY harm belief (the "one op, degenerate case"
+#       property that justified a single template over two).
+#
+# End-to-end behaviour preservation through the credence-pi shim (`decide`/`decide_multi`
+# now delegate here) is additionally pinned by apps/credence-pi/tests/julia/test_feature_brain.jl
+# (unchanged, passes through the shim).
+#
+# Run from repo root:
+#     julia test/test_decide_with_voi.jl
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: BetaPrevision, TaggedBetaPrevision, MixturePrevision, structure_decision_kernel
+using Credence.Ontology: decide_with_voi
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+
+# The decision belief shape is exactly what `belief_at_context` returns: a one-cell
+# `MixturePrevision` over a `TaggedBetaPrevision` (E[θ] = α/(α+β)). This carries the
+# `LinearCombination`/`Projection` Functionals the EU template integrates against.
+cell(α, β) = MixturePrevision([TaggedBetaPrevision(1, BetaPrevision(α, β))], [0.0])
+
+println("="^64)
+println("decide_with_voi — proceed/block/ask EU template (Move 3)")
+println("="^64)
+
+k = structure_decision_kernel()
+HUGE = 1.0e9   # an interrupt cost that removes :ask from contention (EU(ask) = voi − HUGE ≪ 0)
+
+# ── (1) single-outcome cutoff: at m=0, λ=1, block beats proceed iff E[θ] < 1/(1+λ) = 0.5 ──
+# EU(block) = c·tf − c·(tf+λ)·E[θ] with tf = 1 ⇒ c − c·(1+λ)·E[θ]; EU(proceed) = 0.
+lo = cell(2.0, 8.0)   # E[θ] = 0.2 < 0.5 ⇒ EU(block) = 1 − 2·0.2 = +0.6 ⇒ :block
+hi = cell(8.0, 2.0)   # E[θ] = 0.8 > 0.5 ⇒ EU(block) = 1 − 2·0.8 = −0.6 ⇒ :proceed
+check("low approve-prob ⇒ :block (hand cutoff 1/(1+λ))",
+      decide_with_voi(lo, k; cost = 1.0, aversion = 1.0, interrupt_cost = HUGE) === :block)
+check("high approve-prob ⇒ :proceed",
+      decide_with_voi(hi, k; cost = 1.0, aversion = 1.0, interrupt_cost = HUGE) === :proceed)
+
+# VOI flows: a maximally-uncertain belief makes one observation worth the (free) gate.
+# Beta(1,1): E[θ] = 0.5 ⇒ EU(block) = 0 = EU(proceed); voi = 0.5·max(0, EU(block|θ⁻)) > 0 ⇒ :ask.
+unc = cell(1.0, 1.0)
+check("uncertain belief + free ask ⇒ :ask (VOI > 0 flows through net_voi)",
+      decide_with_voi(unc, k; cost = 1.0, aversion = 1.0, interrupt_cost = 0.0) === :ask)
+
+# ── (2a) harm coordinate is additive: a high-harm belief flips :proceed → :block ──
+# approve E[θ_a] = 0.8 alone ⇒ :proceed (EU(block) = −0.6). Add unsafe E[θ_u] = 0.9, H = 2 ⇒
+# EU(block) = −0.6 + H·E[θ_u] = −0.6 + 1.8 = +1.2 ⇒ :block.
+unsafe = cell(9.0, 1.0)   # E[θ_u] = 0.9
+check("harm belief flips :proceed → :block (additive H·θ_u)",
+      decide_with_voi(hi, k; cost = 1.0, aversion = 1.0, interrupt_cost = HUGE,
+                      harm_belief = unsafe, harm_cost = 2.0) === :block)
+
+# ── (2b) degenerate reduction: harm_cost = 0 ≡ single-outcome, for ANY harm belief ──
+# The harm Projection coefficient is 0 ⇒ the joint EU(block) and the ask-gate VOI (always on
+# the approve belief) match the single-outcome triple exactly ⇒ identical argmax.
+for (bθ, hb) in [(lo, unsafe), (hi, cell(1.0, 1.0)), (unc, cell(3.0, 4.0))]
+    single = decide_with_voi(bθ, k; cost = 1.0, aversion = 1.0, interrupt_cost = 0.5)
+    degen  = decide_with_voi(bθ, k; cost = 1.0, aversion = 1.0, interrupt_cost = 0.5,
+                             harm_belief = hb, harm_cost = 0.0)
+    check("harm_cost=0 ≡ single-outcome (bit-exact, any harm belief)", single === degen,
+          "single=$single degen=$degen")
+end
+
+println("="^64)
+println("ALL CHECKS PASSED — decide_with_voi exact")
+println("="^64)

--- a/test/test_structure_bma.jl
+++ b/test/test_structure_bma.jl
@@ -1,0 +1,80 @@
+# test_structure_bma.jl — the structure-BMA builder + observe + readout lifted into
+# engine stdlib (decouple Move 3, src/structure_bma.jl). Asserts the lifted functions are
+# EXACT through the engine's own public names (not the credence-pi shim): the sparse prior
+# and posterior equal the dense reference bit-for-bit, and the soft-evidence path reduces
+# exactly to the hard-label path at the certain-signal corners.
+#
+# Behaviour-preservation vs the pre-lift app brain is additionally pinned end-to-end by
+# apps/credence-pi/tests/julia/test_feature_brain.jl (unchanged, passes through the shim).
+#
+# Run from repo root:
+#     julia --project=. test/test_structure_bma.jl
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: weights
+
+function check(name, cond, detail = "")
+    if cond
+        println("PASSED: $name")
+    else
+        println("FAILED: $name — $detail")
+        error("assertion failed: $name")
+    end
+end
+
+println("="^64)
+println("structure-BMA (lifted to engine stdlib) — Move 3")
+println("="^64)
+
+# 2 features (tool, rep) ⇒ 4 structures (∅, {tool}, {rep}, {tool,rep}).
+model = build_structure_model(["tool", "rep"], [["bash", "read"], ["rep0", "rep3"]];
+                              alpha0 = 2.0, beta0 = 2.0, p_edge = 0.5)
+check("4 structures enumerated", length(model.structures) == 4, "got $(length(model.structures))")
+
+# Prior: the sparse store is an exact backend of the dense product ⇒ bit-identical weights.
+ps = build_structure_prior(model)
+pd = build_structure_prior_dense(model)
+check("prior weights sparse ≡ dense (exact)", weights(ps) == weights(pd),
+      "$(weights(ps)) vs $(weights(pd))")
+
+# Posterior after a sequence of hard observations across two contexts: still bit-identical.
+seq = [(["bash", "rep3"], 1), (["bash", "rep3"], 1), (["read", "rep0"], 0), (["bash", "rep0"], 1)]
+ts, td = ps, pd
+for (X, o) in seq
+    global ts = structure_observe(model, ts, X, o)
+    global td = structure_observe(model, td, X, o)
+end
+check("posterior weights sparse ≡ dense (exact, 4 obs)", weights(ts) == weights(td),
+      "$(weights(ts)) vs $(weights(td))")
+
+# belief_at_context: the per-decision view carries the structure posterior verbatim ⇒ the
+# sparse and dense views agree exactly.
+let X = ["bash", "rep3"]
+    bs = belief_at_context(model, ts, X)
+    bd = belief_at_context(model, td, X)
+    check("belief_at_context weights sparse ≡ dense (exact)", weights(bs) == weights(bd),
+          "$(weights(bs)) vs $(weights(bd))")
+end
+
+# Soft-evidence reduces EXACTLY to the hard label at the certain-signal corners:
+# (r,w)=(1,0) ≡ obs=1, (r,w)=(0,1) ≡ obs=0 (a degenerate-corner identity).
+let X = ["read", "rep3"]
+    check("soft (r,w)=(1,0) ≡ hard obs=1 (exact)",
+          weights(structure_observe(model, ps, X, 1)) ==
+          weights(structure_observe_soft(model, ps, X, 1.0, 0.0)))
+    check("soft (r,w)=(0,1) ≡ hard obs=0 (exact)",
+          weights(structure_observe(model, ps, X, 0)) ==
+          weights(structure_observe_soft(model, ps, X, 0.0, 1.0)))
+end
+
+# firing_tags: exactly one cell per structure fires (globally-unique tags).
+let X = ["bash", "rep3"]
+    tags = structure_firing_tags(model, X)
+    check("one firing tag per structure", length(tags) == length(model.structures),
+          "got $(length(tags)) for $(length(model.structures)) structures")
+end
+
+println("="^64)
+println("ALL CHECKS PASSED — structure-BMA lift exact")
+println("="^64)


### PR DESCRIPTION
## Move 3 — credence-pi separable refit (design doc)

Per the `decouple` convention (design-doc PR → code PR). Makes credence-pi **able to live in a separate repo** by moving its brain math behind the skin wire.

**Key finding:** the hard substrate is already Tier-1 — `SparseStructurePrevision` + its conditioning (FiringByTag routing, 2ⁿ mixture reweight) live in `src/` today and `feature_brain.jl` reimplements no axiom op. So this move lifts the *builder/wrapper + decision* layer, not new inference machinery.

**What lands (code PR):**
- `src/structure_bma.jl` — lifted `StructureBMA`/`build_prior`/`structure_observe`/`belief_at_context` (compositions over existing types; no new frozen type).
- `src/stdlib.jl` — typed EU template `decide_with_voi` (peer of `voi`/`net_voi`); the named-template decision (consumer ships utility *data*, engine assembles every Functional + `net_voi` + `optimise`).
- `apps/skin/server.jl` — four additive verbs + a model-descriptor registry; protocol `1.1`→`1.2`.
- `apps/credence-pi/brain/feature_brain.jl` → thin shim (domain wiring stays; model/decision math delegates to engine).

**Why a verb surface (not sugar):** `FiringByTag` isn't exposable on the wire, there's no `MixturePrevision(SparseStructurePrevision)` builder, no `with_components` verb, and no `voi`/`net_voi` verb — so these verbs are the *only* way a non-embedding client drives structure-BMA.

**Open questions for review (§5):** (1) separate `model_id` handle vs. self-describing state; (2) `belief_at_context` as a verb only for read-back; (3) one decision template with optional harm coordinate vs. two; (4) EU template as stdlib op vs. skin helper. My leans are in the doc.

Behaviour preserved: `structure_observe` reproduces the warm posterior bit-for-bit; `decide_with_voi` ≡ inline `decide`/`decide_multi`; ClawsBench decisions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)