### PR TITLE
decouple Move 4: lift the routing brain into the engine

### DIFF
--- a/apps/credence-pi/brain/routing_brain.jl
+++ b/apps/credence-pi/brain/routing_brain.jl
@@ -1,424 +1,66 @@
-# Role: brain
+# Role: brain (thin shim)
 """
-    routing_brain.jl — EU-max model routing over the credence-pi feature brain.
+    routing_brain.jl — credence-pi's thin shim over the engine's routing stdlib.
 
-The credence-proxy decision: given a request's features X and a set of candidate
-models, pick the model that maximises expected welfare
-
-    EU(model a | X) = reward · E[θ_a | X] − cost_a
-
-where θ_a = P(model a answers correctly | X) is the per-model belief and `reward`
-is the profile's dollar value of a correct answer. This is the SAME EU-max the
-governance brain runs — only the action set changes from {proceed, block, ask} to
-the model roster, and the per-action payoff is reward·accuracy − cost instead of the
-waste/harm payoff.
-
-REUSE, not reimplementation. The belief is `FeatureBrain.StructureBMA`: one shared
-feature schema, K trained posteriors `tops[a]` (one per model, label = "model a was
-correct"), each a structure-BMA that auto-discovers which features matter. The
-decision is built EXACTLY as `FeatureBrain.decide_multi` builds its multi-outcome
-EU — a joint `ProductMeasure` over the per-model `belief_at_context` views, a
-per-action `LinearCombination` over `Projection`s, maximised by the ONE canonical
-`optimise`. No new axiom op; no raw probability arithmetic here (the `credence-lint`
-brain/ rule enforces it — the EU is closed-form inside `expect`/`optimise`, and the
-only arithmetic below builds LinearCombination coefficients out of declared utility
-data: reward and per-model cost).
-
-Why per-model posteriors and not one joint belief: each "is model a correct?" is its
-own Bernoulli-labelled prediction problem, so each model gets its own StructureBMA
-posterior (mirroring credence-pi's per-outcome brains: waste vs harm). At decision
-time the K views are assembled into the joint the argmax integrates over — the
-independence across models is the ProductMeasure, exactly as the waste⊗harm joint in
-`decide_multi`.
+After decouple Move 4 the routing brain (decisions + the online confound-learning EM) lives
+in the engine (`src/routing.jl`: `RoutingState` / `route` / `route_eu` / `escalation_next` /
+`posterior_accuracy` / `route_outcome!` / `decode_correctness` / `route_decide` /
+`escalate_decide` / `reconstruct_*_from_data`). This module re-exports them under the names
+the daemon, tests, and eval use, and keeps ONLY the genuinely consumer-side wiring:
+`wire_routing!` (reads the BDSL env + installs the route/escalate closures), and the
+path-reading reconstruction wrappers (the embedding daemon reads its committed counts files;
+the wire path ships the counts as inline data to `routing_init`). NO `optimise` /
+`LinearCombination` / `Projection` / `ProductMeasure` import remains — the leak-closed
+witness, mirroring `feature_brain.jl`.
 """
 module RoutingBrain
 
-using Main.Credence: MixturePrevision, BetaPrevision, GammaPrevision, Projection,
-    LinearCombination, TestFunction, Identity, Kernel, Interval, Finite, WeightedBernoulli,
-    mean, condition, expect, wrap_in_measure
-import Main.Credence.Ontology: optimise, ProductMeasure, Measure
-# `..FeatureBrain` (the sibling submodule), NOT `Main.FeatureBrain`: this resolves both
-# when the eval includes both brains at Main (siblings of Main) and when the daemon
-# includes both inside `module Server` (siblings of Server). FeatureBrain itself reaches
-# Credence via the always-Main `Main.Credence`, so only this sibling ref needs to be relative.
-using ..FeatureBrain: StructureBMA, belief_at_context, context_from_features,
-    build_model_from_decls, build_prior, observe, observe_soft
+using Main.Credence: RoutingState, EmissionBelief, LatencyBelief, route, route_eu,
+    escalation_next, posterior_accuracy, route_outcome!, decode_correctness, latency_at,
+    route_decide, escalate_decide, reconstruct_latency_from_data,
+    reconstruct_routing_tops_from_data, _ctx_key, MixturePrevision
+# `..FeatureBrain` (the sibling submodule), NOT `Main.FeatureBrain`: resolves both when the
+# eval includes both brains at Main and when the daemon includes both inside `module Server`.
+using ..FeatureBrain: build_model_from_decls
 using JSON3
 
 export route, route_eu, escalation_next, posterior_accuracy, wire_routing!,
     RoutingState, EmissionBelief, route_outcome!, decode_correctness,
-    LatencyBelief, reconstruct_latency, latency_at
+    LatencyBelief, reconstruct_latency, latency_at, _ctx_key
 
-# ── Latency belief: E[time | model, X] = E[turns|X]·s̄, the TIME coordinate ─────────
-#
-# Time is the profile coordinate that lets a user trade wall-clock against money/quality.
-# It is a LEARNED belief (you cannot know a call's duration before making it): the SAME
-# Poisson-Gamma "turns" belief the dominance eval already uses for E[cost] (tb_dominance.jl
-# `CostBelief`), reused for E[time]. E[time|model,X] = E[turns|model,X]·s̄_model, where the
-# per-model turns posterior is a Gamma (reconstructed below) read by `expect(·,Identity)`=α/β,
-# and s̄_model is the measured seconds/turn. The decision folds w_time·E[time] into the EU
-# offset (route/escalation_next), so a slow-but-cheap model loses to a fast one exactly when
-# the user values their seconds enough — the time/money trade-off, via the one `optimise`.
-#
-# Version-stable like the other warm artifacts: ship the Gamma sufficient statistic
-# (sum_turns, n_obs) per (model, context) + the measured rate_s per model + the prior; the
-# posterior Gamma(α0+Σt, β0+n) is order-independent, so reconstruction is exact (no
-# Serialization). E[time] is computed once at load through `expect` and cached per cell.
-struct LatencyBelief
-    time_mean::Dict{Tuple{String, String}, Float64}   # (model_id, ctx_key) -> E[time] seconds
-end
+# ── Path-reading reconstruction wrappers (co-released-image-only) ──────────────────────────
+# The embedding daemon reads its committed counts files; the wire consumer ships the parsed
+# content to the engine's `reconstruct_*_from_data` instead (the skin never touches host FS).
 
-# Reconstruct E[time] per (model, context) from the counts-JSON. Shape:
-# { "turns_prior":[α0,β0], "per_model":[ {"model_id":..., "rate_s":..,
-#   "contexts":[ {"ctx":["short"], "sum_turns":412, "n_obs":30 } ]} ] }
-function reconstruct_latency(path)::LatencyBelief
-    data = JSON3.read(read(String(path), String))
-    α0, β0 = Float64(data["turns_prior"][1]), Float64(data["turns_prior"][2])
-    tm = Dict{Tuple{String, String}, Float64}()
-    for pm in data["per_model"]
-        id = String(pm["model_id"]); rate = Float64(pm["rate_s"])
-        for ctx in pm["contexts"]
-            g = GammaPrevision(α0 + Float64(ctx["sum_turns"]), β0 + Float64(ctx["n_obs"]))
-            etime = Float64(expect(g, Identity())) * rate     # E[turns]=α/β, ×s̄ ⇒ E[time]
-            tm[(id, _ctx_key([String(c) for c in ctx["ctx"]]))] = etime
-        end
-    end
-    LatencyBelief(tm)
-end
+reconstruct_latency(path) = reconstruct_latency_from_data(JSON3.read(read(String(path), String)))
 
-# E[time|model,X] seconds, or 0.0 for an unknown (model, context) ⇒ that candidate carries no
-# time term (conservative: time never penalises a model we have no latency belief for).
-latency_at(lb::LatencyBelief, model_id::AbstractString, X::AbstractVector) =
-    get(lb.time_mean, (String(model_id), _ctx_key(X)), 0.0)
-latency_at(::Nothing, ::AbstractString, ::AbstractVector) = 0.0
-
-# Per-action EU functional: reward·θ_a − cost_a, expressed over the joint belief's
-# a-th component (Projection(a) = θ_a). `reward` and `cost` are declared utility DATA;
-# multiplying them into LinearCombination coefficients is coefficient construction, not
-# probability arithmetic (mirrors decide_multi's `(-cost*(tf+aversion), Projection(1))`).
-# `time_cost` = w_time·E[time|a,X] (declared weight × learned latency, prepared upstream); it
-# folds into the SAME constant offset as `-cost` — E[time] is a known scalar at decision time
-# (it does not co-vary with the routing posterior θ), so it belongs in the offset, not a new
-# Projection. time_cost=0 ⇒ `-(cost+0.0)`==`-cost` ⇒ bit-identical to the pre-time functional.
-_eu_functional(a::Int, reward::Float64, cost::Float64, time_cost::Float64 = 0.0) =
-    LinearCombination(Tuple{Float64, TestFunction}[(reward, Projection(a))], -(cost + time_cost))
-
-# Build the joint belief over all K models at context X: a ProductMeasure of each
-# model's belief-at-context view (the independence-across-models assumption made
-# explicit, exactly as decide_multi joins the waste and harm beliefs). The action's
-# EU then reads its own component via Projection(a) — the other components integrate
-# out, so EU(a) depends only on model a's belief, as it must.
-function _joint_at(model::StructureBMA, tops::AbstractVector, X::AbstractVector)
-    K = length(tops)
-    cells = Measure[wrap_in_measure(belief_at_context(model, tops[a], X)) for a in 1:K]
-    ProductMeasure(cells), K
-end
-
-function _fpa(K::Int, reward::Real, costs::AbstractVector,
-             w_time::Real = 0.0, times = nothing)
-    r = Float64(reward); wt = Float64(w_time)
-    Dict{Int, LinearCombination}(
-        a => _eu_functional(a, r, Float64(costs[a]),
-                            times === nothing ? 0.0 : wt * Float64(times[a])) for a in 1:K)
-end
-
-"""
-    route(model, tops, X, costs, reward) -> Int
-
-Return the 1-based index of the EU-max model for a request with context `X`.
-`tops[a]` is model a's `StructureBMA` posterior over P(correct|·); `costs[a]` its
-per-call cost; `reward` the profile's dollar value of a correct answer. The argmax
-is the single canonical `optimise` over the joint per-model belief (Invariant 1).
-
-Routing is non-degenerate for k ≥ 2 models: the per-profile argmax over
-reward·E[θ_a|X] − cost_a is a different model for different reward, so no single
-fixed table is the Bayes rule for more than one profile — the Wald complete-class
-core of the dominance proof.
-"""
-function route(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
-               costs::AbstractVector, reward::Real; w_time::Real = 0.0, times = nothing)
-    length(tops) == length(costs) ||
-        error("route: tops/costs length mismatch ($(length(tops)) vs $(length(costs)))")
-    (times === nothing || length(times) == length(tops)) ||
-        error("route: tops/times length mismatch ($(length(tops)) vs $(length(times)))")
-    joint, K = _joint_at(model, tops, X)
-    optimise(joint, collect(1:K), _fpa(K, reward, costs, w_time, times))
-end
-
-"""
-    route_eu(model, tops, X, costs, reward) -> (Int, Float64)
-
-`route` plus the EU of the chosen model (reward·E[θ_a|X] − cost_a), for reporting.
-The EU is `expect` of the chosen action's functional — the same number `optimise`
-maximised — so this re-reads through the canalised path, never recomputing it by hand.
-"""
-function route_eu(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
-                  costs::AbstractVector, reward::Real; w_time::Real = 0.0, times = nothing)
-    joint, K = _joint_at(model, tops, X)
-    fpa = _fpa(K, reward, costs, w_time, times)
-    a = optimise(joint, collect(1:K), fpa)
-    a, Float64(expect(joint, fpa[a]))
-end
-
-"""
-    posterior_accuracy(model, top, X) -> Float64
-
-E[θ | X] = the posterior-mean accuracy of one model at context X, read through
-`expect` of `Identity` over its belief-at-context view. The public way to inspect a
-model's learned accuracy (for reporting / the structure-posterior diagnostic); never
-used to make a routing decision — that is `route`'s job, through `optimise`.
-"""
-posterior_accuracy(model::StructureBMA, top::MixturePrevision, X::AbstractVector) =
-    Float64(expect(belief_at_context(model, top, X), Identity()))
-
-# Stop action = the zero functional (EU 0: decline to spend). Peer of `_eu_functional`.
-const _STOP_FUNCTIONAL = LinearCombination(Tuple{Float64, TestFunction}[], 0.0)
-
-"""
-    escalation_next(model, tops, X, costs_X, reward, tried) -> Int
-
-Observe-then-escalate routing (the deployable strategy that wins the dominance eval when
-up-front prediction can't — features don't determine the capability boundary, but observing
-a failure does). Among tiers not yet `tried`, cheapest first (`costs_X` ascending), return
-the cheapest whose single-step EU to try is at least the EU of stopping — i.e. `optimise`
-prefers "try" to "stop" — else 0 (STOP). The host runs the returned tier, observes success
-via its verifier, and on failure calls again with that tier added to `tried`.
-
-The {try, stop} choice is the SINGLE canonical `optimise` (Invariant 1) over the tier's
-belief-at-context: try-functional = reward·E[θ_a|X] − cost (an `Identity` LinearCombination,
-the per-tier analogue of `route`'s Projection one), stop-functional = constant 0. Cost is
-context-dependent prepared utility data (`costs_X[a]` = E[cost|a,X]; see `route`). MYOPIC —
-one rung at a time, ignoring the option value of still-dearer rungs (conservative); the
-exact sequential value is a future refinement. This is the ONE escalation decision; the eval
-calls it rather than reimplementing the gate (no host-side decision mechanism).
-"""
-function escalation_next(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
-                         costs_X::AbstractVector, reward::Real, tried;
-                         w_time::Real = 0.0, times_X = nothing)
-    r = Float64(reward); wt = Float64(w_time)
-    for a in eachindex(tops)                       # costs_X ascending ⇒ cheapest-first
-        a in tried && continue
-        tc = times_X === nothing ? 0.0 : wt * Float64(times_X[a])   # w_time·E[time|a,X]
-        # Single-tier joint + Projection(1) — mirror `route`'s ProductMeasure path so
-        # `expect` resolves to Measure×LinearCombination (a bare MixtureMeasure×TestFunction
-        # is ambiguous against the LinearCombination method).
-        belief = ProductMeasure(Measure[wrap_in_measure(belief_at_context(model, tops[a], X))])
-        tryf = LinearCombination(Tuple{Float64, TestFunction}[(r, Projection(1))], -(Float64(costs_X[a]) + tc))
-        return optimise(belief, [1, 2], Dict(1 => tryf, 2 => _STOP_FUNCTIONAL)) == 1 ? a : 0
-    end
-    0
-end
-
-# ── Warm routing belief: per-model COUNTS, reconstructed via `observe` ──
-#
-# Mirrors FeatureBrain.reconstruct_harm_posterior, but yields K posteriors (one per
-# model) from one shared schema. Bayesian updating is order-independent, so the warm
-# belief depends only on each (model, context) pair's correct/incorrect counts; we ship
-# those as JSON and replay `observe` — version-stable (unlike Serialization). Any load
-# failure falls back LOUDLY to the cold prior (a stale warm belief must not mis-route).
-# JSON shape: { "per_model": [ { "contexts": [ {"ctx":["short"], "n1":44, "n0":6} ] }, … ] }
-# where n1 = correct, n0 = incorrect, ctx = the prompt-length bucket.
-function _reconstruct_routing_tops(model::StructureBMA, K::Int, warm_path)
-    cold() = MixturePrevision[build_prior(model) for _ in 1:K]
-    (warm_path === nothing || isempty(string(warm_path))) && return cold()
+function _reconstruct_routing_tops(model, K, warm_path)
+    (warm_path === nothing || isempty(string(warm_path))) &&
+        return reconstruct_routing_tops_from_data(model, K, nothing)
     isfile(string(warm_path)) ||
-        (@warn "routing warm brain not found; cold start" path=string(warm_path); return cold())
+        (@warn "routing warm brain not found; cold start" path = string(warm_path);
+         return reconstruct_routing_tops_from_data(model, K, nothing))
     try
         data = JSON3.read(read(string(warm_path), String))
-        pm = data.per_model
-        length(pm) == K ||
-            error("routing warm brain has $(length(pm)) models but the roster has $K")
-        tops = MixturePrevision[]
-        for entry in pm
-            top = build_prior(model)
-            for c in entry.contexts
-                ctx = String[String(v) for v in c.ctx]
-                for _ in 1:Int(c.n1); top = observe(model, top, ctx, 1); end
-                for _ in 1:Int(c.n0); top = observe(model, top, ctx, 0); end
-            end
-            push!(tops, top)
-        end
-        @info "routing warm brain reconstructed" path=string(warm_path) models=K
+        tops = reconstruct_routing_tops_from_data(model, K, data)
+        @info "routing warm brain reconstructed" path = string(warm_path) models = K
         tops
     catch e
-        @warn "routing warm brain failed to load; cold start" path=string(warm_path) error=e
-        cold()
+        @warn "routing warm brain failed to load; cold start" path = string(warm_path) error = e
+        reconstruct_routing_tops_from_data(model, K, nothing)
     end
-end
-
-# ── Online correctness learning: latent per-turn correctness + learned confounds ──
-#
-# The deferred online signal (ROUTING_DOMINANCE.md). We never observe model correctness
-# directly; we observe a per-turn signal — did the proposed call execute cleanly (e). e is
-# a NOISY emission of the latent C = "the model's turn was correct", confounded by TOOL
-# RELIABILITY: a correct call can still error on a flaky tool, a wrong call can still
-# execute. We model the confound explicitly and learn it, so a flaky tool is absorbed by
-# the reliability latent, NOT mis-attributed to the model.
-#
-#   θ_a(X) = P(C=1 | model a, context X)   — the routing belief (its own prior for C)
-#   ρ_X    = P(e=1 | C=1)                  — tool reliability (correct ⇒ clean exec)
-#   σ_X    = P(e=1 | C=0)                  — false-success (wrong ⇒ clean exec anyway)
-#
-# ρ_X, σ_X are SHARED across models at a context (the environment doesn't know which model
-# proposed the call) — the identification lever: the cross-model spread in observed e-rate,
-# against the (oracle-anchored) θ_a, pins ρ and σ. They are LATENT Beta beliefs
-# (weakly-informative directional prior E[ρ]>E[σ], refined by data — not fixed constants),
-# updated only through `condition`.
-#
-# Per turn (no human label): decode π = P(C=1 | e) with θ_a(X) as prior and the emission
-# means as likelihoods (emission uncertainty integrated via `expect`/`mean` — P(e|C) is
-# linear in ρ,σ, so the mean IS the integrated likelihood). Then ONE coupled coordinate
-# step (the EM the constitution treats as a computational strategy, invisible to the DSL):
-#   * routing belief: observe_soft(model, top_a, X, r, w)  — mean-exact soft-count
-#   * emissions (M-step): ρ_X ← (e, weight π),  σ_X ← (e, weight 1−π)   (WeightedBernoulli)
-# A human approve/reject, when present, makes C KNOWN — a clean hard `observe` on θ_a and a
-# unit-weight emission update — the gold anchor (no human-emission constant).
-
-# Default weakly-informative DIRECTIONAL emission prior: E[ρ0]=2/3 > E[σ0]=1/3. Only the
-# inequality is load-bearing (it breaks the EM label-symmetry); the magnitudes are weak
-# (pseudo-count 3) and washed out by data. Overridable via the declared `emission-prior`
-# (routing.bdsl) — auditable data, not a buried constant.
-const _DEFAULT_EMISSION_PRIOR = (2.0, 1.0, 1.0, 2.0)  # (ρα, ρβ, σα, σβ)
-
-mutable struct EmissionBelief
-    rho_cells::Dict{String, BetaPrevision}     # P(e=1|C=1) per context-key, lazily populated
-    sigma_cells::Dict{String, BetaPrevision}   # P(e=1|C=0) per context-key
-    rho0::BetaPrevision                        # directional prior, E[ρ0] > E[σ0]
-    sigma0::BetaPrevision
-end
-
-EmissionBelief(prior::NTuple{4, Float64} = _DEFAULT_EMISSION_PRIOR) =
-    EmissionBelief(Dict{String, BetaPrevision}(), Dict{String, BetaPrevision}(),
-                   BetaPrevision(prior[1], prior[2]), BetaPrevision(prior[3], prior[4]))
-
-# The live routing belief: per-model posteriors `tops` (MUTATED by route_outcome!) and the
-# shared emission belief. Captured by the `route-decide` closure, so routing reads the live
-# belief — un-frozen vs v1's closure-captured constant.
-mutable struct RoutingState
-    model::StructureBMA
-    tops::Vector{MixturePrevision}              # warm beliefs for the DEFAULT roster (positional)
-    extra_tops::Dict{String, MixturePrevision}  # beliefs for models NOT in the default roster —
-                                                # the user's OWN models: cold prior on first sight,
-                                                # then learned online; keyed by model id
-    emission::EmissionBelief
-    # The DEFAULT roster (declared in routing.bdsl): the warm/known models, and the fallback
-    # used when a route-request carries no live roster. The LIVE roster (the user's actual
-    # OpenClaw models) arrives PER REQUEST — that is what makes routing roster-aware.
-    names::Vector{String}
-    providers::Vector{String}
-    model_ids::Vector{String}
-    costs::Vector{Float64}
-    reward::Float64
-    w_time::Float64                             # profile weight on time ($/sec of the user's wall-clock)
-    latency::Union{LatencyBelief, Nothing}      # learned E[time|model,X]; nothing ⇒ time-blind (default)
-end
-
-# Fetch model_id's belief plus a setter to write an update back. KNOWN models (the default
-# roster) live in the positional `tops`; the user's OWN models live in `extra_tops` (cold
-# `build_prior` on first sight, then learned). No error on an unknown model — routing is
-# roster-aware, so any model the body routes to gets a coherent belief.
-function _belief_slot(rt::RoutingState, model_id::AbstractString)
-    a = findfirst(==(String(model_id)), rt.model_ids)
-    a !== nothing && return (rt.tops[a], top -> (rt.tops[a] = top))
-    id = String(model_id)
-    cur = get!(() -> build_prior(rt.model), rt.extra_tops, id)
-    (cur, top -> (rt.extra_tops[id] = top))
-end
-
-_ctx_key(X::AbstractVector) = join(string.(X), "|")
-
-# WeightedBernoulli kernel for the emission Beta updates (fractional pseudo-counts). The
-# conjugate update keys on likelihood_family; generate/log_density are not consulted.
-_emission_kernel() = Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta,
-                            (h, o) -> 0.0; likelihood_family = WeightedBernoulli())
-
-# Emission likelihoods of the exec signal e under each correctness hypothesis:
-# r = P(e | C=1), w = P(e | C=0), from the emission belief means (`mean` = the integrated
-# likelihood, since P(e|C) is linear in ρ/σ).
-function _emission_likelihoods(em::EmissionBelief, key::AbstractString, e::Bool)
-    ρ̄ = mean(get(em.rho_cells,   key, em.rho0))
-    σ̄ = mean(get(em.sigma_cells, key, em.sigma0))
-    e ? (ρ̄, σ̄) : (1.0 - ρ̄, 1.0 - σ̄)
-end
-
-"""
-    decode_correctness(em, θ̄, key, e) -> (r, w, π)
-
-The signal→correctness likelihood: r = P(e|C=1), w = P(e|C=0) from the emission belief, and
-π = P(C=1 | e) = r·θ̄/(r·θ̄ + w·(1−θ̄)) with the routing belief θ̄ as the coherent prior. π is
-the soft correctness label; (r,w) is the virtual evidence the routing belief conditions on
-(SoftBernoulli). Pure readout — `mean` and Bayes, no mutation.
-"""
-function decode_correctness(em::EmissionBelief, θ̄::Float64, key::AbstractString, e::Bool)
-    r, w = _emission_likelihoods(em, key, e)
-    denom = r * θ̄ + w * (1.0 - θ̄)
-    π = denom > 0.0 ? r * θ̄ / denom : θ̄
-    (r, w, π)
-end
-
-# Update one reliability cell. `into_rho` selects ρ (the C=1 cell) vs σ (the C=0 cell); the
-# outcome is the exec signal e, credited `weight` pseudo-counts (WeightedBernoulli).
-function _update_emission!(em::EmissionBelief, key::AbstractString, into_rho::Bool,
-                           e::Bool, weight::Float64)
-    weight > 0.0 || return em
-    d  = into_rho ? em.rho_cells : em.sigma_cells
-    p0 = into_rho ? em.rho0 : em.sigma0
-    cur = get(d, key, p0)
-    d[key] = condition(cur, _emission_kernel(), (e ? 1 : 0, weight))
-    em
-end
-
-"""
-    route_outcome!(rt, model_id, features, success; human=nothing) -> RoutingState
-
-Learn from one routed turn's per-turn outcome. `features` is the route-request feature dict
-(converted to the context via `context_from_features`). `success` = the proposed call executed
-cleanly (the exec signal e). With no `human` label, decode the latent correctness from e
-(confound-aware) and take one coupled coordinate step: the routing belief conditions on the
-virtual evidence (mean-exact soft-count via `observe_soft`); the shared emission belief
-takes the EM M-step (ρ←(e,π), σ←(e,1−π) through `condition`). A `human` approve/reject makes
-C known: a hard `observe` on the routed model and a unit-weight emission update — the gold
-anchor. The single learning mechanism is `condition` throughout; the θ↔emission coupling is
-coordinate computation (a strategy), invisible to the DSL. Mutates `rt` in place.
-"""
-function route_outcome!(rt::RoutingState, model_id::AbstractString, features::AbstractDict,
-                        success::Bool; human::Union{Nothing, Bool} = nothing)
-    X = context_from_features(rt.model, features)
-    key = _ctx_key(X)
-    e = success
-    top, setby = _belief_slot(rt, model_id)                 # known slot or the user's own model
-    if human !== nothing
-        C = human ? 1 : 0                                   # known correctness
-        setby(observe(rt.model, top, X, C))
-        _update_emission!(rt.emission, key, C == 1, e, 1.0)
-    else
-        θ̄ = posterior_accuracy(rt.model, top, X)            # E[θ|X] — the decode prior
-        r, w, π = decode_correctness(rt.emission, θ̄, key, e)
-        setby(observe_soft(rt.model, top, X, r, w))
-        _update_emission!(rt.emission, key, true,  e, π)        # ρ gets weight π
-        _update_emission!(rt.emission, key, false, e, 1.0 - π)  # σ gets weight 1−π
-    end
-    rt
 end
 
 """
     wire_routing!(env; warm_path) -> RoutingState | nothing
 
-Inject `env[:route-decide]` — the daemon's model-routing closure — from the declared
-routing manifest (routing.bdsl) and the per-profile reward (utility.bdsl). Mirrors
-`FeatureBrain.wire_brain!`: the `.bdsl` carries the DECLARED DATA (roster, costs,
-feature spaces, reward); this builds the typed belief and installs the closure, so the
-daemon call-site (`env[:route-decide](features)`) is unchanged in shape.
-
-INERT (returns `nothing`, installs no closure) unless `routing-models` is declared —
-so a governance-only install with no routing.bdsl is unaffected. The K per-model
-`StructureBMA` posteriors are warm-seeded from `warm_path` (measured per-model accuracy);
-they are held LIVE in the returned `RoutingState` and the `route-decide` closure reads them,
-so `route_outcome!` updates flow into subsequent routing decisions (the deferred online
-signal, now landed — per-turn decoded correctness with learned confounds; see
-ROUTING_DOMINANCE.md). `route-decide` returns `Dict("model"=>id, "provider"=>provider,
-"name"=>name)` for the daemon's route signal. The daemon stores the returned `RoutingState`
-and drives learning via `route_outcome!`.
+Inject `env[:route-decide]`/`[:escalate-decide]` from the declared routing manifest
+(routing.bdsl) + per-profile reward (utility.bdsl). The `.bdsl` carries the DECLARED DATA
+(roster, costs, feature spaces, reward); this builds the typed `RoutingState` (engine struct)
+and installs closures over the lifted `route_decide`/`escalate_decide`, so the daemon
+call-sites are unchanged in shape. INERT (returns `nothing`) unless `routing-models` is
+declared. The K per-model `StructureBMA` posteriors are warm-seeded from `warm_path`; held
+LIVE in the returned `RoutingState` so `route_outcome!` updates flow into later decisions.
 """
 function wire_routing!(env;
                        warm_path = get(env, Symbol("routing-brain-path"),
@@ -438,9 +80,8 @@ function wire_routing!(env;
 
     reward = Float64(get(env, Symbol("correct-answer-value"), 0.02))
 
-    # TIME coordinate (profile dial): w-time = $/sec of the user's wall-clock. 0.0 ⇒ time-blind
-    # (bit-identical to the pre-time router). The latency belief is opt-in by file presence
-    # (like the tail belief): absent ⇒ nothing ⇒ no time term. routing-latency-path overrides.
+    # TIME coordinate (profile dial): w-time = $/sec of wall-clock. 0.0 ⇒ time-blind. Latency
+    # belief is opt-in by file presence; absent ⇒ nothing ⇒ no time term.
     w_time = Float64(get(env, Symbol("w-time"), 0.0))
     latency = let p = get(env, Symbol("routing-latency-path"),
                           joinpath(@__DIR__, "routing_latency.counts.json"))
@@ -453,11 +94,12 @@ function wire_routing!(env;
             end
     end
 
-    # Emission prior: declared (`emission-prior`) auditable data, else the directional default.
+    # Emission prior: declared (`emission-prior`) auditable data, else the engine's directional
+    # default (EmissionBelief() with no arg).
     ep = get(env, Symbol("emission-prior"), nothing)
-    emission_prior = (ep isa AbstractVector && length(ep) == 4) ?
-        (Float64(ep[1]), Float64(ep[2]), Float64(ep[3]), Float64(ep[4])) :
-        _DEFAULT_EMISSION_PRIOR
+    emission = (ep isa AbstractVector && length(ep) == 4) ?
+        EmissionBelief((Float64(ep[1]), Float64(ep[2]), Float64(ep[3]), Float64(ep[4]))) :
+        EmissionBelief()
 
     rfeat = get(env, Symbol("routing-features"), nothing)
     rfeat isa AbstractVector ||
@@ -466,106 +108,20 @@ function wire_routing!(env;
     tops = _reconstruct_routing_tops(rmodel, K, warm_path)
 
     rt = RoutingState(rmodel, tops, Dict{String, MixturePrevision}(),
-                      EmissionBelief(emission_prior), names, providers,
+                      emission, names, providers,
                       model_ids, costs, reward, w_time, latency)
 
-    # The daemon's routing call-site: (feature dict[, live roster]) → the chosen model's wire
-    # fields, or `nothing` (inert ⇒ body keeps OpenClaw's model). Reads rt's beliefs LIVE
-    # (route_outcome! mutates them); the argmax is the single canonical `optimise` inside
-    # `route` (Invariant 1); the only arithmetic is reward/cost coefficient construction.
+    # The daemon's routing call-sites: closures over the LIVE RoutingState (route_outcome!
+    # mutates it). All arithmetic is engine-side inside route_decide/escalate_decide.
     env[Symbol("route-decide")] = (features, roster = nothing, profile = nothing) ->
-        _route_decide(rt, features, roster, profile)
+        route_decide(rt, features, roster, profile)
 
-    # Observe-then-escalate call-site (the dominance proof's WINNING policy, now wired live):
-    # (feature dict, live roster, tried-set, reward) → the next rung's wire fields + its
-    # cost-ascending `tier_index` (the host adds it to `tried` on an observed failure), or
-    # `nothing` (STOP — no positive-EU rung left ⇒ body keeps the current model). The gate is
-    # the single canonical `optimise` inside `escalation_next` (Invariant 1); the host drives
-    # the try→observe→escalate loop. Reads rt's beliefs LIVE, same as route-decide.
     env[Symbol("escalate-decide")] =
         (features, roster = nothing, tried = Int[], reward = nothing, profile = nothing) ->
-            _escalate_decide(rt, features, roster, tried,
-                             reward === nothing ? rt.reward : Float64(reward), profile)
+            escalate_decide(rt, features, roster, tried,
+                            reward === nothing ? rt.reward : Float64(reward), profile)
 
     rt
-end
-
-# Resolve a routing decision over the LIVE roster (the user's actual models, sent per request)
-# or the declared default roster. Returns `nothing` — body keeps OpenClaw's model — when fewer
-# than 2 candidates exist (routing is a no-op with nothing to choose between), so routing-on-
-# by-default is safe for a single-model install.
-# Per-request profile override: the user's utility weights, sent by the body PER REQUEST (like
-# the live roster), so a user switches their cost/time/quality trade-off with NO daemon restart.
-# Returns the override value for `key` if the profile carries it, else the wired default. The
-# profile is preference DATA the body ships; the brain still does all the EU-max (body math-free).
-_pget(profile, key::AbstractString, default::Float64)::Float64 =
-    (profile isa AbstractDict && haskey(profile, key) && profile[key] !== nothing) ?
-        Float64(profile[key]) : default
-
-function _route_decide(rt::RoutingState, features, roster, profile = nothing)
-    names, providers, ids, costs, tops = _resolve_roster(rt, roster)
-    length(ids) >= 2 || return nothing
-    reward = _pget(profile, "reward", rt.reward)        # quality coordinate (per-request override)
-    w_time = _pget(profile, "w_time", rt.w_time)        # time coordinate (per-request override)
-    X = context_from_features(rt.model, features)
-    times = Float64[latency_at(rt.latency, ids[a], X) for a in eachindex(ids)]   # E[time|a,X], 0 if unknown
-    a = route(rt.model, tops, X, costs, reward; w_time = w_time, times = times)
-    Dict{String, Any}("model" => ids[a], "provider" => providers[a], "name" => names[a])
-end
-
-# One escalation step over the LIVE roster: the cheapest not-yet-`tried` rung whose myopic
-# try-EU clears the stop gate, else `nothing` (STOP). `tried` carries cost-ascending indices
-# the host accumulated from observed failures; `reward` is the per-call profile value (defaults
-# to the wired reward). The gate is `escalation_next` (the canonical {try,stop} `optimise`);
-# rungs are ordered cheapest-first because `escalation_next` scans `eachindex(tops)` ascending.
-# The returned `tier_index` is in that cost-ascending space, so the host pushes it straight
-# back into `tried` on a failure (mirrors the eval's `push!(tried, a)` loop).
-function _escalate_decide(rt::RoutingState, features, roster, tried, reward, profile = nothing)
-    names, providers, ids, costs, tops = _resolve_roster(rt, roster)
-    length(ids) >= 2 || return nothing
-    reward = _pget(profile, "reward", Float64(reward))   # per-request quality override
-    w_time = _pget(profile, "w_time", rt.w_time)         # per-request time override
-    order = sortperm(costs)                              # cheapest → dearest
-    X = context_from_features(rt.model, features)
-    triedset = Set{Int}(Int(t) for t in tried)          # indices in cost-ascending space
-    times = Float64[latency_at(rt.latency, ids[i], X) for i in order]   # E[time], aligned to tops[order]
-    a = escalation_next(rt.model, tops[order], X, costs[order], reward, triedset;
-                        w_time = w_time, times_X = times)
-    a == 0 && return nothing                             # no positive-EU rung ⇒ STOP
-    j = order[a]
-    Dict{String, Any}("model" => ids[j], "provider" => providers[j], "name" => names[j],
-                      "tier_index" => a)
-end
-
-# Aligned (names, providers, ids, costs, tops) for the decision. No live roster ⇒ the declared
-# default (warm beliefs). A live roster ⇒ each entry is (name provider model-id cost): a known
-# model reuses its warm/learned belief, an unknown one its cold/learned belief from extra_tops
-# (instantiated on first sight). This is how the user's OWN models get routed.
-function _resolve_roster(rt::RoutingState, roster)
-    (roster === nothing || (roster isa AbstractVector && isempty(roster))) &&
-        return (rt.names, rt.providers, rt.model_ids, rt.costs, rt.tops)
-    roster isa AbstractVector ||
-        error("route-decide: roster must be a list of (name provider model-id cost), got $(typeof(roster))")
-    names = String[]; providers = String[]; ids = String[]; costs = Float64[]
-    tops = MixturePrevision[]
-    for m in roster
-        name, provider, id, cost = _roster_entry(m)
-        push!(names, name); push!(providers, provider); push!(ids, id); push!(costs, cost)
-        push!(tops, _belief_slot(rt, id)[1])
-    end
-    (names, providers, ids, costs, tops)
-end
-
-# One roster entry off the wire: a 4-vector (name provider id cost) or a dict carrying those.
-function _roster_entry(m)
-    if m isa AbstractDict
-        id = String(get(m, "model", get(m, "model_id", get(m, "id", ""))))
-        return (String(get(m, "name", id)), String(get(m, "provider", "")), id,
-                Float64(get(m, "cost", 0.0)))
-    elseif m isa AbstractVector && length(m) == 4
-        return (string(m[1]), string(m[2]), string(m[3]), Float64(m[4]))
-    end
-    error("route-decide: roster entry must be (name provider model-id cost) or {model,provider,cost}, got $(m)")
 end
 
 end # module RoutingBrain

--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -1,6 +1,6 @@
 # Credence Skin Protocol
 
-Protocol-Version: 1.4
+Protocol-Version: 1.5
 
 JSON-RPC 2.0 over stdio. Skin reads newline-delimited JSON from stdin,
 writes newline-delimited JSON to stdout, logs to stderr.
@@ -13,6 +13,15 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
 
 ### Changelog
 
+- **1.5** — routing verbs (decouple Move 4, additive): `routing_init` (build the per-model
+  StructureBMA belief + ρ/σ emission + Gamma latency latents server-side from declared data —
+  roster, costs, reward, and the warm/latency counts INLINE — returning one opaque `rt_*`
+  handle), `routing_decide` (the EU-max model choice), `routing_escalate` (the cheapest-first
+  observe-then-escalate gate), `routing_outcome` (the coupled-EM confound-learning step from a
+  turn's exec signal), `routing_belief` (telemetry: the learned θ/ρ̄/σ̄), and `destroy_routing`.
+  All arithmetic — the ProductMeasure join, the `optimise` argmax, the decode + EM — stays
+  engine-side (`src/routing.jl`); the client ships only data. Additive; no existing verb
+  changes shape. See the `Routing` section below.
 - **1.4** — Move 1 commit-3 specs (additive): a `logistic_reaction` kernel-spec — a binary
   reaction to a latent x under a τ-marginalised choice model, conditioning a categorical over
   the x-grid (replaces life-agent's host-side `reaction_probability`); and a
@@ -421,6 +430,127 @@ tail), `w_time`/`exp_time` (the wall-clock saving), and `harm` are optional; omi
 of them gives the myopic single-outcome decision. `belief_at_context` is intentionally not
 a verb — `structure_decide` consumes the per-context view internally and no consumer reads
 it across the wire.
+
+## Routing (protocol 1.5)
+
+A non-embedding consumer drives EU-max model routing over the wire — no probability
+arithmetic client-side. Unlike the structure-BMA descriptor/belief split, the whole routing
+session is **one opaque `rt_*` handle** (a `RoutingState`: the per-model `StructureBMA`
+beliefs `tops`, the shared ρ/σ emission latents, the Gamma latency belief, the roster +
+utility data). It is a *mutable, growing* bundle — `routing_outcome` mutates it in place and
+it cold-starts beliefs for unseen models/contexts — so the consumer addresses neither
+internal belief; it ships data and reads back a model id. The warm/latency counts are shipped
+**inline** in `routing_init` (the skin reads no host filesystem) and reconstructed
+server-side (order-independent ⇒ exact).
+
+### routing_init
+
+Build the routing session from declared data. `roster` is `[[name, provider, model_id,
+cost], …]`; `warm_counts` (optional) is the per-model correct/incorrect counts replayed to
+warm-seed each model's belief; `latency_counts` (optional) the Gamma turns sufficient
+statistics for the time coordinate. `feature_names`/`feature_values`/`alpha0`/`beta0`/`p_edge`
+mirror `structure_bma`.
+
+```json
+{"method": "routing_init", "params": {
+  "feature_names": ["prompt-length"], "feature_values": [["short", "long"]],
+  "roster": [["haiku", "anthropic", "claude-haiku-4-5", 0.01],
+             ["sonnet", "anthropic", "claude-sonnet-4-6", 0.05],
+             ["opus", "anthropic", "claude-opus-4-8", 0.20]],
+  "reward": 0.02, "w_time": 0.0,
+  "warm_counts": {"per_model": [{"contexts": [{"ctx": ["short"], "n1": 44, "n0": 6}]}, ...]},
+  "latency_counts": {"turns_prior": [2.0, 1.0], "per_model": [{"model_id": "...", "rate_s": 1.4, "contexts": [...]}]},
+  "emission_prior": [2.0, 1.0, 1.0, 2.0]
+}}
+```
+
+```json
+{"result": {"routing_state_id": "rt_1", "n_models": 3}}
+```
+
+`warm_counts.per_model` must have one entry per roster model (positional) or `routing_init`
+fails loud. All of `warm_counts`/`latency_counts`/`emission_prior`/`w_time` are optional
+(cold beliefs / time-blind / directional default).
+
+### routing_decide
+
+The EU-max model for a request (`reward·E[θ_a|X] − cost_a`, the single canonical `optimise`).
+`roster` (optional) is the per-request LIVE roster (the user's actual models, same shape as
+`routing_init`'s); `profile` (optional) per-request `{reward, w_time}` overrides.
+
+```json
+{"method": "routing_decide", "params": {
+  "routing_state_id": "rt_1", "features": {"prompt-length": "short"},
+  "profile": {"reward": 1.0}
+}}
+```
+
+```json
+{"result": {"model": "claude-sonnet-4-6", "provider": "anthropic", "name": "sonnet"}}
+```
+
+Returns `{"model": null}` when fewer than 2 candidates exist (inert — the body keeps its
+model).
+
+### routing_escalate
+
+One observe-then-escalate step: the cheapest not-yet-`tried` rung whose myopic try-EU clears
+the stop gate, else STOP. `tried` is the cost-ascending indices the host accumulated from
+observed failures; the returned `tier_index` is in that same space (push it straight back
+into `tried` on a failure).
+
+```json
+{"method": "routing_escalate", "params": {
+  "routing_state_id": "rt_1", "features": {"prompt-length": "short"}, "tried": [0]
+}}
+```
+
+```json
+{"result": {"model": "claude-sonnet-4-6", "provider": "anthropic", "name": "sonnet", "tier_index": 1}}
+```
+
+Returns `{"model": null}` when no positive-EU rung remains (STOP).
+
+### routing_outcome
+
+Learn from one routed turn's exec signal — the coupled-EM confound step (decode the latent
+correctness from `success`, soft-count the routing belief, M-step the shared ρ/σ emission
+latents). With `human` (optional `true`/`false`), the correctness is known (the gold anchor).
+Mutates the session in place.
+
+```json
+{"method": "routing_outcome", "params": {
+  "routing_state_id": "rt_1", "model_id": "claude-haiku-4-5",
+  "features": {"prompt-length": "short"}, "success": true
+}}
+```
+
+```json
+{"result": {"routing_state_id": "rt_1"}}
+```
+
+No `log_marginal` (the step is a coupled multi-`condition`, not a single update).
+
+### routing_belief
+
+Telemetry: the EM-learned `theta` (E[θ|X]) and the reliability means `rho_bar`/`sigma_bar` at
+a `(model, context)`. For calibration/shadow-mode; the hot `routing_decide` never round-trips
+this. Read-only (an unseen model id is an error, not a silent cold-start).
+
+```json
+{"method": "routing_belief", "params": {
+  "routing_state_id": "rt_1", "model_id": "claude-haiku-4-5", "features": {"prompt-length": "short"}
+}}
+```
+
+```json
+{"result": {"theta": 0.41, "rho_bar": 0.78, "sigma_bar": 0.33}}
+```
+
+### destroy_routing
+
+Free a routing session (`{routing_state_id}` → `{ok: true}`). Matters for long-lived daemons
+— a session's emission/`extra_tops` cells grow with distinct contexts/models.
 
 ## Program-Space Operations (Tier 2)
 

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -38,6 +38,8 @@ using Credence: log_density_at
 using Credence: StructureBMA, build_structure_model, build_structure_prior, structure_observe,
                 belief_at_context, context_from_features, structure_decision_kernel
 using Credence.Ontology: decide_with_voi
+using Credence: RoutingState, EmissionBelief, route_decide, escalate_decide, route_outcome!,
+    routing_belief_readout, reconstruct_routing_tops_from_data, reconstruct_latency_from_data
 
 using JSON3
 using Serialization
@@ -86,6 +88,30 @@ end
 function get_model(id::String)
     haskey(MODEL_REGISTRY, id) || throw(StateNotFound(id))
     MODEL_REGISTRY[id]
+end
+
+# Routing state (decouple Move 4) — a MUTABLE, growing bundle: route_outcome! mutates `tops`
+# + emission cells in place, and `extra_tops`/ρ/σ cells grow with unseen models/contexts. So
+# it gets its OWN `rt_*` registry, NOT MODEL_REGISTRY (which holds IMMUTABLE descriptors —
+# putting a mutated, growing bundle there would void that invariant) and NOT STATE_REGISTRY
+# (so the generic Prevision verbs give a clean StateNotFound on a routing handle).
+const ROUTING_REGISTRY = Dict{String, Any}()
+let counter = Ref(0)
+    global function next_routing_id()
+        counter[] += 1
+        "rt_$(counter[])"
+    end
+end
+
+function register_routing(rt)
+    id = next_routing_id()
+    ROUTING_REGISTRY[id] = rt
+    id
+end
+
+function get_routing(id::String)
+    haskey(ROUTING_REGISTRY, id) || throw(StateNotFound(id))
+    ROUTING_REGISTRY[id]
 end
 
 # ═══════════════════════════════════════
@@ -652,7 +678,7 @@ end
 # rides the `credence-skin` image tag). MAJOR bumps on a breaking protocol
 # change; MINOR on additive. Apps pin the major in code and `initialize`
 # rejects a mismatching major with -32010. See docs/decouple/master-plan.md.
-const PROTOCOL_VERSION = "1.4"
+const PROTOCOL_VERSION = "1.5"
 protocol_major(v) = String(first(split(String(v), ".")))
 
 # Advertised method set, returned by `initialize` for client capability
@@ -666,6 +692,8 @@ const SKIN_METHODS = [
     "top_grammars", "belief_summary", "condition_and_prune", "eu_interact",
     "call_dsl", "factor", "replace_factor", "n_factors",
     "structure_bma", "structure_observe", "structure_decide",
+    "routing_init", "routing_decide", "routing_escalate", "routing_outcome",
+    "routing_belief", "destroy_routing",
 ]
 
 function handle_request(method::String, params, id)
@@ -701,6 +729,18 @@ function handle_request(method::String, params, id)
         handle_structure_observe(params)
     elseif method == "structure_decide"
         handle_structure_decide(params)
+    elseif method == "routing_init"
+        handle_routing_init(params)
+    elseif method == "routing_decide"
+        handle_routing_decide(params)
+    elseif method == "routing_escalate"
+        handle_routing_escalate(params)
+    elseif method == "routing_outcome"
+        handle_routing_outcome(params)
+    elseif method == "routing_belief"
+        handle_routing_belief(params)
+    elseif method == "destroy_routing"
+        handle_destroy_routing(params)
     elseif method == "draw"
         handle_draw(params)
     elseif method == "enumerate"
@@ -1213,6 +1253,112 @@ function handle_structure_decide(params)
         _wrap_inf("decide_with_voi failed")(e)
     end
     Dict{String, Any}("action" => string(action))
+end
+
+# ═══════════════════════════════════════
+# Routing verbs (decouple Move 4)
+#
+# A non-embedding consumer drives EU-max model routing over the wire: build the per-model
+# StructureBMA belief + emission/latency latents server-side (`routing_init`, from declared
+# DATA — roster, costs, reward, and the warm/latency counts INLINE), choose the EU-max model
+# (`routing_decide`) or the next escalation rung (`routing_escalate`), learn from a turn's
+# exec signal (`routing_outcome` — the coupled-EM confound step), and read the learned belief
+# (`routing_belief`, telemetry). The whole RoutingState is ONE opaque `rt_*` handle; ALL
+# arithmetic (the ProductMeasure join, the optimise argmax, the decode + EM) is engine-side
+# (src/routing.jl), so Invariant 1 holds across the wire by construction.
+# ═══════════════════════════════════════
+
+# Wire dicts use string-or-symbol keys depending on the JSON reader; normalise to a plain
+# String=>String features dict (as the structure verbs do) and a String=>Any profile dict.
+_features(f) = Dict(string(k) => string(v) for (k, v) in pairs(f))
+_profile(p) = p === nothing ? nothing : Dict(string(k) => v for (k, v) in pairs(p))
+
+function handle_routing_init(params)
+    names = String[string(n) for n in params["feature_names"]]
+    values = Vector{String}[String[string(v) for v in vs] for vs in params["feature_values"]]
+    roster = params["roster"]                       # [[name, provider, model_id, cost], …]
+    rnames = String[]; rproviders = String[]; rids = String[]; rcosts = Float64[]
+    for m in roster
+        push!(rnames, string(m[1])); push!(rproviders, string(m[2]))
+        push!(rids, string(m[3])); push!(rcosts, Float64(m[4]))
+    end
+    K = length(rids)
+    rt = try
+        model = build_structure_model(names, values;
+                                      alpha0 = Float64(get(params, "alpha0", 2.0)),
+                                      beta0 = Float64(get(params, "beta0", 2.0)),
+                                      p_edge = Float64(get(params, "p_edge", 0.5)))
+        tops = reconstruct_routing_tops_from_data(model, K, get(params, "warm_counts", nothing))
+        emp = get(params, "emission_prior", nothing)
+        emission = (emp !== nothing && length(emp) == 4) ?
+            EmissionBelief((Float64(emp[1]), Float64(emp[2]), Float64(emp[3]), Float64(emp[4]))) :
+            EmissionBelief()
+        lat = get(params, "latency_counts", nothing)
+        latency = lat === nothing ? nothing : reconstruct_latency_from_data(lat)
+        RoutingState(model, tops, Dict{String, MixturePrevision}(), emission,
+                     rnames, rproviders, rids, rcosts,
+                     Float64(get(params, "reward", 0.02)), Float64(get(params, "w_time", 0.0)),
+                     latency)
+    catch e
+        _wrap_dsl("routing_init failed")(e)
+    end
+    Dict{String, Any}("routing_state_id" => register_routing(rt), "n_models" => K)
+end
+
+function handle_routing_decide(params)
+    rt = get_routing(string(params["routing_state_id"]))
+    res = try
+        route_decide(rt, _features(params["features"]),
+                     get(params, "roster", nothing), _profile(get(params, "profile", nothing)))
+    catch e
+        _wrap_inf("routing_decide failed")(e)
+    end
+    res === nothing ? Dict{String, Any}("model" => nothing) : res   # <2 candidates ⇒ inert
+end
+
+function handle_routing_escalate(params)
+    rt = get_routing(string(params["routing_state_id"]))
+    rew = get(params, "reward", nothing)
+    res = try
+        escalate_decide(rt, _features(params["features"]), get(params, "roster", nothing),
+                        [Int(t) for t in get(params, "tried", Int[])],
+                        rew === nothing ? rt.reward : Float64(rew),
+                        _profile(get(params, "profile", nothing)))
+    catch e
+        _wrap_inf("routing_escalate failed")(e)
+    end
+    res === nothing ? Dict{String, Any}("model" => nothing) : res   # no positive-EU rung ⇒ STOP
+end
+
+function handle_routing_outcome(params)
+    id = string(params["routing_state_id"])
+    rt = get_routing(id)
+    human = get(params, "human", nothing)
+    try
+        route_outcome!(rt, string(params["model_id"]), _features(params["features"]),
+                       Bool(params["success"]); human = human === nothing ? nothing : Bool(human))
+    catch e
+        _wrap_inf("routing_outcome failed")(e)
+    end
+    Dict{String, Any}("routing_state_id" => id)              # mutated in place; no log_marginal
+end
+
+# Telemetry read-back (the routing analogue of belief_at_context-as-verb): the EM-learned
+# θ/ρ̄/σ̄ at a (model, context), for calibration/shadow-mode + the wire parity test. The hot
+# routing_decide builds the per-context view server-side and never round-trips this. The
+# actual reads live in the engine (`routing_belief_readout`); the verb only marshals.
+function handle_routing_belief(params)
+    rt = get_routing(string(params["routing_state_id"]))
+    try
+        routing_belief_readout(rt, string(params["model_id"]), _features(params["features"]))
+    catch e
+        _wrap_inf("routing_belief failed")(e)
+    end
+end
+
+function handle_destroy_routing(params)
+    delete!(ROUTING_REGISTRY, string(params["routing_state_id"]))
+    Dict{String, Any}("ok" => true)
 end
 
 function handle_draw(params)

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -1131,6 +1131,68 @@ def test_structure_bma_roundtrip():
         skin.shutdown()
 
 
+def test_routing_verbs_roundtrip():
+    """A non-embedding consumer drives EU-max model routing over the wire only: build the
+    session (`routing_init`, warm counts inline), pick the EU-max model (`routing_decide`),
+    learn from a turn (`routing_outcome`), read the learned belief (`routing_belief`), and
+    walk the escalation ladder (`routing_escalate`) — ZERO probability arithmetic client-side.
+    Asserts the Wald flip over the wire (cost-hawk → cheap, quality-hawk → best-believed),
+    that learning raises θ, and the cheapest-first escalation ladder."""
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        roster = [["haiku", "anthropic", "claude-haiku-4-5", 0.01],
+                  ["sonnet", "anthropic", "claude-sonnet-4-6", 0.05],
+                  ["opus", "anthropic", "claude-opus-4-8", 0.20]]
+        # Warm so sonnet is best-believed, haiku worst (and cheapest) — sets up the Wald flip.
+        warm = {"per_model": [
+            {"contexts": [{"ctx": ["short"], "n1": 35, "n0": 15}]},   # haiku
+            {"contexts": [{"ctx": ["short"], "n1": 45, "n0": 5}]},    # sonnet
+            {"contexts": [{"ctx": ["short"], "n1": 40, "n0": 10}]},   # opus
+        ]}
+        init = skin._call("routing_init", {
+            "feature_names": ["prompt-length"], "feature_values": [["short", "long"]],
+            "roster": roster, "reward": 0.02, "warm_counts": warm})
+        rt = init["routing_state_id"]
+        assert rt.startswith("rt_") and init["n_models"] == 3, init
+
+        feats = {"prompt-length": "short"}
+        cheap = skin._call("routing_decide", {"routing_state_id": rt, "features": feats,
+                                              "profile": {"reward": 0.01}})
+        best = skin._call("routing_decide", {"routing_state_id": rt, "features": feats,
+                                             "profile": {"reward": 1.0}})
+        # credence-lint: allow — precedent:test-oracle — asserts the Wald flip over the wire; non-causal w.r.t. any agent
+        assert cheap["model"] == "claude-haiku-4-5", f"cost-hawk should route cheap: {cheap}"
+        # credence-lint: allow — precedent:test-oracle — asserts the Wald flip over the wire; non-causal w.r.t. any agent
+        assert best["model"] == "claude-sonnet-4-6", f"quality-hawk should route best-believed: {best}"
+
+        # Learning over the wire raises the routed model's θ (routing_belief makes the EM observable).
+        before = skin._call("routing_belief", {"routing_state_id": rt,
+                                               "model_id": "claude-haiku-4-5", "features": feats})["theta"]
+        for _ in range(20):
+            r = skin._call("routing_outcome", {"routing_state_id": rt, "model_id": "claude-haiku-4-5",
+                                               "features": feats, "success": True})
+            assert r["routing_state_id"] == rt, r
+        after = skin._call("routing_belief", {"routing_state_id": rt,
+                                              "model_id": "claude-haiku-4-5", "features": feats})["theta"]
+        # credence-lint: allow — precedent:test-oracle — asserts online learning raised θ; non-causal w.r.t. any agent
+        assert after > before, f"successes should raise θ over the wire: {before} → {after}"
+
+        # Escalation ladder (reward high so every rung is positive-EU): cheapest-first 1→2→3→null.
+        def rung(tried):
+            return skin._call("routing_escalate", {"routing_state_id": rt, "features": feats,
+                                                   "tried": tried, "reward": 1.0})
+        # credence-lint: allow — precedent:test-oracle — asserts the cheapest-first escalation ladder; non-causal
+        assert rung([])["tier_index"] == 1 and rung([1])["tier_index"] == 2, "ladder should climb cheapest-first"
+        # credence-lint: allow — precedent:test-oracle — asserts the ladder STOPs once all rungs are tried; non-causal
+        assert rung([1, 2])["tier_index"] == 3 and rung([1, 2, 3])["model"] is None, "ladder should STOP when exhausted"
+
+        assert skin._call("destroy_routing", {"routing_state_id": rt})["ok"] is True
+        print("PASS: routing verbs roundtrip (init / decide Wald-flip / outcome / belief / escalate)")
+    finally:
+        skin.shutdown()
+
+
 # ── Wire-contract tests (decouple Move 0) ──
 
 
@@ -1139,7 +1201,7 @@ def test_initialize_returns_contract():
     skin = SkinClient()
     try:
         result = skin.initialize()
-        assert result["protocol"] == "1.4", f"protocol: {result.get('protocol')}"
+        assert result["protocol"] == "1.5", f"protocol: {result.get('protocol')}"
         assert "version" in result, "engine version missing"
         methods = result["methods"]
         # Core canalised verbs + the Move-3 structure-BMA verbs must be advertised.
@@ -1185,7 +1247,7 @@ def test_dsl_sources_inline_equivalent_to_path():
         # a subsequent call_dsl against the loaded env resolves (the path-based
         # test_router_roundtrip already covers the path branch).
         result = skin.initialize(dsl_sources={"router": source})
-        assert result["protocol"] == "1.4"
+        assert result["protocol"] == "1.5"
         print("PASS: inline dsl_sources loads equivalently to a path load")
     finally:
         skin.shutdown()
@@ -1291,6 +1353,8 @@ if __name__ == "__main__":
     test_call_dsl_belief_roundtrip()
     print()
     test_structure_bma_roundtrip()
+    print()
+    test_routing_verbs_roundtrip()
     print()
     test_labelled_mixture_rho_latent()
     print()

--- a/docs/decouple/move-4-design.md
+++ b/docs/decouple/move-4-design.md
@@ -1,0 +1,186 @@
+# Decouple Move 4 — routing-brain lift
+
+## 0. Final-state alignment
+
+Move 3 lifted credence-pi's **governance** brain into engine stdlib + skin verbs
+(`structure_bma`/`structure_observe`/`structure_decide`), making it wire-drivable, and
+*enabled* — but explicitly deferred — the literal repo extraction. Move 4 closes the
+remaining gap so the **entire** credence-pi reasoning surface is wire-drivable: it lifts
+the **routing** brain. Move 5 (separate doc) then extracts credence-pi to its own repo
+(`credence-openclaw`) as a pure wire consumer that pins the `credence-skin` image.
+
+After Move 4, `apps/credence-pi/brain/routing_brain.jl` carries **zero** probabilistic
+Julia (a shim, like `feature_brain.jl`); the routing math lives in `src/routing.jl` and
+is reachable over the wire via six additive skin verbs at protocol **1.5**.
+
+## 1. Purpose
+
+credence-openclaw will be an *external* app → it must consume the engine across the skin
+wire only, carrying no probabilistic Julia (`SPEC §6.9`; the principle "credence must
+not enable an external app to host its own brain"). Governance is already wire-ready;
+routing is not. The routing **decisions** (`route`/`escalation_next`) and the **online
+confound-learning** (`decode_correctness` + the coupled-EM `route_outcome!` over ρ/σ
+emission Betas + the Gamma latency belief) live only in `routing_brain.jl`, with no
+routing skin verbs. Move 4 lifts them.
+
+Routing **reuses** the already-lifted `StructureBMA` substrate
+(`build_structure_prior`/`structure_observe`/`structure_observe_soft`/
+`belief_at_context`), so this is a builder/decision/learning **lift**, not new inference
+— exactly as Move 3 was a lift of an already-Tier-1 substrate.
+
+## 2. Files touched
+
+### Created
+- `src/routing.jl` — the lifted routing body: `RoutingState`, `EmissionBelief`,
+  `LatencyBelief`, `route`/`route_eu`/`escalation_next`/`posterior_accuracy`, the
+  coupled-EM `route_outcome!`, the closed-form `decode_correctness`, the named decision
+  resolvers `route_decide`/`escalate_decide` (un-underscored from the app's
+  `_route_decide`/`_escalate_decide`), and the data-in `reconstruct_latency_from_data` /
+  `reconstruct_routing_tops_from_data`. Composes only Tier-1 ops — no new frozen type,
+  no new axiom-constrained fn.
+- `test/test_routing.jl` — self-contained engine oracle (no `apps/` dependency).
+
+### Modified
+- `src/ontology.jl` — `include("routing.jl")` immediately after
+  `include("structure_bma.jl")` (routing depends on it); import the lifted names.
+- `src/Credence.jl` — export the lifted names.
+- `apps/skin/server.jl` — a new `ROUTING_REGISTRY` (`rt_*` handles) + six verbs
+  (`routing_init`/`routing_decide`/`routing_escalate`/`routing_outcome`/
+  `routing_belief`/`destroy_routing`) + `SKIN_METHODS` + dispatch; `PROTOCOL_VERSION`
+  1.4 → 1.5.
+- `apps/skin/protocol.md` — header 1.5 + changelog + verb specs + `rt_*` lifecycle +
+  inline-counts shape.
+- `apps/skin/test_skin.py` — a routing wire trace.
+- `apps/credence-pi/brain/routing_brain.jl` — collapse to a thin shim re-exporting the
+  lifted names + keeping the env-reading `wire_routing!` and the path-reading
+  reconstruction wrappers.
+
+### Not touched (explicit non-goals)
+- **No daemon rewire / repo extraction** — that is Move 5. The daemon still embeds
+  (`using Credence`) after this move; embedding is now *optional*, the verbs are the
+  wire path.
+- **No governance changes** — already lifted in Move 3.
+- The body (`openclaw-plugin` TS, HTTP→daemon) is unchanged.
+
+## 3. Behaviour preserved
+
+`apps/credence-pi/tests/julia/test_routing.jl` (40 assertions: exact `==` for
+decisions/replay, bounded tolerances for the EM identifiability) passes **byte-for-byte
+unmodified** through the shim — the canonical "capture PRE-refactor, assert `==`" pin
+(green on `39fa38c` before the lift; must stay green after with zero edits). The daemon
+(`server.jl:55 using .RoutingBrain: wire_routing!, route_outcome!`) and every `eval/`
+reach-in resolve through the shim's re-export union.
+
+## 4. Worked end-to-end example (the wire path credence-openclaw will use)
+
+```
+initialize                                  → {protocol:"1.5", …}
+routing_init {feature_names, feature_values, roster:[[name,provider,id,cost]×3],
+              reward:0.02, warm_counts:{…inline JSON…}}   → {routing_state_id:"rt_1", n_models:3}
+routing_decide {rt_1, features:{prompt-length:"short"}, profile:{reward:0.02}}  → {model:"haiku",…}   # cost-hawk → cheap
+routing_decide {rt_1, features:{prompt-length:"short"}, profile:{reward:1.0}}   → {model:"sonnet",…}  # quality-hawk → best-believed (Wald flip)
+routing_outcome {rt_1, model_id:"haiku", features:{…}, success:true} ×30        → {routing_state_id:"rt_1"}
+routing_belief {rt_1, model_id:"haiku", features:{…}}                           → {theta:↑, rho_bar, sigma_bar}
+routing_escalate {rt_1, features, tried:[]}  → tier 1; {…tried:[0]} → tier 2; … → null (STOP)
+```
+All coefficient assembly (`reward·θ − cost`, the ProductMeasure join, the EM decode)
+happens server-side; the consumer ships only data and reads back a model id.
+
+## 5. Open design questions
+
+1. **RoutingState = one opaque handle in a new `ROUTING_REGISTRY`** (recommended,
+   adopted). It is a *mutable* bundle (mutated every `routing_outcome`) that grows
+   unboundedly (`extra_tops` per unseen model id, ρ/σ cells per unseen context key), and
+   the consumer addresses *neither* internal belief — so the Move-3 `m_*`/`s_*` split
+   does not transfer (that split exists because the governance consumer addresses both,
+   and `MODEL_REGISTRY` is justified by descriptor *immutability*). Pushback welcome on:
+   reuse `STATE_REGISTRY` (it already holds the mutable `AgentState`) vs a dedicated
+   registry? Chosen: dedicated, so the generic `weights`/`expect`/`destroy_state` verbs
+   give a clean typed error on an `rt_*` handle rather than a confusing one.
+2. **`decode_correctness` stays closed-form** (do NOT re-express via a transient
+   `condition`+`mean`). `conjugate.jl:63-73` computes the identical `π` formula but at the
+   *per-cell* level (`θ̄=α/(α+β)`); routing needs `θ̄=E[θ|X]` at the *mixture* level
+   (`posterior_accuracy`), because the emission M-step must be weighted by the coherent
+   per-turn correctness, not a per-cell responsibility. The transient-condition route
+   computes the wrong π and breaks bit-exactness. Is the closed-form `π` (sanctioned
+   E-step arithmetic, legal in `src/`) the right call? (Yes — see §8.)
+3. **Warm reconstruction = inline counts data** in `routing_init`, reconstructed
+   server-side (skin never reads the host FS for external consumers — same rule as
+   `dsl_sources`). This is a genuinely new transport shape (its only precedent is
+   `dsl_sources`). The path-reading wrappers stay in the shim for the still-embedding
+   daemon.
+4. **Named decision templates** (`route`/`escalation_next` lifted as engine functions the
+   verbs call), NOT a raw-`optimise`-over-Functional-JSON wire path — the latter would
+   re-leak `Projection`/`LinearCombination` assembly into the consumer, the anti-pattern
+   Move-3's named `decide_with_voi` exists to prevent.
+5. **`routing_belief` telemetry verb** — is it worth a verb the hot path never uses? It
+   exists so calibration/shadow-mode and the wire parity test can observe the EM-learned
+   belief; the hot `routing_decide` builds the per-context view server-side and never
+   round-trips. (Mirrors the Move-3 question about `belief_at_context`-as-verb; kept
+   because the wire test cannot otherwise see learning.)
+
+## 6. Risk + mitigation
+
+- **Silent re-export miss** → an `eval/` or daemon `RoutingBrain.foo` resolves to
+  nothing. *Mitigation:* the shim re-exports the grepped union (`route`, `route_eu`,
+  `escalation_next`, `posterior_accuracy`, `route_outcome!`, `decode_correctness`,
+  `latency_at`, `reconstruct_latency`, `_reconstruct_routing_tops`, `wire_routing!`,
+  `RoutingState`, `EmissionBelief`, `LatencyBelief`, `_ctx_key`); `test_routing.jl` +
+  loading every `eval/*.jl` is the gate.
+- **`_ctx_key` drift** → emission/latency key mismatch. *Mitigation:* re-export, never
+  re-define, the engine `_ctx_key`.
+- **Replay non-determinism** → the exact-`==` replay oracle breaks. *Mitigation:*
+  `reconstruct_routing_tops_from_data` replays `structure_observe` in the same n1-then-n0
+  order the app used; Bayesian updates are order-independent so cold-starts stay exact.
+- **Protocol header≠const** (Move-3 risk). *Mitigation:* bump both; CI invariant + the
+  new skin-wire-smoke gate.
+- **Mutable bundle in the immutable-descriptor registry.** *Mitigation:* `ROUTING_REGISTRY`,
+  not `MODEL_REGISTRY`; do not dual-register the inner `StructureBMA`.
+
+## 7. Verification cadence
+
+1. Baseline: `test_routing.jl` green on `39fa38c` (done).
+2. After the lift: `test_routing.jl` byte-for-byte green; `test_server.jl`; every
+   `eval/*.jl` loads; the engine precompiles.
+3. New `test/test_routing.jl` engine oracle green (Wald flip exact, escalation gate
+   ±1e-6, `w_time=0` bit-identical, soft↔hard corners, confound-partialling, seeded EM
+   bands).
+4. Skin: `test_skin.py` routing trace + backward-compat; lint `check apps/` clean;
+   header==const(1.5).
+5. CI green + author approval → rebase-merge.
+
+## 8. de Finettian discipline self-audit
+
+- **Invariant 1 (one reasoner):** preserved. `route`/`escalation_next` still go through
+  the single canonical `optimise`; `route_outcome!` is *learning*, and every belief
+  change is `condition` (emission Betas via `WeightedBernoulli`, routing belief via
+  `structure_observe`/`structure_observe_soft`). No second optimiser, no hand-rolled
+  posterior.
+- **Invariant 2 (declared structure / closed-form EU):** preserved. The lifted
+  decisions keep typed `LinearCombination`/`Projection` Functionals; the verbs never put
+  a Functional or `ProductMeasure` on the wire (consumer ships scalars; the template
+  assembles coefficients server-side).
+- **Invariant 3 (single-responsibility representations):** the subtle one. `RoutingState`
+  *fuses* an immutable `StructureBMA` descriptor with mutable beliefs **under one
+  handle**, but they remain **separate objects** — the fusion is at *handle* granularity
+  (ergonomics), not *representation* granularity. Not a violation; called out because a
+  reviewer conditioned on Move-3's `m_*`/`s_*` split will reach for the flag.
+- **"Every numerical query through `expect`?"** — a *weaker* "yes" than Move 3.
+  `decode_correctness` does a closed-form Bayes combine `π = r·θ̄/(r·θ̄+w·(1−θ̄))` on
+  `θ̄` (an `expect` query) and `(r,w)` (emission `mean` queries). The combine is
+  sanctioned E-step arithmetic, legal in `src/` (Tier 1) and structurally identical to
+  the posterior-param arithmetic `conjugate.jl` already blesses — **not** Move-3's "no
+  raw probability arithmetic at all." This is the one place the audit answer differs from
+  Move 3's clean yes.
+
+## Reviewer checklist
+
+- [ ] `apps/credence-pi/tests/julia/test_routing.jl` passes **unmodified**.
+- [ ] Every `RoutingBrain.*` reach-in (daemon, `eval/`, tests) resolves via the shim.
+- [ ] `decode_correctness` is closed-form (not transient-condition); bit-exact replay.
+- [ ] `ROUTING_REGISTRY` (not `MODEL_REGISTRY`); `destroy_routing` present.
+- [ ] No `optimise`/`LinearCombination`/`Projection`/`ProductMeasure` import left in the
+      shim.
+- [ ] Protocol header == `PROTOCOL_VERSION` == 1.5; verbs additive (MINOR).
+- [ ] Inline counts (`warm_counts`/`latency_counts`) reconstructed server-side; skin
+      reads no host FS.

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -58,6 +58,7 @@ export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal, wrap_in_measure
 export ConjugatePrevision, maybe_conjugate, update
 export StructureBMA, build_structure_model, build_structure_prior, build_structure_prior_dense, structure_observe, structure_observe_soft, belief_at_context, context_from_features, structure_firing_tags, structure_decision_kernel
+export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next, posterior_accuracy, route_outcome!, decode_correctness, latency_at, route_decide, escalate_decide, reconstruct_latency_from_data, reconstruct_routing_tops_from_data, _ctx_key
 export draw
 export weights, mean, variance, probability, marginal, prune, truncate, logsumexp
 export WeightsDomainError

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -58,7 +58,7 @@ export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal, wrap_in_measure
 export ConjugatePrevision, maybe_conjugate, update
 export StructureBMA, build_structure_model, build_structure_prior, build_structure_prior_dense, structure_observe, structure_observe_soft, belief_at_context, context_from_features, structure_firing_tags, structure_decision_kernel
-export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next, posterior_accuracy, route_outcome!, decode_correctness, latency_at, route_decide, escalate_decide, reconstruct_latency_from_data, reconstruct_routing_tops_from_data, _ctx_key
+export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next, posterior_accuracy, route_outcome!, decode_correctness, latency_at, route_decide, escalate_decide, routing_belief_readout, reconstruct_latency_from_data, reconstruct_routing_tops_from_data, _ctx_key
 export draw
 export weights, mean, variance, probability, marginal, prune, truncate, logsumexp
 export WeightsDomainError

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1755,7 +1755,7 @@ export StructureBMA, build_structure_model, build_structure_prior,
 include("routing.jl")
 export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next,
        posterior_accuracy, route_outcome!, decode_correctness, latency_at,
-       route_decide, escalate_decide, reconstruct_latency_from_data,
+       route_decide, escalate_decide, routing_belief_readout, reconstruct_latency_from_data,
        reconstruct_routing_tops_from_data, _ctx_key
 
 end # module Ontology

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1752,4 +1752,10 @@ export StructureBMA, build_structure_model, build_structure_prior,
        belief_at_context, context_from_features, structure_firing_tags,
        structure_decision_kernel
 
+include("routing.jl")
+export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next,
+       posterior_accuracy, route_outcome!, decode_correctness, latency_at,
+       route_decide, escalate_decide, reconstruct_latency_from_data,
+       reconstruct_routing_tops_from_data, _ctx_key
+
 end # module Ontology

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -1,0 +1,377 @@
+# routing.jl — EU-max model routing, lifted into the engine (decouple Move 4).
+#
+# The probabilistic body of what was apps/credence-pi/brain/routing_brain.jl: the routing
+# DECISIONS (route / route_eu / escalation_next over a ProductMeasure of per-model
+# belief-at-context views) and the ONLINE confound-learning (decode_correctness + the
+# coupled-EM route_outcome! over ρ/σ emission Betas + the Gamma latency belief). It REUSES
+# the structure-BMA substrate already lifted in structure_bma.jl
+# (build_structure_prior / structure_observe / structure_observe_soft / belief_at_context /
+# context_from_features) — one shared feature schema, K trained posteriors `tops[a]` (label
+# "model a was correct"). Composes only Tier-1 ops; no new frozen type, no new
+# axiom-constrained function. Included inside `module Ontology` after structure_bma.jl, so
+# every symbol is in scope (no Main.Credence / ..FeatureBrain qualifiers).
+#
+# The decision: given a request's features X and a roster of candidate models, pick the model
+# maximising expected welfare EU(a|X) = reward·E[θ_a|X] − cost_a — the SAME EU-max the
+# governance brain runs (decide_with_voi), only the action set is the model roster and the
+# payoff is reward·accuracy − cost. The argmax is the single canonical `optimise` (Invariant 1).
+
+# ── Latency belief: E[time | model, X] = E[turns|X]·s̄, the TIME coordinate ──────────────
+struct LatencyBelief
+    time_mean::Dict{Tuple{String, String}, Float64}   # (model_id, ctx_key) -> E[time] seconds
+end
+
+# Reconstruct E[time] per (model, context) from already-parsed counts data (the skin/shim
+# does the JSON parsing; the engine never reads the host FS). Shape:
+# { "turns_prior":[α0,β0], "per_model":[ {"model_id":..,"rate_s":..,
+#   "contexts":[ {"ctx":["short"],"sum_turns":412,"n_obs":30} ]} ] }. The posterior
+# Gamma(α0+Σt, β0+n) is order-independent, so reconstruction is exact (no Serialization).
+function reconstruct_latency_from_data(data)::LatencyBelief
+    α0, β0 = Float64(data["turns_prior"][1]), Float64(data["turns_prior"][2])
+    tm = Dict{Tuple{String, String}, Float64}()
+    for pm in data["per_model"]
+        id = String(pm["model_id"]); rate = Float64(pm["rate_s"])
+        for ctx in pm["contexts"]
+            g = GammaPrevision(α0 + Float64(ctx["sum_turns"]), β0 + Float64(ctx["n_obs"]))
+            etime = Float64(expect(g, Identity())) * rate     # E[turns]=α/β, ×s̄ ⇒ E[time]
+            tm[(id, _ctx_key([String(c) for c in ctx["ctx"]]))] = etime
+        end
+    end
+    LatencyBelief(tm)
+end
+
+# E[time|model,X] seconds, or 0.0 for an unknown (model, context) ⇒ that candidate carries no
+# time term (conservative: time never penalises a model we have no latency belief for).
+latency_at(lb::LatencyBelief, model_id::AbstractString, X::AbstractVector) =
+    get(lb.time_mean, (String(model_id), _ctx_key(X)), 0.0)
+latency_at(::Nothing, ::AbstractString, ::AbstractVector) = 0.0
+
+# Per-action EU functional: reward·θ_a − cost_a, over the joint belief's a-th component
+# (Projection(a) = θ_a). reward/cost are declared utility DATA; multiplying them into
+# LinearCombination coefficients is coefficient construction, not probability arithmetic.
+# `time_cost` = w_time·E[time|a,X] folds into the SAME offset as −cost (E[time] is a known
+# scalar at decision time, not co-varying with θ). time_cost=0 ⇒ −(cost+0)==−cost.
+_eu_functional(a::Int, reward::Float64, cost::Float64, time_cost::Float64 = 0.0) =
+    LinearCombination(Tuple{Float64, TestFunction}[(reward, Projection(a))], -(cost + time_cost))
+
+# Joint belief over all K models at context X: a ProductMeasure of each model's
+# belief-at-context view (independence-across-models made explicit). Action a's EU reads its
+# own component via Projection(a); the others integrate out.
+function _joint_at(model::StructureBMA, tops::AbstractVector, X::AbstractVector)
+    K = length(tops)
+    cells = Measure[wrap_in_measure(belief_at_context(model, tops[a], X)) for a in 1:K]
+    ProductMeasure(cells), K
+end
+
+function _fpa(K::Int, reward::Real, costs::AbstractVector,
+             w_time::Real = 0.0, times = nothing)
+    r = Float64(reward); wt = Float64(w_time)
+    Dict{Int, LinearCombination}(
+        a => _eu_functional(a, r, Float64(costs[a]),
+                            times === nothing ? 0.0 : wt * Float64(times[a])) for a in 1:K)
+end
+
+"""
+    route(model, tops, X, costs, reward) -> Int
+
+Return the 1-based index of the EU-max model for a request with context `X`. `tops[a]` is
+model a's `StructureBMA` posterior over P(correct|·); `costs[a]` its per-call cost; `reward`
+the profile's dollar value of a correct answer. The argmax is the single canonical `optimise`
+over the joint per-model belief (Invariant 1).
+"""
+function route(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
+               costs::AbstractVector, reward::Real; w_time::Real = 0.0, times = nothing)
+    length(tops) == length(costs) ||
+        error("route: tops/costs length mismatch ($(length(tops)) vs $(length(costs)))")
+    (times === nothing || length(times) == length(tops)) ||
+        error("route: tops/times length mismatch ($(length(tops)) vs $(length(times)))")
+    joint, K = _joint_at(model, tops, X)
+    optimise(joint, collect(1:K), _fpa(K, reward, costs, w_time, times))
+end
+
+"""
+    route_eu(model, tops, X, costs, reward) -> (Int, Float64)
+
+`route` plus the EU of the chosen model (reward·E[θ_a|X] − cost_a), re-read through `expect`
+of the chosen action's functional — never recomputed by hand.
+"""
+function route_eu(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
+                  costs::AbstractVector, reward::Real; w_time::Real = 0.0, times = nothing)
+    joint, K = _joint_at(model, tops, X)
+    fpa = _fpa(K, reward, costs, w_time, times)
+    a = optimise(joint, collect(1:K), fpa)
+    a, Float64(expect(joint, fpa[a]))
+end
+
+"""
+    posterior_accuracy(model, top, X) -> Float64
+
+E[θ | X] = the posterior-mean accuracy of one model at context X, read through `expect` of
+`Identity` over its belief-at-context view. Inspection only; never used to decide.
+"""
+posterior_accuracy(model::StructureBMA, top::MixturePrevision, X::AbstractVector) =
+    Float64(expect(belief_at_context(model, top, X), Identity()))
+
+# Stop action = the zero functional (EU 0: decline to spend). Peer of `_eu_functional`.
+const _STOP_FUNCTIONAL = LinearCombination(Tuple{Float64, TestFunction}[], 0.0)
+
+"""
+    escalation_next(model, tops, X, costs_X, reward, tried) -> Int
+
+Observe-then-escalate routing. Among tiers not yet `tried`, cheapest first (`costs_X`
+ascending), return the cheapest whose single-step EU to try is at least the EU of stopping
+(`optimise` prefers "try" to "stop"), else 0 (STOP). The {try, stop} choice is the single
+canonical `optimise` over the tier's belief-at-context. MYOPIC (one rung at a time).
+"""
+function escalation_next(model::StructureBMA, tops::AbstractVector, X::AbstractVector,
+                         costs_X::AbstractVector, reward::Real, tried;
+                         w_time::Real = 0.0, times_X = nothing)
+    r = Float64(reward); wt = Float64(w_time)
+    for a in eachindex(tops)                       # costs_X ascending ⇒ cheapest-first
+        a in tried && continue
+        tc = times_X === nothing ? 0.0 : wt * Float64(times_X[a])   # w_time·E[time|a,X]
+        belief = ProductMeasure(Measure[wrap_in_measure(belief_at_context(model, tops[a], X))])
+        tryf = LinearCombination(Tuple{Float64, TestFunction}[(r, Projection(1))], -(Float64(costs_X[a]) + tc))
+        return optimise(belief, [1, 2], Dict(1 => tryf, 2 => _STOP_FUNCTIONAL)) == 1 ? a : 0
+    end
+    0
+end
+
+# ── Warm routing belief: per-model COUNTS, reconstructed via structure_observe ──
+# K posteriors (one per model) from one shared schema. Bayesian updating is order-independent,
+# so the warm belief depends only on each (model, context)'s correct/incorrect counts; the
+# skin/shim ships the parsed counts and the engine replays structure_observe (version-stable).
+# JSON shape: { "per_model": [ { "contexts": [ {"ctx":["short"], "n1":44, "n0":6} ] }, … ] }
+# where n1 = correct, n0 = incorrect. `data === nothing` ⇒ K cold priors.
+function reconstruct_routing_tops_from_data(model::StructureBMA, K::Int, data)
+    cold() = MixturePrevision[build_structure_prior(model) for _ in 1:K]
+    data === nothing && return cold()
+    pm = data["per_model"]
+    length(pm) == K ||
+        error("routing warm brain has $(length(pm)) models but the roster has $K")
+    tops = MixturePrevision[]
+    for entry in pm
+        top = build_structure_prior(model)
+        for c in entry["contexts"]
+            ctx = String[String(v) for v in c["ctx"]]
+            for _ in 1:Int(c["n1"]); top = structure_observe(model, top, ctx, 1); end
+            for _ in 1:Int(c["n0"]); top = structure_observe(model, top, ctx, 0); end
+        end
+        push!(tops, top)
+    end
+    tops
+end
+
+# ── Online correctness learning: latent per-turn correctness + learned confounds ──
+# We never observe model correctness directly; we observe a per-turn exec signal e (did the
+# proposed call execute cleanly), a NOISY emission of the latent C = "the turn was correct",
+# confounded by TOOL RELIABILITY. We model the confound explicitly and learn it:
+#   θ_a(X) = P(C=1 | model a, context X)   — the routing belief (its own prior for C)
+#   ρ_X    = P(e=1 | C=1)                  — tool reliability
+#   σ_X    = P(e=1 | C=0)                  — false-success
+# ρ_X, σ_X are SHARED across models at a context (the identification lever) — LATENT Beta
+# beliefs, updated only through `condition`. Per turn: decode π = P(C=1|e) with θ_a as prior,
+# then ONE coupled coordinate step (the EM the constitution treats as a computational
+# strategy): routing belief soft-counted by (r,w); emissions M-stepped by (e, π) / (e, 1−π).
+
+# Default weakly-informative DIRECTIONAL emission prior: E[ρ0]=2/3 > E[σ0]=1/3. Only the
+# inequality is load-bearing (it breaks the EM label-symmetry); magnitudes are weak.
+const _DEFAULT_EMISSION_PRIOR = (2.0, 1.0, 1.0, 2.0)  # (ρα, ρβ, σα, σβ)
+
+mutable struct EmissionBelief
+    rho_cells::Dict{String, BetaPrevision}     # P(e=1|C=1) per context-key, lazily populated
+    sigma_cells::Dict{String, BetaPrevision}   # P(e=1|C=0) per context-key
+    rho0::BetaPrevision                        # directional prior, E[ρ0] > E[σ0]
+    sigma0::BetaPrevision
+end
+
+EmissionBelief(prior::NTuple{4, Float64} = _DEFAULT_EMISSION_PRIOR) =
+    EmissionBelief(Dict{String, BetaPrevision}(), Dict{String, BetaPrevision}(),
+                   BetaPrevision(prior[1], prior[2]), BetaPrevision(prior[3], prior[4]))
+
+# The live routing belief: per-model posteriors `tops` (MUTATED by route_outcome!) and the
+# shared emission belief. An immutable StructureBMA descriptor + mutable beliefs as SEPARATE
+# objects (Invariant 3 holds at representation granularity; the bundling is handle-level).
+mutable struct RoutingState
+    model::StructureBMA
+    tops::Vector{MixturePrevision}              # warm beliefs for the DEFAULT roster (positional)
+    extra_tops::Dict{String, MixturePrevision}  # beliefs for models NOT in the default roster —
+                                                # the user's OWN models: cold prior on first sight,
+                                                # then learned online; keyed by model id
+    emission::EmissionBelief
+    names::Vector{String}
+    providers::Vector{String}
+    model_ids::Vector{String}
+    costs::Vector{Float64}
+    reward::Float64
+    w_time::Float64                             # profile weight on time ($/sec of wall-clock)
+    latency::Union{LatencyBelief, Nothing}      # learned E[time|model,X]; nothing ⇒ time-blind
+end
+
+# Fetch model_id's belief plus a setter to write an update back. KNOWN models (the default
+# roster) live in the positional `tops`; the user's OWN models live in `extra_tops` (cold
+# build_structure_prior on first sight, then learned). No error on an unknown model.
+function _belief_slot(rt::RoutingState, model_id::AbstractString)
+    a = findfirst(==(String(model_id)), rt.model_ids)
+    a !== nothing && return (rt.tops[a], top -> (rt.tops[a] = top))
+    id = String(model_id)
+    cur = get!(() -> build_structure_prior(rt.model), rt.extra_tops, id)
+    (cur, top -> (rt.extra_tops[id] = top))
+end
+
+_ctx_key(X::AbstractVector) = join(string.(X), "|")
+
+# WeightedBernoulli kernel for the emission Beta updates (fractional pseudo-counts). The
+# conjugate update keys on likelihood_family; generate/log_density are not consulted.
+_emission_kernel() = Kernel(Interval(0.0, 1.0), Finite([0, 1]), theta -> theta,
+                            (h, o) -> 0.0; likelihood_family = WeightedBernoulli())
+
+# Emission likelihoods of the exec signal e under each correctness hypothesis:
+# r = P(e | C=1), w = P(e | C=0), from the emission belief means (mean = the integrated
+# likelihood, since P(e|C) is linear in ρ/σ).
+function _emission_likelihoods(em::EmissionBelief, key::AbstractString, e::Bool)
+    ρ̄ = mean(get(em.rho_cells,   key, em.rho0))
+    σ̄ = mean(get(em.sigma_cells, key, em.sigma0))
+    e ? (ρ̄, σ̄) : (1.0 - ρ̄, 1.0 - σ̄)
+end
+
+"""
+    decode_correctness(em, θ̄, key, e) -> (r, w, π)
+
+The signal→correctness likelihood: r = P(e|C=1), w = P(e|C=0) from the emission belief, and
+π = P(C=1 | e) = r·θ̄/(r·θ̄ + w·(1−θ̄)) with the routing belief θ̄ as the coherent prior. π is
+the soft correctness label; (r,w) is the virtual evidence the routing belief conditions on
+(SoftBernoulli). Pure readout — `mean` and Bayes, no mutation. `θ̄` is the MIXTURE-level
+E[θ|X] (`posterior_accuracy`), not a per-cell α/(α+β) — the closed form is what keeps the
+emission M-step weighted by the coherent per-turn correctness (and keeps replay bit-exact).
+"""
+function decode_correctness(em::EmissionBelief, θ̄::Float64, key::AbstractString, e::Bool)
+    r, w = _emission_likelihoods(em, key, e)
+    denom = r * θ̄ + w * (1.0 - θ̄)
+    π = denom > 0.0 ? r * θ̄ / denom : θ̄
+    (r, w, π)
+end
+
+# Update one reliability cell. `into_rho` selects ρ (the C=1 cell) vs σ (the C=0 cell); the
+# outcome is the exec signal e, credited `weight` pseudo-counts (WeightedBernoulli).
+function _update_emission!(em::EmissionBelief, key::AbstractString, into_rho::Bool,
+                           e::Bool, weight::Float64)
+    weight > 0.0 || return em
+    d  = into_rho ? em.rho_cells : em.sigma_cells
+    p0 = into_rho ? em.rho0 : em.sigma0
+    cur = get(d, key, p0)
+    d[key] = condition(cur, _emission_kernel(), (e ? 1 : 0, weight))
+    em
+end
+
+"""
+    route_outcome!(rt, model_id, features, success; human=nothing) -> RoutingState
+
+Learn from one routed turn's per-turn outcome. `features` → context via
+`context_from_features`. `success` = the proposed call executed cleanly (the exec signal e).
+With no `human` label, decode the latent correctness from e (confound-aware) and take one
+coupled coordinate step: the routing belief conditions on the virtual evidence (mean-exact
+soft-count via `structure_observe_soft`); the shared emission belief takes the EM M-step
+(ρ←(e,π), σ←(e,1−π) through `condition`). A `human` approve/reject makes C known — a hard
+`structure_observe` and a unit-weight emission update (the gold anchor). The single learning
+mechanism is `condition` throughout; the θ↔emission coupling is coordinate computation
+(a strategy). Mutates `rt` in place.
+"""
+function route_outcome!(rt::RoutingState, model_id::AbstractString, features::AbstractDict,
+                        success::Bool; human::Union{Nothing, Bool} = nothing)
+    X = context_from_features(rt.model, features)
+    key = _ctx_key(X)
+    e = success
+    top, setby = _belief_slot(rt, model_id)                 # known slot or the user's own model
+    if human !== nothing
+        C = human ? 1 : 0                                   # known correctness
+        setby(structure_observe(rt.model, top, X, C))
+        _update_emission!(rt.emission, key, C == 1, e, 1.0)
+    else
+        θ̄ = posterior_accuracy(rt.model, top, X)            # E[θ|X] — the decode prior
+        r, w, π = decode_correctness(rt.emission, θ̄, key, e)
+        setby(structure_observe_soft(rt.model, top, X, r, w))
+        _update_emission!(rt.emission, key, true,  e, π)        # ρ gets weight π
+        _update_emission!(rt.emission, key, false, e, 1.0 - π)  # σ gets weight 1−π
+    end
+    rt
+end
+
+# Per-request profile override: the user's utility weights, shipped by the body per request.
+# Returns the override for `key` if present, else the wired default. Preference DATA only.
+_pget(profile, key::AbstractString, default::Float64)::Float64 =
+    (profile isa AbstractDict && haskey(profile, key) && profile[key] !== nothing) ?
+        Float64(profile[key]) : default
+
+"""
+    route_decide(rt, features, roster, profile) -> Dict | nothing
+
+Resolve a routing decision over the LIVE roster (the user's actual models, sent per request)
+or the declared default roster. Returns `nothing` — body keeps OpenClaw's model — when fewer
+than 2 candidates exist. Per-request profile overrides reward/w_time with no daemon restart.
+"""
+function route_decide(rt::RoutingState, features, roster, profile = nothing)
+    names, providers, ids, costs, tops = _resolve_roster(rt, roster)
+    length(ids) >= 2 || return nothing
+    reward = _pget(profile, "reward", rt.reward)        # quality coordinate (per-request override)
+    w_time = _pget(profile, "w_time", rt.w_time)        # time coordinate (per-request override)
+    X = context_from_features(rt.model, features)
+    times = Float64[latency_at(rt.latency, ids[a], X) for a in eachindex(ids)]   # E[time|a,X], 0 if unknown
+    a = route(rt.model, tops, X, costs, reward; w_time = w_time, times = times)
+    Dict{String, Any}("model" => ids[a], "provider" => providers[a], "name" => names[a])
+end
+
+"""
+    escalate_decide(rt, features, roster, tried, reward, profile) -> Dict | nothing
+
+One escalation step over the LIVE roster: the cheapest not-yet-`tried` rung whose myopic
+try-EU clears the stop gate, else `nothing` (STOP). `tried` carries cost-ascending indices;
+the returned `tier_index` is in that cost-ascending space, so the host pushes it straight
+back into `tried` on a failure.
+"""
+function escalate_decide(rt::RoutingState, features, roster, tried, reward, profile = nothing)
+    names, providers, ids, costs, tops = _resolve_roster(rt, roster)
+    length(ids) >= 2 || return nothing
+    reward = _pget(profile, "reward", Float64(reward))   # per-request quality override
+    w_time = _pget(profile, "w_time", rt.w_time)         # per-request time override
+    order = sortperm(costs)                              # cheapest → dearest
+    X = context_from_features(rt.model, features)
+    triedset = Set{Int}(Int(t) for t in tried)          # indices in cost-ascending space
+    times = Float64[latency_at(rt.latency, ids[i], X) for i in order]   # E[time], aligned to tops[order]
+    a = escalation_next(rt.model, tops[order], X, costs[order], reward, triedset;
+                        w_time = w_time, times_X = times)
+    a == 0 && return nothing                             # no positive-EU rung ⇒ STOP
+    j = order[a]
+    Dict{String, Any}("model" => ids[j], "provider" => providers[j], "name" => names[j],
+                      "tier_index" => a)
+end
+
+# Aligned (names, providers, ids, costs, tops) for the decision. No live roster ⇒ the declared
+# default (warm beliefs). A live roster ⇒ each entry is (name provider model-id cost): a known
+# model reuses its warm/learned belief, an unknown one its cold/learned belief from extra_tops.
+function _resolve_roster(rt::RoutingState, roster)
+    (roster === nothing || (roster isa AbstractVector && isempty(roster))) &&
+        return (rt.names, rt.providers, rt.model_ids, rt.costs, rt.tops)
+    roster isa AbstractVector ||
+        error("route-decide: roster must be a list of (name provider model-id cost), got $(typeof(roster))")
+    names = String[]; providers = String[]; ids = String[]; costs = Float64[]
+    tops = MixturePrevision[]
+    for m in roster
+        name, provider, id, cost = _roster_entry(m)
+        push!(names, name); push!(providers, provider); push!(ids, id); push!(costs, cost)
+        push!(tops, _belief_slot(rt, id)[1])
+    end
+    (names, providers, ids, costs, tops)
+end
+
+# One roster entry off the wire: a 4-vector (name provider id cost) or a dict carrying those.
+function _roster_entry(m)
+    if m isa AbstractDict
+        id = String(get(m, "model", get(m, "model_id", get(m, "id", ""))))
+        return (String(get(m, "name", id)), String(get(m, "provider", "")), id,
+                Float64(get(m, "cost", 0.0)))
+    elseif m isa AbstractVector && length(m) == 4
+        return (string(m[1]), string(m[2]), string(m[3]), Float64(m[4]))
+    end
+    error("route-decide: roster entry must be (name provider model-id cost) or {model,provider,cost}, got $(m)")
+end

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -297,6 +297,27 @@ function route_outcome!(rt::RoutingState, model_id::AbstractString, features::Ab
     rt
 end
 
+"""
+    routing_belief_readout(rt, model_id, features) -> Dict("theta"=>…, "rho_bar"=>…, "sigma_bar"=>…)
+
+Telemetry readout (NON-causal): the EM-learned E[θ|X] and the reliability means ρ̄/σ̄ at a
+(model_id, context). For calibration / shadow-mode / the wire parity test — the hot
+`route_decide` builds the per-context view internally and never reads this. Read-only: an
+unseen model id errors (no `extra_tops` cold-start). Lives engine-side (not the skin verb) so
+the parameter reads stay out of the consumer.
+"""
+function routing_belief_readout(rt::RoutingState, model_id::AbstractString, features::AbstractDict)
+    X = context_from_features(rt.model, features)
+    a = findfirst(==(String(model_id)), rt.model_ids)
+    top = a !== nothing ? rt.tops[a] : get(rt.extra_tops, String(model_id), nothing)
+    top === nothing && error("routing belief: unknown model id $(model_id)")
+    key = _ctx_key(X)
+    Dict{String, Any}(
+        "theta"     => posterior_accuracy(rt.model, top, X),
+        "rho_bar"   => mean(get(rt.emission.rho_cells, key, rt.emission.rho0)),
+        "sigma_bar" => mean(get(rt.emission.sigma_cells, key, rt.emission.sigma0)))
+end
+
 # Per-request profile override: the user's utility weights, shipped by the body per request.
 # Returns the override for `key` if present, else the wired default. Preference DATA only.
 _pget(profile, key::AbstractString, default::Float64)::Float64 =

--- a/test/test_routing.jl
+++ b/test/test_routing.jl
@@ -1,0 +1,127 @@
+# test_routing.jl — the engine routing stdlib (decouple Move 4, src/routing.jl). Self-contained
+# (no apps/ dependency): builds a tiny inline routing fixture and pins the lifted ops directly
+# through the engine's public names. The end-to-end behavioural oracle is
+# apps/credence-pi/tests/julia/test_routing.jl (passes unmodified through the shim); this file
+# pins the engine primitives. Asserts:
+#   (1) Wald flip — route's EU-max model changes with `reward` ALONE (cost-hawk → cheap,
+#       quality-hawk → best-believed), exact index;
+#   (2) escalation gate boundary — escalation_next opens iff reward·θ ≥ cost, at cost = reward·θ ± 1e-6;
+#   (3) w_time=0 is bit-identical to the pre-time router;
+#   (4) the route_outcome! soft path reduces EXACTLY to a hard structure_observe at the
+#       certain-signal corners (the substrate-equivalence guard);
+#   (5) the coupled-EM route_outcome!: successes raise θ; a pure-flakiness stream leaves θ
+#       ~flat and drops the learned reliability ρ̄ (confound-partialling); a seeded stream
+#       identifies ρ toward the truth.
+#
+# Run from repo root:  julia test/test_routing.jl
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: build_structure_model, build_structure_prior, structure_observe,
+                structure_observe_soft, context_from_features,
+                RoutingState, EmissionBelief, route, route_eu, escalation_next,
+                posterior_accuracy, route_outcome!, decode_correctness, _ctx_key,
+                MixturePrevision, mean
+using Random: MersenneTwister
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+
+println("="^64)
+println("routing engine stdlib — lifted route / escalate / route_outcome! (Move 4)")
+println("="^64)
+
+# ── Fixture: one feature (prompt length), two models. A = cheap + lower accuracy, B = dear +
+# higher accuracy. Seed each model's per-feature StructureBMA posterior by hand. ──
+model = build_structure_model(["len"], [["short", "long"]]; alpha0 = 2.0, beta0 = 2.0, p_edge = 0.5)
+X = ["short"]
+feats = Dict("len" => "short")
+seed(top, n1, n0) = begin
+    for _ in 1:n1; top = structure_observe(model, top, X, 1); end
+    for _ in 1:n0; top = structure_observe(model, top, X, 0); end
+    top
+end
+topA = seed(build_structure_prior(model), 3, 7)    # low θ
+topB = seed(build_structure_prior(model), 7, 3)    # high θ
+tops = MixturePrevision[topA, topB]
+costs = [0.01, 0.10]                               # A cheap, B dear
+θA = posterior_accuracy(model, topA, X)
+θB = posterior_accuracy(model, topB, X)
+check("fixture: θ_B > θ_A (B better-believed)", θB > θA, "$θA vs $θB")
+
+# ── (1) Wald flip: cheap at low reward, best-believed at high reward ──
+check("route picks the CHEAP model at low reward (cost-hawk)", route(model, tops, X, costs, 0.01) == 1)
+check("route picks the BEST-BELIEVED model at high reward (quality-hawk)", route(model, tops, X, costs, 100.0) == 2)
+
+# ── (2) escalation gate boundary: opens iff reward·θ ≥ cost ──
+check("escalation opens when cost just below reward·θ (tier 1)",
+      escalation_next(model, tops, X, [1.0 * θA - 1e-6, 9.9], 1.0, Set{Int}()) == 1,
+      "θA=$θA")
+check("escalation STOPs when every rung's cost just above its reward·θ",
+      escalation_next(model, tops, X, [1.0 * θA + 1e-6, 9.9], 1.0, Set{Int}()) == 0)
+
+# ── (3) w_time=0 bit-identical ──
+base = route(model, tops, X, costs, 1.0)
+check("w_time=0 with times == the time-blind router (bit-identical)",
+      route(model, tops, X, costs, 1.0; w_time = 0.0, times = [0.5, 0.9]) == base)
+check("w_time=0 with times=nothing == the time-blind router (bit-identical)",
+      route(model, tops, X, costs, 1.0; w_time = 0.0, times = nothing) == base)
+
+# ── (4) route_outcome! soft path ≡ hard structure_observe at certain-signal corners ──
+let top0 = build_structure_prior(model)
+    h1 = posterior_accuracy(model, structure_observe(model, top0, X, 1), X)
+    s1 = posterior_accuracy(model, structure_observe_soft(model, top0, X, 1.0, 0.0), X)
+    h0 = posterior_accuracy(model, structure_observe(model, top0, X, 0), X)
+    s0 = posterior_accuracy(model, structure_observe_soft(model, top0, X, 0.0, 1.0), X)
+    check("soft (r,w)=(1,0) ≡ hard obs=1 (exact)", s1 == h1, "$s1 vs $h1")
+    check("soft (r,w)=(0,1) ≡ hard obs=0 (exact)", s0 == h0, "$s0 vs $h0")
+end
+
+# ── (5) the coupled-EM route_outcome! ──
+mkstate() = RoutingState(model, MixturePrevision[seed(build_structure_prior(model), 20, 30),
+                                                 seed(build_structure_prior(model), 20, 30)],
+                         Dict{String, MixturePrevision}(), EmissionBelief(),
+                         ["a", "b"], ["p", "p"], ["id-a", "id-b"], [0.01, 0.10], 0.5, 0.0, nothing)
+ρ̄of(rt) = mean(get(rt.emission.rho_cells, _ctx_key(X), rt.emission.rho0))
+
+# successes raise the routed model's θ
+let rt = mkstate()
+    before = posterior_accuracy(rt.model, rt.tops[1], X)
+    for _ in 1:30; route_outcome!(rt, "id-a", feats, true); end
+    check("clean successes raise the routed model's θ", posterior_accuracy(rt.model, rt.tops[1], X) > before,
+          "$before → $(posterior_accuracy(rt.model, rt.tops[1], X))")
+end
+
+# confound-partialling: a pure-flakiness stream (every call fails) leaves θ ~flat and is
+# absorbed by the learned reliability ρ̄ (correct calls failed too ⇒ the tool is flaky).
+let rt = mkstate()
+    before = [posterior_accuracy(rt.model, rt.tops[a], X) for a in 1:2]
+    for _ in 1:60, a in 1:2; route_outcome!(rt, ["id-a", "id-b"][a], feats, false); end
+    drift = maximum(abs.([posterior_accuracy(rt.model, rt.tops[a], X) for a in 1:2] .- before))
+    ρ̄_drop = 0.667 - ρ̄of(rt)
+    # The confound-partialling signature: the flakiness lands in ρ̄ (which falls sharply),
+    # NOT in θ (which barely moves) — ρ̄'s drop dwarfs θ's drift.
+    check("flakiness drops the learned reliability ρ̄ sharply (≫ θ drift)",
+          ρ̄_drop > 0.1 && ρ̄_drop > 3 * drift, "ρ̄_drop=$ρ̄_drop  drift=$drift")
+end
+
+# seeded identifiability: a true emission process (ρ_true high, σ_true low) is recovered —
+# ρ̄ rises from the 2/3 prior toward ρ_true while θ stays anchored.
+let rt = mkstate(), rng = MersenneTwister(20260624)
+    ρ_true, σ_true, θ_true = 0.9, 0.25, 0.5
+    θ0 = [posterior_accuracy(rt.model, rt.tops[a], X) for a in 1:2]
+    for _ in 1:1000
+        a = rand(rng, 1:2)
+        C = rand(rng) < θ_true
+        e = rand(rng) < (C ? ρ_true : σ_true)
+        route_outcome!(rt, ["id-a", "id-b"][a], feats, e)
+    end
+    Δθ = maximum(abs.([posterior_accuracy(rt.model, rt.tops[a], X) for a in 1:2] .- θ0))
+    check("seeded EM lifts ρ̄ from prior toward ρ_true (0.667 → >0.74)", ρ̄of(rt) > 0.74, "ρ̄=$(ρ̄of(rt))")
+    check("seeded EM keeps θ anchored (Δθ < 0.1)", Δθ < 0.1, "Δθ=$Δθ")
+end
+
+println("="^64)
+println("ALL CHECKS PASSED — routing engine stdlib exact")
+println("="^64)


### PR DESCRIPTION
Lifts credence-pi's **routing** brain into the engine so the *entire* credence-pi reasoning surface is wire-drivable, math-free — the gating dependency for Move 5 (extracting credence-pi to its own `credence-openclaw` repo as a pure wire consumer). Governance was already wire-ready (Move 3); routing was the only gap.

**What moved.** The probabilistic body of `apps/credence-pi/brain/routing_brain.jl` → `src/routing.jl` (inside `module Ontology`): the named decision templates `route`/`route_eu`/`escalation_next`/`posterior_accuracy`, the coupled-EM `route_outcome!`, the closed-form `decode_correctness`, `route_decide`/`escalate_decide`, the ρ/σ `EmissionBelief` + Gamma `LatencyBelief`, and the data-in `reconstruct_*_from_data`. Composes only Tier-1 ops — no new frozen type, no new axiom-constrained fn; routing **reuses** the already-lifted `StructureBMA` substrate. `routing_brain.jl` collapses to a thin shim (re-exports + the env-reading `wire_routing!` + path-reading reconstruction wrappers); no `optimise`/`LinearCombination`/`Projection`/`ProductMeasure` import remains.

**Wire surface.** Six additive skin verbs at **protocol 1.5**: `routing_init` (build the `RoutingState` server-side from declared data incl. inline warm/latency counts → one opaque `rt_*` handle in a dedicated `ROUTING_REGISTRY`), `routing_decide`, `routing_escalate`, `routing_outcome`, `routing_belief` (telemetry), `destroy_routing`.

**Key design calls** (see `docs/decouple/move-4-design.md`): `RoutingState` as one opaque mutable handle (not the immutable-descriptor `MODEL_REGISTRY`); `decode_correctness` kept closed-form (mixture-level θ̄, not per-cell — the only way the EM M-step stays coherent and replay stays bit-exact); inline counts as a new transport shape; named decision templates (not raw Functional-over-wire).

**Verification.**
- `apps/credence-pi/tests/julia/test_routing.jl` passes **byte-for-byte unmodified** (40 assertions incl. the exact-replay oracle) — the capture-PRE-refactor / assert-`==` parity pin.
- Full credence-pi Julia loop green (`test_server` 23, `test_feature_brain`, `test_harm_governance`, …); `test_core`, `test_structure_bma` green; every `eval/` + daemon `RoutingBrain` reach-in resolves.
- New self-contained engine oracle `test/test_routing.jl` (exact Wald flip, escalation gate ±1e-6, `w_time=0` bit-identical, soft↔hard corners, the coupled-EM confound-partialling + seeded identifiability).
- New `test_skin.py` routing wire trace (Wald flip *over the wire*, learning raises θ, escalation ladder 1→2→3→null) — now CI-gated.
- Lint `check apps/` clean (226 files); `protocol.md` header == `PROTOCOL_VERSION` == 1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)