### PR TITLE
decouple Move 1 finish: exact claim-EU moment + marginalise verb (protocol 1.7)

### DIFF
--- a/apps/skin/clients/python/credence_skin_client/__init__.py
+++ b/apps/skin/clients/python/credence_skin_client/__init__.py
@@ -389,6 +389,20 @@ class SkinClient:
         })
         return result["value"]
 
+    def marginalise(self, state_id: str, shape: list[int], axis: int) -> list[float]:
+        """Marginal of a flat product-grid categorical along ``axis`` (0-based).
+
+        ``shape`` is the per-axis grid sizes in row-major order (last axis fastest,
+        matching ``itertools.product``); the engine sums out the other axes and
+        returns the length-``shape[axis]`` marginal. A terminal readout — the
+        marginalisation stays engine-side, so the consumer ships only data."""
+        result = self._call("marginalise", {
+            "state_id": state_id,
+            "shape": shape,
+            "axis": axis,
+        })
+        return result["weights"]
+
     def draw(self, state_id: str) -> Any:
         """Sample from the measure."""
         result = self._call("draw", {"state_id": state_id})

--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -1,6 +1,6 @@
 # Credence Skin Protocol
 
-Protocol-Version: 1.6
+Protocol-Version: 1.7
 
 JSON-RPC 2.0 over stdio. Skin reads newline-delimited JSON from stdin,
 writes newline-delimited JSON to stdout, logs to stderr.
@@ -13,6 +13,13 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
 
 ### Changelog
 
+- **1.7** — the deferred Move-1 commit-3 pieces (additive), completing the life-agent body
+  decouple: a `centered_power` function spec — `(θ−mu)^n` with the exact closed-form Beta
+  moment, so the integrated claim-inclusion EU rides `optimise{include,withhold}` over the cell
+  Beta (`E_θ[θ·u_assert(θ)]−κ`, exact — replaces narrative.py's point-estimate `p̄²`); and a
+  `marginalise` verb — the marginal of a flat product-grid categorical along an axis (replaces
+  utility.py's host-side joint-grid fold). Both keep the arithmetic engine-side. Additive; no
+  existing verb or spec changes shape.
 - **1.6** — `structure_bma` gains an optional inline `warm_counts` (decouple Move 5
   prerequisite, additive): `{contexts: [{ctx, n1, n0}]}` reconstructs the warm governance
   posterior server-side in one call (symmetric with `routing_init`'s `warm_counts`), so a wire
@@ -31,8 +38,8 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
   reaction to a latent x under a τ-marginalised choice model, conditioning a categorical over
   the x-grid (replaces life-agent's host-side `reaction_probability`); and a
   `discretised_gaussian` belief-spec — a Gaussian discretised onto a grid (replaces host-side
-  `gaussian_weights`). [+ a quadratic narrative functional and the `marginalise` verb as the
-  remaining commit-3 pieces land — both coupled to utility.py/narrative.py representations.]
+  `gaussian_weights`). [The remaining commit-3 pieces — the `centered_power` claim functional
+  and the `marginalise` verb — landed in 1.7, once coupled to the narrative.py/utility.py rewire.]
 - **1.3** — carried-latent specs (no new verb): a `labelled_mixture` belief-spec
   (`build_prevision`) — a `MixturePrevision` over a label-grid of `LabelledCategoricalPrevision`
   components sharing one categorical prior (a shared discrete latent, e.g. extractor
@@ -347,6 +354,27 @@ Maximum expected utility (without returning the action).
 
 ```json
 {"result": {"value": 0.85}}
+```
+
+### marginalise
+
+Marginal of a flat product-grid categorical along one axis (protocol 1.7). The
+state's `weights` index a row-major product grid (last axis varies fastest, matching
+`itertools.product`) with per-axis sizes `shape`; the verb sums out every other axis
+and returns the length-`shape[axis]` marginal. `axis` is 0-based. A terminal readout
+(the consumer never re-conditions the marginal) that keeps the joint-grid fold's
+marginalisation engine-side — the consumer ships `{shape, axis}` data, not arithmetic.
+
+```json
+{"method": "marginalise", "params": {
+  "state_id": "s_joint",
+  "shape": [3, 4],
+  "axis": 0
+}}
+```
+
+```json
+{"result": {"weights": [0.21, 0.34, 0.45]}}
 ```
 
 ### draw
@@ -856,6 +884,7 @@ for `opaque_bdsl` depending on the measure). Structure enables fast paths
 | `projection` | `index` (0-based) | `f(x) = x[index]`. Decomposes on ProductMeasure. `project` accepted as alias. |
 | `nested_projection` | `indices: [Int]` (0-based) | Recursive navigation through nested ProductMeasures. |
 | `tabular` | `values: [Float]` | Weighted sum over CategoricalMeasure atoms. |
+| `centered_power` | `n` (Int ≥ 0), `mu?` (default 0.0) | `f(θ) = (θ − mu)^n`. Closed-form moment on Beta leaves (raw moment `E[θ^n]` at `mu=0`, central moment / variance at `mu=mean`); quadrature on others. `centered_square` is the alias for `n=2`. |
 | `linear_combination` | `terms: [[coeff, sub_fn_spec]]`, `offset?` | Linearity of expectation: sum of (coeff · sub-functional expectations) + offset. Sub-specs are recursive function specs. |
 | `opaque_bdsl` | `env_id`, `expr` | DSL lambda; delegates to the bare-function `expect` method for the measure type (closed-form / quadrature / Monte Carlo depending on measure). `bdsl` accepted as alias. |
 

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -26,6 +26,7 @@ using Credence: ProductPrevision, MixturePrevision, CategoricalPrevision
 using Credence: Finite, Interval, ProductSpace, Euclidean, PositiveReals, Simplex
 using Credence: Kernel, FactorSelector, support
 using Credence: Functional, Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure
+using Credence: CenteredPower, CenteredSquare, marginalise
 using Credence: factor, replace_factor
 using Credence: AgentState, sync_prune!, sync_truncate!
 using Credence: Grammar, Program, CompiledKernel, ProductionRule
@@ -539,6 +540,12 @@ function build_function(spec)::Functional
         NestedProjection(Int[Int(i) + 1 for i in spec["indices"]])
     elseif t == "tabular"
         Tabular(collect(Float64, spec["values"]))
+    elseif t == "centered_power" || t == "centered_square"
+        # E[(θ−μ)^n] over a scalar belief; μ=0 (default) is the raw moment E[θ^n].
+        # The integrated claim-EU ships LinearCombination([(u_c−u_w, centered_power n=2),
+        # (u_w, identity)], offset=−κ) — exact via the closed-form Beta moment.
+        deg = t == "centered_square" ? 2 : Int(spec["n"])
+        CenteredPower{deg}(Float64(get(spec, "mu", 0.0)))
     elseif t == "linear_combination"
         terms = Tuple{Float64, Functional}[
             (Float64(pair[1]), build_function(pair[2]))
@@ -678,7 +685,7 @@ end
 # rides the `credence-skin` image tag). MAJOR bumps on a breaking protocol
 # change; MINOR on additive. Apps pin the major in code and `initialize`
 # rejects a mismatching major with -32010. See docs/decouple/master-plan.md.
-const PROTOCOL_VERSION = "1.6"
+const PROTOCOL_VERSION = "1.7"
 protocol_major(v) = String(first(split(String(v), ".")))
 
 # Advertised method set, returned by `initialize` for client capability
@@ -687,7 +694,7 @@ protocol_major(v) = String(first(split(String(v), ".")))
 const SKIN_METHODS = [
     "initialize", "shutdown", "create_state", "destroy_state",
     "snapshot_state", "restore_state", "condition", "condition_on_event",
-    "weights", "mean", "expect", "optimise", "value", "draw", "enumerate",
+    "weights", "mean", "expect", "optimise", "value", "marginalise", "draw", "enumerate",
     "perturb_grammar", "add_programs", "sync_prune", "sync_truncate",
     "top_grammars", "belief_summary", "condition_and_prune", "eu_interact",
     "call_dsl", "factor", "replace_factor", "n_factors",
@@ -723,6 +730,8 @@ function handle_request(method::String, params, id)
         handle_optimise(params)
     elseif method == "value"
         handle_value(params)
+    elseif method == "marginalise"
+        handle_marginalise(params)
     elseif method == "structure_bma"
         handle_structure_bma(params)
     elseif method == "structure_observe"
@@ -1042,6 +1051,19 @@ function handle_weights(params)
     id = string(params["state_id"])
     state = get_state(id)
     Dict("weights" => collect(Float64, weights(state)))
+end
+
+# marginalise: marginal of a flat product-grid categorical along `axis` (0-based).
+# A terminal readout (the consumer never re-conditions the marginal) — the engine
+# sums out the other axes so the consumer ships only `{shape, axis}` data, doing no
+# belief arithmetic of its own (Invariant 1). `shape` is the per-axis grid sizes in
+# row-major order (last axis fastest, matching the consumer's product enumeration).
+function handle_marginalise(params)
+    id = string(params["state_id"])
+    state = get_state(id)
+    shape = Int[Int(x) for x in params["shape"]]
+    axis = Int(params["axis"])
+    Dict("weights" => collect(Float64, marginalise(state, shape, axis)))
 end
 
 function handle_mean(params)

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -1050,6 +1050,76 @@ def test_labelled_mixture_rho_latent():
         skin.shutdown()
 
 
+def test_centered_power_claim_eu():
+    """The integrated claim-inclusion EU over the wire (decouple Move 1 finish, 1.7): a cell
+    belief is a Beta over reliability θ; the include action's EU is E_θ[θ·u_assert(θ)]−κ —
+    a LinearCombination of the closed-form moments [(u_c−u_w)·E[θ²] + u_w·E[θ] − κ], shipped
+    as a `centered_power` functional. `optimise{include,withhold}` integrates the Beta exactly
+    (the engine, not the client). Asserts a low-reliability cell withholds, a high-reliability
+    cell includes, and the include EU equals the closed form — NO client probability arithmetic,
+    and NOT the old body's point-estimate p̄² (the variance term is kept)."""
+    u_c, u_w, kappa = 1.0, -1.0, 0.05
+    include_fn = {"type": "linear_combination",
+                  "terms": [[u_c - u_w, {"type": "centered_power", "n": 2}],
+                            [u_w, {"type": "identity"}]],
+                  "offset": -kappa}
+    withhold_fn = {"type": "linear_combination", "terms": [], "offset": 0.0}
+    pref = {"type": "functional_per_action", "actions": {"0": withhold_fn, "1": include_fn}}
+    actions = {"type": "finite", "values": [0.0, 1.0]}
+
+    def include_eu_closed(a, b):
+        e2 = a * (a + 1) / ((a + b) * (a + b + 1))
+        e1 = a / (a + b)
+        return (u_c - u_w) * e2 + u_w * e1 - kappa
+
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        # Low-reliability cell Beta(2,3): include EU < 0 → withhold.
+        lo = skin.create_state(type="beta", alpha=2.0, beta=3.0)
+        a_lo, eu_lo = skin.optimise(lo, actions=actions, preference=pref)
+        # credence-lint: allow — precedent:test-oracle — engine include-EU vs the closed-form moment; non-causal
+        assert abs(eu_lo - max(include_eu_closed(2.0, 3.0), 0.0)) < 1e-12, eu_lo
+        assert a_lo == 0, f"low-reliability cell should withhold, got action {a_lo}"
+
+        # High-reliability cell Beta(20,2): include EU > 0 → include.
+        hi = skin.create_state(type="beta", alpha=20.0, beta=2.0)
+        a_hi, eu_hi = skin.optimise(hi, actions=actions, preference=pref)
+        # credence-lint: allow — precedent:test-oracle — engine include-EU vs the closed-form moment; non-causal
+        assert abs(eu_hi - include_eu_closed(20.0, 2.0)) < 1e-12, eu_hi
+        assert a_hi == 1, f"high-reliability cell should include, got action {a_hi}"
+        print("PASS: centered_power integrated claim-EU over the wire (exact, Wald include/withhold)")
+    finally:
+        skin.shutdown()
+
+
+def test_marginalise_joint_grid():
+    """The joint-grid fold's marginalisation over the wire (decouple Move 1 finish, 1.7):
+    condition a flat product-grid categorical, then `marginalise` to each axis. The engine
+    sums out the other axes (replacing utility.py's host-side `marg[ix[j]] += joint[k]`),
+    so the consumer ships only `{shape, axis}` — no belief arithmetic client-side."""
+    import math
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        # 2×3 grid, row-major (axis-1 fastest): flat [w00,w01,w02, w10,w11,w12].
+        w = [0.05, 0.10, 0.15, 0.20, 0.18, 0.32]
+        sid = skin.create_state(
+            type="categorical",
+            space={"type": "finite", "values": [float(i) for i in range(6)]},
+            log_weights=[math.log(x) for x in w],
+        )
+        m0 = skin.marginalise(sid, shape=[2, 3], axis=0)
+        m1 = skin.marginalise(sid, shape=[2, 3], axis=1)
+        # credence-lint: allow — precedent:test-oracle — engine marginal vs hand-summed grid axes; non-causal
+        assert abs(m0[0] - 0.30) < 1e-12 and abs(m0[1] - 0.70) < 1e-12, m0
+        # credence-lint: allow — precedent:test-oracle — engine marginal vs hand-summed grid axes; non-causal
+        assert abs(m1[0] - 0.25) < 1e-12 and abs(m1[1] - 0.28) < 1e-12 and abs(m1[2] - 0.47) < 1e-12, m1
+        print("PASS: marginalise joint-grid fold over the wire")
+    finally:
+        skin.shutdown()
+
+
 # ── Structure-BMA verbs (decouple Move 3) ──
 
 
@@ -1211,7 +1281,7 @@ def test_initialize_returns_contract():
     skin = SkinClient()
     try:
         result = skin.initialize()
-        assert result["protocol"] == "1.6", f"protocol: {result.get('protocol')}"
+        assert result["protocol"] == "1.7", f"protocol: {result.get('protocol')}"
         assert "version" in result, "engine version missing"
         methods = result["methods"]
         # Core canalised verbs + the Move-3 structure-BMA verbs must be advertised.
@@ -1257,7 +1327,7 @@ def test_dsl_sources_inline_equivalent_to_path():
         # a subsequent call_dsl against the loaded env resolves (the path-based
         # test_router_roundtrip already covers the path branch).
         result = skin.initialize(dsl_sources={"router": source})
-        assert result["protocol"] == "1.6"
+        assert result["protocol"] == "1.7"
         print("PASS: inline dsl_sources loads equivalently to a path load")
     finally:
         skin.shutdown()
@@ -1371,5 +1441,9 @@ if __name__ == "__main__":
     test_logistic_reaction_kernel()
     print()
     test_discretised_gaussian_prior()
+    print()
+    test_centered_power_claim_eu()
+    print()
+    test_marginalise_joint_grid()
     print()
     print("All tests passed!")

--- a/docs/decouple/move-1-design.md
+++ b/docs/decouple/move-1-design.md
@@ -226,3 +226,33 @@ on beliefs remains in `src/life_agent/core/` (eval-only `gate.py` excepted).
 - [ ] New kernels carry exact-oracle tests incl. degenerate reductions.
 - [ ] §8 yes-or-justified on all four.
 - [ ] The body ends with zero belief arithmetic (the grep gate in §7).
+
+---
+
+## 9. Landed — the deferred commit-3 finish (3c/3d, protocol 1.7)
+
+The §2.3/§2.4 pieces deferred at first pass landed together once the body rewire pinned
+their shapes, with two refinements over the original sketch:
+
+- **§2.4 claim functional → reuse `CenteredPower{n}`, not a new type.** The integrated
+  claim-inclusion EU is `E_θ[θ·u_assert(θ)] − κ = (u_c−u_w)·E[θ²] + u_w·E[θ] − κ`, a
+  `LinearCombination([(u_c−u_w, centered_power n=2), (u_w, identity)], offset=−κ)`. The
+  existing `CenteredPower{n}` (the central/raw moment test function) gains an exact
+  closed-form `expect(::Beta{Measure,Prevision}, ::CenteredPower)` (raw moment via rising
+  factorials), so the claim decision is `optimise{include,withhold}` over the cell Beta —
+  integrated **exactly**, keeping the `Var(θ)·(u_c−u_w)` term the body's point-estimate `p̄²`
+  dropped. No new functional type; composes with the existing `linear_combination` spec.
+  This is the [[feedback_decouple_express_proper_model_not_port]] principle in practice — the
+  decoupled model is the *proper* integral, not a port of the host's plug-at-the-mean.
+- **§2.3 `marginalise` verb shape → `{state_id, shape, axis}`, not `keep:[...]`.** The body
+  builds one flat row-major (C-order) product-grid categorical; `shape` (per-axis sizes) +
+  `axis` names the coordinate projection unambiguously and the engine sums out the rest —
+  the pushforward through π_axis, server-side. One axis per call (the fold reads each latent's
+  marginal in turn). `marginalise` lives in `src/stdlib.jl` (the canalised `push` path); the
+  skin verb only marshals (lint-clean, no apps/ arithmetic).
+
+Verification: `test/test_centered_moment.jl` (exact moments + integrated claim-EU Wald
+flip + marginalise row-major folds + guards); `apps/skin/test_skin.py`
+`test_centered_power_claim_eu` + `test_marginalise_joint_grid` (both over the wire,
+zero client arithmetic); engine regression (routing/structure-BMA/typed-decision/core)
+green; `check apps/` clean (180 files); header==const(1.7).

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -60,7 +60,7 @@ export ConjugatePrevision, maybe_conjugate, update
 export StructureBMA, build_structure_model, build_structure_prior, build_structure_prior_dense, structure_observe, structure_observe_soft, belief_at_context, context_from_features, structure_firing_tags, structure_decision_kernel, reconstruct_structure_prior_from_data
 export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next, posterior_accuracy, route_outcome!, decode_correctness, latency_at, route_decide, escalate_decide, routing_belief_readout, reconstruct_latency_from_data, reconstruct_routing_tops_from_data, _ctx_key
 export draw
-export weights, mean, variance, probability, marginal, prune, truncate, logsumexp
+export weights, mean, variance, probability, marginal, marginalise, prune, truncate, logsumexp
 export WeightsDomainError
 export save_state, load_state, MigrationError
 export initial_rel_state, initial_cov_state, marginalize_betas, update_beta_state

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -50,7 +50,7 @@ export ConjugatePrevision, maybe_conjugate, update
 export draw
 export weights, mean, variance, log_density_at, prune, truncate, logsumexp
 export FrozenVectorView
-export WeightsDomainError, probability, marginal, CenteredPower, CenteredSquare, GeometricTail
+export WeightsDomainError, probability, marginal, marginalise, CenteredPower, CenteredSquare, GeometricTail
 
 # ================================================================
 # FrozenVectorView{T}
@@ -690,6 +690,28 @@ function expect(m::BetaMeasure, ::GeometricTail)
     m.alpha / (m.beta - 1.0)
 end
 expect(m::TaggedBetaMeasure, ::GeometricTail) = expect(m.beta, GeometricTail())
+
+# Exact Beta moment E_Beta[(θ−μ)^n], closed form via binomial expansion into raw
+# moments m_j = E[θ^j] = ∏_{i=0}^{j-1}(α+i)/(α+β+i). μ=0 gives the raw moment E[θ^n]
+# (the integrated claim-EU needs E[θ²] = CenteredPower{2}(0.0)); μ=mean gives the
+# central moment (variance at n=2). Reaches the fast path with no quadrature, so the
+# integrated decision is exact, not the generic `expect(::Beta, ::TestFunction)` MC.
+function _beta_central_moment(α::Float64, β::Float64, n::Int, μ::Float64)
+    n >= 0 || error("CenteredPower exponent must be ≥ 0, got $n")
+    raw = Vector{Float64}(undef, n + 1)          # raw[j+1] = E[θ^j]
+    raw[1] = 1.0
+    for j in 1:n
+        raw[j+1] = raw[j] * (α + (j - 1)) / (α + β + (j - 1))
+    end
+    s = 0.0
+    for j in 0:n
+        s += binomial(n, j) * (-μ)^(n - j) * raw[j+1]
+    end
+    s
+end
+expect(m::BetaMeasure, cp::CenteredPower{n}) where n = _beta_central_moment(m.alpha, m.beta, n, cp.μ)
+expect(m::TaggedBetaMeasure, cp::CenteredPower) = expect(m.beta, cp)
+
 expect(m::GammaMeasure, ::Identity)    = m.alpha / m.beta
 expect(m::GaussianMeasure, ::Identity) = m.mu
 
@@ -783,6 +805,11 @@ function expect(p::BetaPrevision, ::GeometricTail)
     p.beta > 1.0 || error("GeometricTail diverges for β ≤ 1 (got β=$(p.beta)); the continuation posterior must have β > 1")
     p.alpha / (p.beta - 1.0)
 end
+
+# Exact Beta moment on Prevision leaves (mirrors the BetaMeasure form): the integrated
+# claim-EU `optimise{include,withhold}` reaches this through a `beta` create_state.
+expect(p::BetaPrevision, cp::CenteredPower{n}) where n = _beta_central_moment(p.alpha, p.beta, n, cp.μ)
+expect(p::TaggedBetaPrevision, cp::CenteredPower) = expect(p.beta, cp)
 expect(p::GaussianPrevision, ::Identity) = p.mu
 expect(p::MvGaussianPrevision, ::Identity) = copy(p.mu)
 expect(p::GammaPrevision, ::Identity) = p.alpha / p.beta
@@ -879,6 +906,15 @@ function expect(p::Prevision, lc::LinearCombination)
     end
     total
 end
+
+# Disambiguate LinearCombination on the scalar leaf Previsions that also carry a generic
+# `expect(::X, ::TestFunction)` quadrature fallback: both that and the decomposition above
+# match `(BetaPrevision, LinearCombination)` equally. Route to the decomposition so each
+# term reaches its closed form (the integrated claim-EU stays exact, not quadrature).
+expect(p::BetaPrevision, lc::LinearCombination)      = invoke(expect, Tuple{Prevision, LinearCombination}, p, lc)
+expect(p::TaggedBetaPrevision, lc::LinearCombination) = invoke(expect, Tuple{Prevision, LinearCombination}, p, lc)
+expect(p::GaussianPrevision, lc::LinearCombination)  = invoke(expect, Tuple{Prevision, LinearCombination}, p, lc)
+expect(p::GammaPrevision, lc::LinearCombination)     = invoke(expect, Tuple{Prevision, LinearCombination}, p, lc)
 
 # Disambiguate MixturePrevision × LinearCombination — both `expect(::MixturePrevision,
 # ::TestFunction)` and `expect(::Prevision, ::LinearCombination)` match. Expand by

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -90,6 +90,39 @@ function marginal(p::MixturePrevision, indices::Vector{Int})
 end
 
 """
+    marginalise(state, shape::Vector{Int}, axis::Int) -> Vector{Float64}
+
+Marginal of a flat product-grid categorical along `axis` (0-based, wire
+convention). The state's `weights` index a row-major (C-order — last axis varies
+fastest, matching Python `itertools.product`) product grid with per-axis sizes
+`shape`; this returns the length-`shape[axis]` marginal — the pushforward of the
+belief through the coordinate projection π_axis, summing out every other axis.
+
+The joint stays a single flat categorical (conditioning on a coupling event
+correlates the axes, so it is not a `ProductMeasure`); the marginal is a terminal
+readout, never fed back. Keeping the sum here rather than in the consumer holds
+Invariant 1 — the consumer ships `{shape, axis}` data and receives weights, doing
+no belief arithmetic of its own.
+"""
+function marginalise(state, shape::Vector{Int}, axis::Int)
+    0 <= axis < length(shape) || error("marginalise: axis $axis out of range for shape $shape")
+    all(>(0), shape) || error("marginalise: shape dims must be ≥ 1, got $shape")
+    w = weights(state)
+    n = prod(shape)
+    length(w) == n || error("marginalise: state has $(length(w)) atoms but shape $shape implies $n")
+    dim = shape[axis + 1]
+    stride = 1                                   # ∏ of axis sizes strictly AFTER `axis`
+    for d in (axis + 2):length(shape)
+        stride *= shape[d]
+    end
+    out = zeros(Float64, dim)
+    for k in 0:(n - 1)
+        out[(k ÷ stride) % dim + 1] += w[k + 1]
+    end
+    out
+end
+
+"""
     with_components(p::MixturePrevision, components) -> MixturePrevision
 
 Re-key a mixture: keep `p`'s weights verbatim, replace its per-component beliefs.

--- a/test/test_centered_moment.jl
+++ b/test/test_centered_moment.jl
@@ -1,0 +1,102 @@
+# test_centered_moment.jl — the exact Beta moment (CenteredPower closed form) and the
+# `marginalise` product-grid fold (decouple Move 1 finish / protocol 1.7). Self-contained
+# (no apps/ dependency): pins the two engine primitives the life-agent body decouple needs.
+# Asserts:
+#   (1) raw moment E[θ^n] = CenteredPower{n}(0) on Beta(α,β) equals the exact rising-factorial
+#       form (n=2 → α(α+1)/((α+β)(α+β+1))); the Prevision path equals the Measure path;
+#   (2) central second moment CenteredPower{2}(mean) equals Var(Beta) exactly;
+#   (3) the integrated claim-inclusion EU LinearCombination([(u_c−u_w, CP2(0)), (u_w, Id)], −κ)
+#       = E_θ[θ·u_assert(θ)]−κ exactly, and that it differs from the OLD body's point-estimate
+#       p̄² by exactly Var·(u_c−u_w) — the variance term the exact integral keeps (NOT a port);
+#       and the decision via expect flips withhold↔include across the reliability bar;
+#   (4) marginalise sums a flat row-major product-grid categorical to the per-axis marginal.
+#
+# Run from repo root:  julia test/test_centered_moment.jl
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: BetaMeasure, BetaPrevision, CategoricalMeasure, Finite, CenteredPower,
+                CenteredSquare, Identity, LinearCombination, Functional, expect, marginalise
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+approx(a, b; atol = 1e-12) = abs(a - b) <= atol
+
+println("="^64)
+println("exact Beta moment (CenteredPower) + marginalise (Move 1 finish, 1.7)")
+println("="^64)
+
+# ── (1) raw moments: E[θ^n] = ∏_{i=0}^{n-1}(α+i)/(α+β+i) ──
+for (α, β) in [(2.0, 3.0), (20.0, 2.0), (1.0, 1.0), (5.0, 7.0)]
+    m = BetaMeasure(α, β)
+    e2_closed = α * (α + 1) / ((α + β) * (α + β + 1))
+    check("E[θ²] Beta($α,$β) exact", approx(expect(m, CenteredPower{2}(0.0)), e2_closed),
+          "$(expect(m, CenteredPower{2}(0.0))) vs $e2_closed")
+    check("E[θ²] prevision path == measure path Beta($α,$β)",
+          approx(expect(BetaPrevision(α, β), CenteredPower{2}(0.0)), e2_closed))
+    check("E[θ¹] == mean Beta($α,$β)", approx(expect(m, CenteredPower{1}(0.0)), α / (α + β)))
+    check("E[θ⁰] == 1 Beta($α,$β)", approx(expect(m, CenteredPower{0}(0.0)), 1.0))
+end
+
+# ── (2) central second moment == variance ──
+for (α, β) in [(2.0, 3.0), (20.0, 2.0), (5.0, 7.0)]
+    μ = α / (α + β)
+    var_closed = α * β / ((α + β)^2 * (α + β + 1))
+    check("Var Beta($α,$β) via CenteredSquare(mean)", approx(expect(BetaMeasure(α, β), CenteredSquare(μ)), var_closed))
+end
+
+# ── (3) integrated claim-inclusion EU = E_θ[θ·u_assert(θ)] − κ ──
+u_c, u_w, κ = 1.0, -1.0, 0.05
+include_fn = LinearCombination([(u_c - u_w, CenteredPower{2}(0.0)), (u_w, Identity())], -κ)
+withhold_fn = LinearCombination(Tuple{Float64, Functional}[], 0.0)   # the gauge zero
+eu_include_exact(α, β) = begin
+    e2 = α * (α + 1) / ((α + β) * (α + β + 1))
+    e1 = α / (α + β)
+    (u_c - u_w) * e2 + u_w * e1 - κ
+end
+for (α, β) in [(2.0, 3.0), (20.0, 2.0), (8.0, 4.0)]
+    got = expect(BetaMeasure(α, β), include_fn)
+    check("include EU exact Beta($α,$β)", approx(got, eu_include_exact(α, β)), "$got vs $(eu_include_exact(α,β))")
+end
+
+# The variance term is real, not ported: exact − point-estimate(p̄²) = Var·(u_c−u_w).
+# Beta(1.4,0.6): mean 0.7, Var = (1.4·0.6)/(2²·3) = 0.07 → Δ = 0.07·2 = 0.14.
+let α = 1.4, β = 0.6
+    p = α / (α + β)
+    point = (u_c - u_w) * p^2 + u_w * p - κ           # the OLD body's plug-at-mean estimate
+    exact = expect(BetaMeasure(α, β), include_fn)
+    check("exact integral keeps Var·(u_c−u_w) over the point estimate", approx(exact - point, 0.14),
+          "Δ = $(exact - point) (expected 0.14)")
+end
+
+# The decision through expect (no host arithmetic): a low-reliability cell withholds, a
+# high-reliability cell includes — the optimise{include,withhold} the wire runs.
+decide(α, β) = expect(BetaMeasure(α, β), include_fn) > expect(BetaMeasure(α, β), withhold_fn) ? :include : :withhold
+check("low-reliability cell withholds", decide(2.0, 3.0) == :withhold, string(eu_include_exact(2.0, 3.0)))
+check("high-reliability cell includes", decide(20.0, 2.0) == :include, string(eu_include_exact(20.0, 2.0)))
+
+# ── (4) marginalise: flat row-major product grid (last axis fastest, matches itertools.product) ──
+# 2×3 grid: flat [w00,w01,w02, w10,w11,w12].
+w = [0.05, 0.10, 0.15, 0.20, 0.18, 0.32]               # Σ = 1.0
+cat = CategoricalMeasure(Finite(collect(Float64, 0:5)), log.(w))
+m0 = marginalise(cat, [2, 3], 0)                        # [w00+w01+w02, w10+w11+w12]
+m1 = marginalise(cat, [2, 3], 1)                        # [w00+w10, w01+w11, w02+w12]
+check("marginalise axis0", approx(m0[1], 0.30) && approx(m0[2], 0.70), string(m0))
+check("marginalise axis1", approx(m1[1], 0.25) && approx(m1[2], 0.28) && approx(m1[3], 0.47), string(m1))
+check("marginalise normalised axis0", approx(sum(m0), 1.0))
+check("marginalise normalised axis1", approx(sum(m1), 1.0))
+
+# 3-axis middle: 2×2×2, flat k = i0·4 + i1·2 + i2.
+w3 = [0.05, 0.05, 0.10, 0.10, 0.15, 0.15, 0.20, 0.20]  # Σ = 1.0
+cat3 = CategoricalMeasure(Finite(collect(Float64, 0:7)), log.(w3))
+mid = marginalise(cat3, [2, 2, 2], 1)                  # i1=0: k∈{0,1,4,5}=.40 ; i1=1: k∈{2,3,6,7}=.60
+check("marginalise 3-axis middle", approx(mid[1], 0.40) && approx(mid[2], 0.60), string(mid))
+
+# Guards: axis out of range and shape/atom mismatch fail loud.
+check("marginalise rejects bad axis", try; marginalise(cat, [2, 3], 2); false; catch; true; end)
+check("marginalise rejects shape mismatch", try; marginalise(cat, [2, 4], 0); false; catch; true; end)
+
+println("="^64)
+println("ALL PASSED")
+println("="^64)


### PR DESCRIPTION
Completes the deferred Move-1 commit-3 engine primitives (the §2.3/§2.4 pieces the
life-agent body decouple needs), both exact and arithmetic-engine-side. This is the
engine half of finishing the **last** decouple consumer (life-agent); the body repoint
lands in the `life-agent` repo against the 1.7 `credence-skin` image this publishes.

## What landed

**3c — integrated claim-inclusion EU.** Closed-form Beta moment
`expect(::Beta{Measure,Prevision}, ::CenteredPower{n})` (raw moment via rising factorials;
variance at `mu=mean`) + a `centered_power` function spec. The claim EU becomes
`LinearCombination([(u_c−u_w, centered_power n=2), (u_w, identity)], −κ)`
`= E_θ[θ·u_assert(θ)] − κ` over the cell Beta, decided by `optimise{include,withhold}` —
integrated **exactly**, keeping the `Var(θ)·(u_c−u_w)` term narrative.py's point-estimate
`p̄²` dropped (express the *proper* model, don't port the host approximation). Reuses the
existing `CenteredPower` type; disambiguates `(Beta/Tagged/Gaussian/Gamma)Prevision ×
LinearCombination` onto the linearity decomposition.

**3d — joint-grid marginalisation.** `marginalise(state, shape, axis)` in `src/stdlib.jl`
(the pushforward through coordinate projection π_axis on a flat row-major product-grid
categorical) + a `marginalise` skin verb + a `credence-skin-client` method. Replaces
utility.py's host-side `marg[ix[j]] += joint[k]`; the consumer ships only `{shape, axis}`.

Protocol **1.6 → 1.7** (additive: one function spec, one verb).

## Verification
- `test/test_centered_moment.jl` — exact moments, integrated claim-EU Wald flip, row-major
  marginals, fail-loud guards.
- `apps/skin/test_skin.py` `test_centered_power_claim_eu` + `test_marginalise_joint_grid` —
  both over the wire, zero client arithmetic.
- Engine regression green (routing / structure-BMA / typed-decision / core); `check apps/`
  clean (180 files); `Protocol-Version` header == `PROTOCOL_VERSION` (1.7).

`docs/decouple/move-1-design.md` §9 records the two shape refinements over the sketch
(reuse `CenteredPower` vs a new functional type; `{shape, axis}` vs `keep:[...]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)