### PR TITLE
decouple: engine prerequisites for the strict body rewire (label_prior + read_params, protocol 1.8)

### DIFF
--- a/apps/skin/clients/python/credence_skin_client/__init__.py
+++ b/apps/skin/clients/python/credence_skin_client/__init__.py
@@ -403,6 +403,12 @@ class SkinClient:
         })
         return result["weights"]
 
+    def read_params(self, state_id: str) -> dict:
+        """The registered belief's declarative ``{type, params...}`` spec (the `params`
+        protocol). Routes a wire-conditioned conjugate posterior back into another spec
+        (e.g. a ρ Beta → a `labelled_mixture` `label_prior`) with no host conjugacy."""
+        return self._call("read_params", {"state_id": state_id})
+
     def draw(self, state_id: str) -> Any:
         """Sample from the measure."""
         result = self._call("draw", {"state_id": state_id})

--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -1,6 +1,6 @@
 # Credence Skin Protocol
 
-Protocol-Version: 1.7
+Protocol-Version: 1.8
 
 JSON-RPC 2.0 over stdio. Skin reads newline-delimited JSON from stdin,
 writes newline-delimited JSON to stdout, logs to stderr.
@@ -13,6 +13,11 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
 
 ### Changelog
 
+- **1.8** — `labelled_mixture` gains an optional `label_prior` belief-spec (additive): the
+  engine discretises a continuous prior (`{type:beta, alpha, beta}` or `{type:gaussian, mu,
+  sigma}`) onto the label grid to set the mixture (latent) weights, so a ρ~Beta latent is
+  carried EXACTLY in shape without host density arithmetic. Omitting it keeps the prior
+  uniform / `label_log_weights` (unchanged). The life-agent lookup ρ-latent uses it.
 - **1.7** — the deferred Move-1 commit-3 pieces (additive), completing the life-agent body
   decouple: a `centered_power` function spec — `(θ−mu)^n` with the exact closed-form Beta
   moment, so the integrated claim-inclusion EU rides `optimise{include,withhold}` over the cell
@@ -850,7 +855,7 @@ Example with state references (the stateful mode, for long-lived agents):
 | `product` | `factors: [measure, ...]` | `ProductMeasure` |
 | `mixture` | `components, log_weights` | `MixtureMeasure` |
 | `tagged_beta` | `tag, alpha, beta` | `TaggedBetaMeasure` |
-| `labelled_mixture` | `labels: [...]`, `component_log_weights: [...]`, optional `label_log_weights` | `MixturePrevision` of `LabelledCategoricalPrevision` — a shared discrete latent (label-grid) over one categorical prior. Routed by `group_noisy_channel`. (protocol 1.3) |
+| `labelled_mixture` | `labels: [...]`, `component_log_weights: [...]`, optional `label_prior` (`{type:beta,alpha,beta}` / `{type:gaussian,mu,sigma}`) or `label_log_weights` | `MixturePrevision` of `LabelledCategoricalPrevision` — a shared discrete latent (label-grid) over one categorical prior. `label_prior` discretises a continuous prior onto the labels engine-side (e.g. ρ~Beta exactly); else uniform / explicit weights. Routed by `group_noisy_channel`. (protocol 1.3; `label_prior` 1.8) |
 | `discretised_gaussian` | `grid: [...]`, `mu`, `sigma` | A Gaussian discretised onto the grid (≡ utility.py `gaussian_weights`), as a `CategoricalMeasure`. (protocol 1.4) |
 
 ### Kernel specs

--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -13,11 +13,15 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
 
 ### Changelog
 
-- **1.8** — `labelled_mixture` gains an optional `label_prior` belief-spec (additive): the
-  engine discretises a continuous prior (`{type:beta, alpha, beta}` or `{type:gaussian, mu,
-  sigma}`) onto the label grid to set the mixture (latent) weights, so a ρ~Beta latent is
-  carried EXACTLY in shape without host density arithmetic. Omitting it keeps the prior
-  uniform / `label_log_weights` (unchanged). The life-agent lookup ρ-latent uses it.
+- **1.8** — two additive prerequisites for the life-agent body rewire. (1) `labelled_mixture`
+  gains an optional `label_prior` belief-spec: the engine discretises a continuous prior
+  (`{type:beta, alpha, beta}` or `{type:gaussian, mu, sigma}`) onto the label grid to set the
+  mixture (latent) weights, so a ρ~Beta latent is carried EXACTLY in shape without host density
+  arithmetic. Omitting it keeps the prior uniform / `label_log_weights` (unchanged). (2) a
+  `read_params` verb returns a registered belief's declarative `{type, params...}` spec (the
+  `params` protocol), so a wire-CONDITIONED conjugate posterior routes back into another spec
+  (a ρ Beta → `labelled_mixture` `label_prior`) with no host conjugacy — the body conditions
+  over the wire then reads the exact posterior, never folding `a += 1`.
 - **1.7** — the deferred Move-1 commit-3 pieces (additive), completing the life-agent body
   decouple: a `centered_power` function spec — `(θ−mu)^n` with the exact closed-form Beta
   moment, so the integrated claim-inclusion EU rides `optimise{include,withhold}` over the cell
@@ -380,6 +384,21 @@ marginalisation engine-side — the consumer ships `{shape, axis}` data, not ari
 
 ```json
 {"result": {"weights": [0.21, 0.34, 0.45]}}
+```
+
+### read_params
+
+A registered belief's declarative `{type, params...}` spec (protocol 1.8) — the `params`
+protocol, the same shape `create_state` consumes, so it round-trips. Routes a wire-conditioned
+conjugate posterior back into another spec (e.g. a ρ Beta → a `labelled_mixture` `label_prior`)
+with no host conjugacy: the consumer conditions over the wire, then reads the exact posterior.
+
+```json
+{"method": "read_params", "params": {"state_id": "s_rho"}}
+```
+
+```json
+{"result": {"type": "beta", "alpha": 7.0, "beta": 5.0}}
 ```
 
 ### draw

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -718,7 +718,7 @@ protocol_major(v) = String(first(split(String(v), ".")))
 const SKIN_METHODS = [
     "initialize", "shutdown", "create_state", "destroy_state",
     "snapshot_state", "restore_state", "condition", "condition_on_event",
-    "weights", "mean", "expect", "optimise", "value", "marginalise", "draw", "enumerate",
+    "weights", "mean", "expect", "optimise", "value", "marginalise", "read_params", "draw", "enumerate",
     "perturb_grammar", "add_programs", "sync_prune", "sync_truncate",
     "top_grammars", "belief_summary", "condition_and_prune", "eu_interact",
     "call_dsl", "factor", "replace_factor", "n_factors",
@@ -756,6 +756,8 @@ function handle_request(method::String, params, id)
         handle_value(params)
     elseif method == "marginalise"
         handle_marginalise(params)
+    elseif method == "read_params"
+        handle_read_params(params)
     elseif method == "structure_bma"
         handle_structure_bma(params)
     elseif method == "structure_observe"
@@ -1088,6 +1090,16 @@ function handle_marginalise(params)
     shape = Int[Int(x) for x in params["shape"]]
     axis = Int(params["axis"])
     Dict("weights" => collect(Float64, marginalise(state, shape, axis)))
+end
+
+# read_params: serialise a registered belief to its declarative `{type, params...}` spec
+# (the `params` protocol, same shape `create_state` consumes). Lets a consumer route a
+# wire-CONDITIONED conjugate posterior back into another spec (e.g. an extractor-reliability
+# ρ Beta → a `labelled_mixture` `label_prior`) WITHOUT host conjugacy — the body never folds
+# `a += 1`, it conditions over the wire then reads the exact posterior params here.
+function handle_read_params(params)
+    id = string(params["state_id"])
+    _belief_spec(get_state(id))
 end
 
 function handle_mean(params)

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -216,6 +216,23 @@ end
 # `params(::MvGaussianPrevision)` emits — a bare matrix flattens on JSON).
 _cov_from_rows(rows) = mapreduce(r -> permutedims(collect(Float64, r)), vcat, rows)
 
+# Discretise a continuous prior onto a label grid (the labelled_mixture latent prior): the
+# unnormalised log-density at each label; MixturePrevision normalises. Keeps a ρ~Beta carried
+# EXACTLY in shape with no host density arithmetic (mirrors discretised_gaussian's grid prior).
+# Labels must be interior to the support (β-kernel diverges at {0,1} for α<1 or β<1).
+function _discretise_label_prior(spec, labels::Vector{Float64})
+    t = spec["type"]
+    if t == "beta"
+        a = Float64(spec["alpha"]); b = Float64(spec["beta"])
+        [(a - 1.0) * log(ℓ) + (b - 1.0) * log(1.0 - ℓ) for ℓ in labels]
+    elseif t == "gaussian"
+        mu = Float64(spec["mu"]); sigma = Float64(spec["sigma"])
+        [-0.5 * ((ℓ - mu) / sigma)^2 for ℓ in labels]
+    else
+        error("unknown label_prior type: $t (expected beta or gaussian)")
+    end
+end
+
 function build_prevision(spec)
     t = spec["type"]
     if t == "categorical"
@@ -253,12 +270,19 @@ function build_prevision(spec)
         # (e.g. a ρ-grid), each component a LabelledCategoricalPrevision sharing one
         # categorical V-prior (`component_log_weights`). A per-component-routing kernel
         # (group_noisy_channel) reads each label at condition time, so conditioning learns
-        # the latent jointly with V and shares it across observations. `label_log_weights`
-        # is the latent prior (default uniform).
+        # the latent jointly with V and shares it across observations. The latent prior over
+        # `labels` is `label_prior` (a belief-spec the engine discretises onto the grid —
+        # e.g. `{type:beta, alpha, beta}` for a ρ~Beta carried exactly, no host density
+        # arithmetic) OR explicit `label_log_weights`; default uniform.
         labels = collect(Float64, spec["labels"])
         comp_lw = collect(Float64, spec["component_log_weights"])
-        label_lw = haskey(spec, "label_log_weights") ?
-            collect(Float64, spec["label_log_weights"]) : zeros(Float64, length(labels))
+        label_lw = if haskey(spec, "label_prior")
+            _discretise_label_prior(spec["label_prior"], labels)
+        elseif haskey(spec, "label_log_weights")
+            collect(Float64, spec["label_log_weights"])
+        else
+            zeros(Float64, length(labels))
+        end
         comps = LabelledCategoricalPrevision[
             LabelledCategoricalPrevision(ℓ, CategoricalPrevision(copy(comp_lw))) for ℓ in labels]
         MixturePrevision(comps, label_lw)
@@ -685,7 +709,7 @@ end
 # rides the `credence-skin` image tag). MAJOR bumps on a breaking protocol
 # change; MINOR on additive. Apps pin the major in code and `initialize`
 # rejects a mismatching major with -32010. See docs/decouple/master-plan.md.
-const PROTOCOL_VERSION = "1.7"
+const PROTOCOL_VERSION = "1.8"
 protocol_major(v) = String(first(split(String(v), ".")))
 
 # Advertised method set, returned by `initialize` for client capability

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -1081,6 +1081,31 @@ def test_labelled_mixture_beta_label_prior():
         skin.shutdown()
 
 
+def test_read_params_conjugate_readback():
+    """A wire-CONDITIONED Beta posterior read back as a spec (decouple Move 1 finish, 1.8): the
+    body conditions a ρ Beta over the wire on audit outcomes (NO host `a += 1`), then reads the
+    exact posterior params to feed another spec (a `labelled_mixture` `label_prior`). Beta(4,4)
+    + 3 successes + 1 failure → Beta(7,5), read back exactly."""
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        sid = skin.create_state(type="beta", alpha=4.0, beta=4.0)
+        for obs in (1.0, 1.0, 1.0, 0.0):  # 3 successes, 1 failure
+            skin.condition(sid, kernel={"type": "bernoulli"}, observation=obs)
+        spec = skin.read_params(sid)
+        # credence-lint: allow — precedent:test-oracle — engine conjugate posterior params vs Beta(4+3, 4+1); non-causal
+        assert spec["type"] == "beta", spec
+        # credence-lint: allow — precedent:test-oracle — Beta-Bernoulli conjugacy α=4+3, β=4+1; non-causal
+        assert abs(spec["alpha"] - 7.0) < 1e-12 and abs(spec["beta"] - 5.0) < 1e-12, spec
+        # And it round-trips: the spec rebuilds an identical Beta state.
+        sid2 = skin.create_state(**spec)
+        # credence-lint: allow — precedent:test-oracle — rebuilt-state mean vs Beta(7,5) mean 7/12; non-causal
+        assert abs(skin.mean(sid2) - 7.0 / 12.0) < 1e-12, skin.mean(sid2)
+        print("PASS: read_params conjugate readback (wire-conditioned Beta → spec, no host conjugacy)")
+    finally:
+        skin.shutdown()
+
+
 def test_centered_power_claim_eu():
     """The integrated claim-inclusion EU over the wire (decouple Move 1 finish, 1.7): a cell
     belief is a Beta over reliability θ; the include action's EU is E_θ[θ·u_assert(θ)]−κ —
@@ -1470,6 +1495,8 @@ if __name__ == "__main__":
     test_labelled_mixture_rho_latent()
     print()
     test_labelled_mixture_beta_label_prior()
+    print()
+    test_read_params_conjugate_readback()
     print()
     test_logistic_reaction_kernel()
     print()

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -1050,6 +1050,37 @@ def test_labelled_mixture_rho_latent():
         skin.shutdown()
 
 
+def test_labelled_mixture_beta_label_prior():
+    """The ρ-grid latent prior carried EXACTLY in shape over the wire (decouple Move 1 finish,
+    1.8): a `labelled_mixture` with `label_prior={beta}` discretises the Beta density onto the
+    ρ-grid engine-side, so the body ships only {alpha, beta} — no host density arithmetic. The
+    returned mixture weights must equal the normalised Beta kernel at the labels."""
+    import math
+    a, b = 4.0, 4.0
+    labels = [0.1, 0.3, 0.5, 0.7, 0.9]
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        sid = skin.create_state(
+            type="labelled_mixture",
+            labels=labels,
+            component_log_weights=[0.0, 0.0, 0.0],
+            label_prior={"type": "beta", "alpha": a, "beta": b},
+        )
+        w = skin.weights(sid)  # the ρ-mixture (latent) weights
+        raw = [x ** (a - 1.0) * (1.0 - x) ** (b - 1.0) for x in labels]
+        z = sum(raw)
+        ref = [r / z for r in raw]
+        # credence-lint: allow — precedent:test-oracle — engine ρ-grid prior vs the Beta-kernel formula; non-causal
+        assert all(abs(p - q) < 1e-12 for p, q in zip(w, ref)), f"{w} vs {ref}"
+        # Beta(4,4) is symmetric around 0.5 → the centre label carries the most mass.
+        # credence-lint: allow — precedent:test-oracle — asserts the discretised prior is peaked at the Beta mode; non-causal
+        assert w[2] == max(w), f"symmetric Beta should peak at 0.5: {w}"
+        print("PASS: labelled_mixture beta label_prior (exact ρ-grid prior over the wire)")
+    finally:
+        skin.shutdown()
+
+
 def test_centered_power_claim_eu():
     """The integrated claim-inclusion EU over the wire (decouple Move 1 finish, 1.7): a cell
     belief is a Beta over reliability θ; the include action's EU is E_θ[θ·u_assert(θ)]−κ —
@@ -1281,7 +1312,7 @@ def test_initialize_returns_contract():
     skin = SkinClient()
     try:
         result = skin.initialize()
-        assert result["protocol"] == "1.7", f"protocol: {result.get('protocol')}"
+        assert result["protocol"] == "1.8", f"protocol: {result.get('protocol')}"
         assert "version" in result, "engine version missing"
         methods = result["methods"]
         # Core canalised verbs + the Move-3 structure-BMA verbs must be advertised.
@@ -1327,7 +1358,7 @@ def test_dsl_sources_inline_equivalent_to_path():
         # a subsequent call_dsl against the loaded env resolves (the path-based
         # test_router_roundtrip already covers the path branch).
         result = skin.initialize(dsl_sources={"router": source})
-        assert result["protocol"] == "1.7"
+        assert result["protocol"] == "1.8"
         print("PASS: inline dsl_sources loads equivalently to a path load")
     finally:
         skin.shutdown()
@@ -1437,6 +1468,8 @@ if __name__ == "__main__":
     test_routing_verbs_roundtrip()
     print()
     test_labelled_mixture_rho_latent()
+    print()
+    test_labelled_mixture_beta_label_prior()
     print()
     test_logistic_reaction_kernel()
     print()


### PR DESCRIPTION
The two additive engine prerequisites for the **strict** life-agent body rewire (owner:
"always strict unless the approximation is validated by strict Bayesian machinery") — every
Beta fold becomes a wire `condition`, no host conjugacy.

## What landed (protocol 1.7 → 1.8)

**`label_prior` on `labelled_mixture`.** The engine discretises a continuous prior
(`{type:beta, alpha, beta}` / `{type:gaussian, mu, sigma}`) onto the label grid to set the
mixture (latent) weights — so the extractor-reliability ρ~Beta is carried **exactly in shape**
across the wire, no host density arithmetic. Mirrors `discretised_gaussian`. Omitting it keeps
the prior uniform / explicit `label_log_weights`.

**`read_params` verb.** Returns a registered belief's declarative `{type, params...}` spec (the
existing `params` protocol via `_belief_spec`), so a wire-**conditioned** conjugate posterior
routes back into another spec (a ρ Beta → `labelled_mixture` `label_prior`) with no host
conjugacy: the body conditions over the wire, then reads the exact `Beta(prior+correct,
prior+incorrect)` — never folding `a += 1` (a second learning path, forbidden by Invariant 1
even when the arithmetic is exact).

## Verification
- `test_labelled_mixture_beta_label_prior` — mixture weights == normalised Beta kernel at the
  labels (1e-12), peaked at the symmetric mode.
- `test_read_params_conjugate_readback` — `Beta(4,4)` + 3 successes + 1 failure → exact
  `Beta(7,5)` read back + round-trips to an identical state.
- Both over the wire, zero client arithmetic; existing `labelled_mixture` roundtrip unchanged;
  `check apps/` clean (180 files); `Protocol-Version` header == `PROTOCOL_VERSION` (1.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)