### PR TITLE
decouple Move 5 (design + step 0): structure_bma warm_counts prerequisite

### DIFF
--- a/apps/credence-pi/brain/feature_brain.jl
+++ b/apps/credence-pi/brain/feature_brain.jl
@@ -20,6 +20,7 @@ module FeatureBrain
 using Main.Credence: StructureBMA, build_structure_model, build_structure_prior,
     build_structure_prior_dense, structure_observe, structure_observe_soft,
     structure_firing_tags, belief_at_context, context_from_features, structure_decision_kernel,
+    reconstruct_structure_prior_from_data,
     MixturePrevision, GammaPrevision, Identity,
     GeometricTail, FeatureDecl, Finite, expect
 # The EU-max template lives in the engine stdlib (decouple Move 3): the app ships utility
@@ -174,17 +175,8 @@ context's (n1, n0) counts — making this artifact version-stable (JSON), unlike
 over the StructureBMA: the harm posterior (P(unsafe|safety-features)) and the warm
 WASTE posterior (P(approve|waste-features)) both reconstruct through this one path.
 """
-function reconstruct_posterior(model::StructureBMA, counts_path::AbstractString)
-    data = JSON3.read(read(counts_path, String))
-    entries = data.contexts
-    top = build_prior(model)
-    for e in entries
-        ctx = String[String(v) for v in e.ctx]
-        for _ in 1:Int(e.n1); top = observe(model, top, ctx, 1); end
-        for _ in 1:Int(e.n0); top = observe(model, top, ctx, 0); end
-    end
-    top
-end
+reconstruct_posterior(model::StructureBMA, counts_path::AbstractString) =
+    reconstruct_structure_prior_from_data(model, JSON3.read(read(counts_path, String)))
 
 # Back-compat alias: the harm posterior was the first consumer of this path.
 const reconstruct_harm_posterior = reconstruct_posterior

--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -1,6 +1,6 @@
 # Credence Skin Protocol
 
-Protocol-Version: 1.5
+Protocol-Version: 1.6
 
 JSON-RPC 2.0 over stdio. Skin reads newline-delimited JSON from stdin,
 writes newline-delimited JSON to stdout, logs to stderr.
@@ -13,6 +13,11 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
 
 ### Changelog
 
+- **1.6** — `structure_bma` gains an optional inline `warm_counts` (decouple Move 5
+  prerequisite, additive): `{contexts: [{ctx, n1, n0}]}` reconstructs the warm governance
+  posterior server-side in one call (symmetric with `routing_init`'s `warm_counts`), so a wire
+  consumer warm-seeds governance without N `structure_observe` round-trips. Omitting it gives
+  the cold prior (unchanged). Backward-compatible.
 - **1.5** — routing verbs (decouple Move 4, additive): `routing_init` (build the per-model
   StructureBMA belief + ρ/σ emission + Gamma latency latents server-side from declared data —
   roster, costs, reward, and the warm/latency counts INLINE — returning one opaque `rt_*`
@@ -382,7 +387,10 @@ cells). Returns the descriptor handle and the prior belief handle.
 {"result": {"model_id": "m_1", "state_id": "s_1"}}
 ```
 
-`alpha0`/`beta0`/`p_edge` are optional (default `2.0`/`2.0`/`0.5`).
+`alpha0`/`beta0`/`p_edge` are optional (default `2.0`/`2.0`/`0.5`). An optional inline
+`warm_counts` (`{"contexts": [{"ctx": [...], "n1": N, "n0": M}, ...]}`, protocol 1.6)
+reconstructs the warm posterior server-side (replaying `structure_observe`, order-independent
+⇒ exact) instead of the cold prior — so a wire consumer warm-seeds governance in one call.
 
 ### structure_observe
 

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -678,7 +678,7 @@ end
 # rides the `credence-skin` image tag). MAJOR bumps on a breaking protocol
 # change; MINOR on additive. Apps pin the major in code and `initialize`
 # rejects a mismatching major with -32010. See docs/decouple/master-plan.md.
-const PROTOCOL_VERSION = "1.5"
+const PROTOCOL_VERSION = "1.6"
 protocol_major(v) = String(first(split(String(v), ".")))
 
 # Advertised method set, returned by `initialize` for client capability
@@ -1198,8 +1198,16 @@ function handle_structure_bma(params)
     catch e
         _wrap_dsl("build_structure_model failed")(e)
     end
+    # Optional inline warm_counts ({contexts:[{ctx,n1,n0}]}) reconstructs the warm posterior
+    # server-side in one call (symmetric with routing_init) — else the cold prior. Lets a wire
+    # consumer warm-seed governance without N structure_observe round-trips.
+    prior = try
+        reconstruct_structure_prior_from_data(model, get(params, "warm_counts", nothing))
+    catch e
+        _wrap_inf("structure warm reconstruction failed")(e)
+    end
     Dict{String, Any}("model_id" => register_model(model),
-                      "state_id" => register_state(build_structure_prior(model)))
+                      "state_id" => register_state(prior))
 end
 
 function handle_structure_observe(params)

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -1126,7 +1126,17 @@ def test_structure_bma_roundtrip():
         })["action"]
         assert a3 == "block", "high harm belief should flip proceed→block"
 
-        print("PASS: structure-BMA verbs roundtrip (build / observe / decide + harm)")
+        # Inline warm_counts (protocol 1.6): one structure_bma call warm-seeds the posterior
+        # server-side (vs N structure_observe round-trips). Refusal-heavy warm ⇒ θ<0.5 ⇒ block.
+        warm = skin._call("structure_bma", {
+            "feature_names": ["tool", "rep"], "feature_values": [["bash", "read"], ["rep0", "rep3"]],
+            "warm_counts": {"contexts": [{"ctx": ["bash", "rep3"], "n1": 1, "n0": 6}]}})
+        a_warm = skin._call("structure_decide", {
+            "model_id": warm["model_id"], "state_id": warm["state_id"], "features": ctx,
+            "cost": 1.0, "aversion": 1.0, "interrupt_cost": HUGE})["action"]
+        assert a_warm == "block", "warm_counts refusals should warm-seed to block in one call"
+
+        print("PASS: structure-BMA verbs roundtrip (build / observe / decide + harm + warm_counts)")
     finally:
         skin.shutdown()
 
@@ -1201,7 +1211,7 @@ def test_initialize_returns_contract():
     skin = SkinClient()
     try:
         result = skin.initialize()
-        assert result["protocol"] == "1.5", f"protocol: {result.get('protocol')}"
+        assert result["protocol"] == "1.6", f"protocol: {result.get('protocol')}"
         assert "version" in result, "engine version missing"
         methods = result["methods"]
         # Core canalised verbs + the Move-3 structure-BMA verbs must be advertised.
@@ -1247,7 +1257,7 @@ def test_dsl_sources_inline_equivalent_to_path():
         # a subsequent call_dsl against the loaded env resolves (the path-based
         # test_router_roundtrip already covers the path branch).
         result = skin.initialize(dsl_sources={"router": source})
-        assert result["protocol"] == "1.5"
+        assert result["protocol"] == "1.6"
         print("PASS: inline dsl_sources loads equivalently to a path load")
     finally:
         skin.shutdown()

--- a/docs/decouple/move-5-design.md
+++ b/docs/decouple/move-5-design.md
@@ -1,0 +1,161 @@
+# Decouple Move 5 — extract credence-pi → the credence-openclaw repo (pure wire consumer)
+
+## 0. Final-state alignment
+
+Moves 0–4 made credence-pi's *entire* reasoning surface wire-drivable: governance
+(`structure_*` verbs, Move 3) and routing (`routing_*` verbs, Move 4) both run server-side
+in the engine, reachable over the protocol-1.5 skin wire. The daemon, however, still
+**embeds** the engine in-process (`daemon/main.jl` `using Credence`). Move 5 performs the
+literal extraction the master plan deferred: credence-pi leaves the engine repo, is renamed
+**credence-openclaw**, and its daemon is rewired as a **pure wire consumer** — it pins the
+`credence-skin` image and drives the verbs, carrying **zero probabilistic Julia**. This
+satisfies the consumption boundary for an *external* app (`SPEC §6.9`): the co-released-image
+embedding exception is for engine-repo images only; a separate repo must use the wire.
+
+## 1. Purpose & decisions
+
+- **Architecture = B (pure wire consumer)** and **rename → credence-openclaw** (both locked
+  this session). Option A (re-publishing an embeddable engine) is off the table — it
+  contradicts Move 0's `Private :: Do Not Upload`.
+- **Daemon language = TypeScript** (locked). It unifies the repo: the `openclaw-plugin` +
+  `extension` are already TS and npm-published, and OpenClaw is a JS framework. The daemon
+  becomes a TS HTTP/SSE server that drives `credence-skin` over a new **TS skin wire client**
+  (JSON-RPC over stdio to `docker run -i credence-skin`). The repo ends up single-toolchain
+  (TS) with no Julia.
+
+## 2. Repos & files touched
+
+### New repo: `credence-openclaw` (`~/git/credence-openclaw`, GitHub `gfrmin/credence-openclaw`, default branch `master`)
+- **Stays (TS, unchanged in shape):** `openclaw-plugin/` (the body — HTTP→daemon, already
+  arithmetic-free), `extension/` (test body).
+- **Stays (declared DATA):** `bdsl/` (feature schema, roster, utility constants),
+  `profiles/`, the brain `*.counts.json` artifacts (shipped INLINE to `routing_init`/
+  `structure_*` over the wire), the eval harness, docs.
+- **New (TS):**
+  - `skin-client/` — a TS JSON-RPC-over-stdio client to a pinned `credence-skin` image (the
+    daemon→skin analogue of the Python `credence_skin_client`; spawns `docker run -i
+    credence-skin@<digest>`, holds opaque `state_id`/`model_id`/`rt_*` handles, exposes
+    `initialize`/`structure_bma`/`structure_observe`/`structure_decide`/`routing_init`/
+    `routing_decide`/`routing_escalate`/`routing_outcome`/`routing_belief`).
+  - `daemon/` (TS) — the rewritten daemon: the HTTP/SSE server (`POST /sensor`, `GET
+    /signals` SSE, `GET /report`), the observation log (append + replay — host-side,
+    non-probabilistic), and the boot/per-event orchestration that calls the verbs. Replaces
+    `daemon/{main,server}.jl` + `brain/{feature,routing}_brain.jl` (the brains are gone —
+    their math is in the engine).
+- **Deleted (the embedded Julia brain):** `brain/*.jl`, `daemon/*.jl`, `daemon/Dockerfile`
+  (the multi-stage build that COPY'd the engine `src/`). The new `daemon/Dockerfile` is a TS
+  image that runs the skin image as a pinned dependency (sidecar or spawned subprocess).
+
+### Engine repo (`credence`, this branch `decouple/openclaw-extract`)
+- **Remove** `apps/credence-pi/`.
+- **Strip CI** (`.github/workflows/publish-image.yml`): the `unit-tests` credence-pi steps
+  (Julia tests + extension + openclaw-plugin builds), the `daemon-smoke-build` job, the
+  `publish-daemon` job, and the workflow name's "+ credence-pi daemon".
+- **Repoint the two engine tests that reach into the departing app:**
+  `test/test_sparse_structure_equivalence.jl` and `test/test_product_bma_routing.jl`
+  `include` `apps/credence-pi/brain/feature_brain.jl` — repoint them onto the lifted
+  `src/structure_bma.jl` / `src/routing.jl` (the substrate they test is now engine-resident),
+  or fold their unique coverage into `test/test_structure_bma.jl` / `test/test_routing.jl`.
+- **Docs:** update `SPEC.md` / `CLAUDE.md` / `docs/decouple/master-plan.md` mentions of the
+  in-repo credence-pi to point at the external repo (the `credence-pi-daemon` co-released
+  exception is retired — it's now an external wire consumer).
+
+## 3. Behaviour preserved
+
+The credence-openclaw daemon reproduces the in-repo Julia daemon's **decisions** through the
+pinned `credence-skin` image: same `POST /sensor` → effector signal, same SSE `/signals`,
+same `/report`, same boot reconstruction (warm counts + observation-log replay). Golden-trace
+parity: a recorded sensor stream produces the same proceed/block/ask + route decisions
+through the TS-wire daemon as through the Julia-embedding daemon (the verbs are the same
+engine code; only the transport changed). The `openclaw-plugin` body is byte-unchanged.
+
+## 4. Worked end-to-end example (the new boot + sensor path)
+
+```
+daemon boot:
+  skin = spawn("docker run -i credence-skin@<digest>"); skin.initialize()
+  gov  = skin.structure_bma({feature_names, feature_values, …from bdsl…})   → {model_id, state_id}
+  rt   = skin.routing_init({roster, reward, warm_counts:<inline counts.json>, …})  → {routing_state_id}
+  replay observation log: for each event → skin.structure_observe(...) / skin.routing_outcome(...)
+
+POST /sensor {tool-proposed, features, proposed_call}:
+  action = skin.structure_decide({model_id, state_id, features, cost, aversion, interrupt_cost, harm})
+  route  = skin.routing_decide({routing_state_id, features, roster, profile})
+  emit SSE signal(action, route); append to observation log; return ack
+```
+Zero arithmetic in the daemon — every probability/utility computation is a verb call.
+
+## 5. Build sequencing (each a reviewable unit)
+
+0. **Engine prerequisite — `structure_bma` gains inline `warm_counts`** (credence repo, this
+   branch). Review finding: the daemon warm-seeds FOUR governance brains (waste/harm/tail +
+   latency) via `reconstruct_posterior` (replays `observe` per count). `routing_init` already
+   takes `warm_counts` inline and reconstructs server-side in one call, but `structure_bma`
+   does not — so governance warm-seeding over the wire would be N `structure_observe`
+   round-trips per brain (hundreds at boot). Add an optional `warm_counts` param to
+   `structure_bma` (engine `build_structure_prior` + the existing
+   `reconstruct_routing_tops_from_data`-style replay; the skin handler reconstructs from the
+   inline counts), so governance warm-seeds in ONE server-side call, symmetric with routing.
+   Additive → protocol 1.5 → 1.6. (The `/report` savings path needs no readback verb —
+   `savings_report` is pure log IO, touches no beliefs.) Lands + republishes the skin before
+   the daemon pins it; dev/test spawns this branch's `server.jl` directly.
+1. **Stand up `credence-openclaw`** — create the repo, move the TS-stays + DATA, rename every
+   load-bearing identifier (§ rename map). Repo builds (TS) with the brains/daemon-Julia
+   removed (daemon stubbed). *Open Q: repo history — `git filter-repo` to preserve
+   `apps/credence-pi` history, or a fresh repo with a provenance note?*
+2. **TS skin client** — the JSON-RPC-over-stdio wrapper; unit-tested against a pinned
+   `credence-skin` image (the verbs round-trip).
+3. **TS daemon** — HTTP/SSE/log + the boot/per-event verb orchestration; golden-trace parity
+   vs the Julia daemon's decisions.
+4. **New-repo CI + publishing** — TS build/test, the daemon image (`FROM`/pins
+   `credence-skin`), npm `@gfrmin/credence-openclaw`, GHCR `credence-openclaw-daemon`.
+5. **Engine-repo cleanup** (this branch) — remove `apps/credence-pi/`, strip CI jobs, repoint
+   the two engine tests, update docs. Engine CI stays green.
+
+### Rename map (load-bearing identifiers, scout-confirmed)
+`apps/credence-pi/` dir; plugin id `credence-pi`; npm `@gfrmin/credence-pi-openclaw` →
+`@gfrmin/credence-openclaw`; image `credence-pi-daemon` → `credence-openclaw-daemon`;
+`CREDENCE_PI_*` env → `CREDENCE_OPENCLAW_*`; `~/.credence-pi/` state dir →
+`~/.credence-openclaw/`. (Cosmetic doc/comment mentions follow.)
+
+## 6. Open design questions
+
+1. **Image pinning / composition.** Digest-pin `credence-skin` (reproducibility). How does
+   the daemon image run it — spawn `docker run -i` (needs docker-in-docker or a mounted
+   socket), or compose the skin as a sidecar the daemon connects to over a pinned local
+   transport? `docker run -i` stdio is simplest for a single-tenant daemon; a sidecar needs a
+   non-stdio skin transport (the skin is stdio-only today — `serve_http.jl` was deferred).
+   **Leaning:** the daemon spawns the skin as a child via the `command` seam (stdio), exactly
+   as the Python client does; the daemon image bundles the skin image reference and a docker
+   socket, or ships the skin binary. Resolve at build step 3.
+2. **Repo history** (filter-repo vs fresh) — step 1.
+3. **BDSL-as-data transcription.** The daemon must turn `bdsl/*.bdsl` (feature schema, roster,
+   utility) into the JSON the verbs take. Parse the `.bdsl` in TS, or pre-bake a JSON config
+   committed alongside? **Leaning:** pre-baked JSON config (the `.bdsl` stays as the
+   human-authored source; a small build step emits the verb-payload JSON) — avoids a TS
+   S-expression parser.
+4. **`serve_http.jl` revisited?** If a sidecar transport is wanted (Q1), the skin needs HTTP;
+   that reopens the Move-0-deferred `serve_http.jl`. Out of scope unless Q1 picks sidecar.
+
+## 7. Verification cadence
+
+- TS skin client unit tests (verbs round-trip against a pinned skin image).
+- Daemon golden-trace parity: a recorded sensor stream → identical decisions vs the Julia
+  daemon (capture the Julia daemon's decisions PRE-extraction as the oracle).
+- `grep -rE 'using Credence|\.jl$' credence-openclaw/{daemon,skin-client}` finds **zero**
+  probabilistic Julia in the consumer.
+- New-repo CI green (TS build/test + daemon image smoke: initialize handshake through the
+  pinned skin).
+- Engine repo: CI green after `apps/credence-pi/` removal + the two tests repointed; lint
+  `check apps/` clean on the smaller tree.
+
+## 8. Reviewer checklist
+
+- [ ] credence-openclaw carries no `*.jl` probabilistic code; the daemon drives only verbs.
+- [ ] `credence-skin` image digest-pinned; daemon reproduces Julia-daemon decisions
+      (golden trace).
+- [ ] Every load-bearing `credence-pi` identifier renamed; existing npm/image consumers noted
+      (one-time re-publish under the new name).
+- [ ] Engine repo: `apps/credence-pi/` gone, CI jobs stripped, the two reach-in tests
+      repointed onto `src/`, engine CI green.
+- [ ] `openclaw-plugin` body unchanged (only the daemon it talks to changed).

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -57,7 +57,7 @@ export push_component!, replace_component!, FrozenVectorView
 export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal, wrap_in_measure
 export ConjugatePrevision, maybe_conjugate, update
-export StructureBMA, build_structure_model, build_structure_prior, build_structure_prior_dense, structure_observe, structure_observe_soft, belief_at_context, context_from_features, structure_firing_tags, structure_decision_kernel
+export StructureBMA, build_structure_model, build_structure_prior, build_structure_prior_dense, structure_observe, structure_observe_soft, belief_at_context, context_from_features, structure_firing_tags, structure_decision_kernel, reconstruct_structure_prior_from_data
 export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next, posterior_accuracy, route_outcome!, decode_correctness, latency_at, route_decide, escalate_decide, routing_belief_readout, reconstruct_latency_from_data, reconstruct_routing_tops_from_data, _ctx_key
 export draw
 export weights, mean, variance, probability, marginal, prune, truncate, logsumexp

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1750,7 +1750,7 @@ include("structure_bma.jl")
 export StructureBMA, build_structure_model, build_structure_prior,
        build_structure_prior_dense, structure_observe, structure_observe_soft,
        belief_at_context, context_from_features, structure_firing_tags,
-       structure_decision_kernel
+       structure_decision_kernel, reconstruct_structure_prior_from_data
 
 include("routing.jl")
 export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next,

--- a/src/structure_bma.jl
+++ b/src/structure_bma.jl
@@ -115,6 +115,28 @@ function build_structure_prior(model::StructureBMA)
 end
 
 """
+    reconstruct_structure_prior_from_data(model, data) -> MixturePrevision
+
+Warm-seed a structure-BMA posterior from already-parsed per-context counts (the skin/shim
+parses the JSON; the engine never reads the host FS) by replaying `structure_observe`.
+Bayesian updating is order-independent ⇒ the posterior depends only on each context's
+(n1, n0) counts, so reconstruction is exact + version-stable. `data === nothing` ⇒ the cold
+prior. JSON shape: `{ "contexts": [ {"ctx":[…], "n1":N, "n0":M}, … ] }`. Symmetric with
+routing's `reconstruct_routing_tops_from_data` — lets a wire consumer warm-seed governance in
+ONE server-side call instead of N `structure_observe` round-trips.
+"""
+function reconstruct_structure_prior_from_data(model::StructureBMA, data)
+    top = build_structure_prior(model)
+    data === nothing && return top
+    for e in data["contexts"]
+        ctx = String[String(v) for v in e["ctx"]]
+        for _ in 1:Int(e["n1"]); top = structure_observe(model, top, ctx, 1); end
+        for _ in 1:Int(e["n0"]); top = structure_observe(model, top, ctx, 0); end
+    end
+    top
+end
+
+"""
     build_structure_prior_dense(model) -> MixturePrevision
 
 The DENSE reference prior: each structure a full `ProductPrevision` of

--- a/test/test_structure_bma.jl
+++ b/test/test_structure_bma.jl
@@ -75,6 +75,24 @@ let X = ["bash", "rep3"]
           "got $(length(tags)) for $(length(model.structures)) structures")
 end
 
+# reconstruct_structure_prior_from_data (Move 5 prereq): warm-seeding from inline counts ≡
+# replaying structure_observe by hand, bit-for-bit (order-independent ⇒ exact). data=nothing
+# is the cold prior.
+let counts = Dict("contexts" => [
+        Dict("ctx" => ["bash", "rep3"], "n1" => 5, "n0" => 2),
+        Dict("ctx" => ["read", "rep0"], "n1" => 1, "n0" => 4)])
+    warm = reconstruct_structure_prior_from_data(model, counts)
+    manual = build_structure_prior(model)
+    for (X, n1, n0) in [(["bash", "rep3"], 5, 2), (["read", "rep0"], 1, 4)]
+        for _ in 1:n1; manual = structure_observe(model, manual, X, 1); end
+        for _ in 1:n0; manual = structure_observe(model, manual, X, 0); end
+    end
+    check("warm_counts reconstruction ≡ hand structure_observe replay (bit-exact)",
+          weights(warm) == weights(manual), "$(weights(warm)) vs $(weights(manual))")
+    check("warm_counts=nothing ≡ the cold prior",
+          weights(reconstruct_structure_prior_from_data(model, nothing)) == weights(build_structure_prior(model)))
+end
+
 println("="^64)
 println("ALL CHECKS PASSED — structure-BMA lift exact")
 println("="^64)


### PR DESCRIPTION
Opens **Move 5** (extract credence-pi → its own `credence-openclaw` repo as a pure TypeScript wire consumer) with the design doc and the one engine prerequisite the design review surfaced. The actual new-repo build (TS daemon + skin client + publishing) lands in `credence-openclaw`; the engine-repo cleanup (remove `apps/credence-pi/`, strip CI) is a final follow-up PR once the new repo is verified.

**Design** (`docs/decouple/move-5-design.md`): daemon = TypeScript pure wire consumer (pins `credence-skin`, drives the verbs, zero probabilistic Julia); `openclaw-plugin` body unchanged. Build sequence + the rename map + open questions (skin-image composition, repo history) inside.

**Step 0 — `structure_bma` gains inline `warm_counts`** (the review finding). The daemon warm-seeds four governance brains via `reconstruct_posterior` (replays `observe` per count). `routing_init` already reconstructs warm server-side in one call, but `structure_bma` didn't — so governance warm-seeding over the wire would be N `structure_observe` round-trips per brain. Added `reconstruct_structure_prior_from_data` (symmetric with the routing one, bit-exact, `data=nothing`→cold), an optional `warm_counts` param on `structure_bma`, and refactored the shim's `reconstruct_posterior` to delegate (single source of truth). Protocol 1.5→1.6 (additive).

**Verified:** engine reconstruction ≡ hand `structure_observe` replay bit-exact (+ cold-prior corner); `test_feature_brain`/`test_harm_governance` green (the shim refactor); full `test_skin.py` green incl. the `warm_counts` wire check (warm-seed-to-block in one call); lint clean (226); header==const(1.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)