### PR TITLE
truncated_gaussian: a continuous bounded prior (engine owns the grid, protocol 1.10)

### DIFF
--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -1,6 +1,6 @@
 # Credence Skin Protocol
 
-Protocol-Version: 1.9
+Protocol-Version: 1.10
 
 JSON-RPC 2.0 over stdio. Skin reads newline-delimited JSON from stdin,
 writes newline-delimited JSON to stdout, logs to stderr.
@@ -13,6 +13,12 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
 
 ### Changelog
 
+- **1.10** — `truncated_gaussian` belief-spec (additive, Phase A cont'd): a continuous N(μ,σ²) on a
+  stated SUPPORT `[lo, hi]` — the proper continuous form for a sign/range-constrained latent (e.g.
+  a utility `u_wrong ≤ 0`). The bounds are model support, not a discretisation grid; the engine
+  integrates over `[lo,hi]` by an internal midpoint quadrature. Conditioning is non-conjugate → a
+  quadrature posterior. Lets the body declare continuous bounded utility latents instead of the
+  host Gaussian-on-a-grid.
 - **1.9** — "the engine owns the grid" (discretisation-antipattern disposal, Phase A). A
   discretisation grid is a computation strategy and must not appear in a declared belief/kernel.
   (1) `discretised_gaussian` belief-spec is **REMOVED** — declare a `gaussian` prior; the engine
@@ -877,6 +883,7 @@ Example with state references (the stateful mode, for long-lived agents):
 | `categorical` | `space`, optional `log_weights` | `CategoricalMeasure` |
 | `beta` | `alpha, beta` | `BetaMeasure` |
 | `gaussian` | `mu, sigma` | `GaussianMeasure` |
+| `truncated_gaussian` | `mu, sigma, lo, hi` | A continuous N(μ,σ²) on the SUPPORT [lo,hi] (a stated bound, e.g. a sign-constrained utility). The bounds are model support, NOT a grid; the engine integrates over [lo,hi] internally. Conditioning is non-conjugate → a quadrature posterior. (protocol 1.10) |
 | `gamma` | `alpha, beta` | `GammaMeasure` |
 | `dirichlet` | `alpha: [...]` | `DirichletMeasure` |
 | `normal_gamma` | `kappa, mu, alpha, beta` | `NormalGammaMeasure` |

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -19,7 +19,7 @@ using Credence: _dispatch_path
 using Credence: weights, mean, variance, prune, truncate, logsumexp
 using Credence: CategoricalMeasure, ProductMeasure, MixtureMeasure
 using Credence: Prevision, Measure, params
-using Credence: BetaPrevision, TaggedBetaPrevision, GaussianPrevision
+using Credence: BetaPrevision, TaggedBetaPrevision, GaussianPrevision, TruncatedGaussianPrevision
 using Credence: MvGaussianPrevision, MvGaussianMeasure, LinearGaussian, GaussianMeasure
 using Credence: GammaPrevision, DirichletPrevision, NormalGammaPrevision
 using Credence: ProductPrevision, MixturePrevision, CategoricalPrevision
@@ -249,6 +249,12 @@ function build_prevision(spec)
                             BetaPrevision(Float64(spec["alpha"]), Float64(spec["beta"])))
     elseif t == "gaussian"
         GaussianPrevision(Float64(spec["mu"]), Float64(spec["sigma"]))
+    elseif t == "truncated_gaussian"
+        # A continuous N(μ,σ) on the SUPPORT [lo,hi] (a stated bound, e.g. a sign-constrained
+        # utility). The engine integrates over [lo,hi] internally — the bounds are model support,
+        # NOT a discretisation grid.
+        TruncatedGaussianPrevision(Float64(spec["mu"]), Float64(spec["sigma"]),
+                                   Float64(spec["lo"]), Float64(spec["hi"]))
     elseif t == "mv_gaussian"
         MvGaussianPrevision(collect(Float64, spec["mu"]), _cov_from_rows(spec["sigma"]))
     elseif t == "gamma"
@@ -703,7 +709,7 @@ end
 # rides the `credence-skin` image tag). MAJOR bumps on a breaking protocol
 # change; MINOR on additive. Apps pin the major in code and `initialize`
 # rejects a mismatching major with -32010. See docs/decouple/master-plan.md.
-const PROTOCOL_VERSION = "1.9"
+const PROTOCOL_VERSION = "1.10"
 protocol_major(v) = String(first(split(String(v), ".")))
 
 # Advertised method set, returned by `initialize` for client capability

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -987,6 +987,28 @@ def test_logistic_reaction_kernel():
         skin.shutdown()
 
 
+def test_truncated_gaussian_prior():
+    """A continuous bounded latent over the wire (Phase A): `truncated_gaussian` declares N(μ,σ) on
+    the SUPPORT [lo,hi] (a sign-constrained utility) — the bounds are model support, NOT a grid; the
+    engine integrates over [lo,hi]. The truncated prior mean sits below the untruncated μ (upper tail
+    cut), and a Gaussian elicitation pulls the mean toward the observation but stays in [lo,hi]."""
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        sid = skin.create_state(type="truncated_gaussian", mu=-4.0, sigma=3.0, lo=-10.0, hi=0.0)
+        m_prior = skin.mean(sid)
+        # credence-lint: allow — precedent:test-oracle — truncation to [-10,0] cuts the upper tail; non-causal
+        assert -10.0 < m_prior < -4.0, f"truncated prior mean should sit below μ=-4 in (-10,0): {m_prior}"
+        # condition on an elicitation (gaussian_known_var → non-conjugate under truncation → quadrature)
+        skin.condition(sid, kernel={"type": "gaussian_known_var", "variance": 4.0}, observation=-6.0)
+        m_post = skin.mean(sid)
+        # credence-lint: allow — precedent:test-oracle — elicitation pulls toward -6, stays bounded; non-causal
+        assert m_prior > m_post > -6.0, f"elicitation should pull toward -6, bounded: {m_post}"
+        print("PASS: truncated_gaussian continuous bounded latent (engine integrates [lo,hi])")
+    finally:
+        skin.shutdown()
+
+
 def test_labelled_mixture_rho_latent():
     """A non-embedding consumer drives the carried ρ-latent over the wire: build a
     `labelled_mixture` (a ρ-grid of categoricals over V), condition it with a
@@ -1314,7 +1336,7 @@ def test_initialize_returns_contract():
     skin = SkinClient()
     try:
         result = skin.initialize()
-        assert result["protocol"] == "1.9", f"protocol: {result.get('protocol')}"
+        assert result["protocol"] == "1.10", f"protocol: {result.get('protocol')}"
         assert "version" in result, "engine version missing"
         methods = result["methods"]
         # Core canalised verbs + the Move-3 structure-BMA verbs must be advertised.
@@ -1360,7 +1382,7 @@ def test_dsl_sources_inline_equivalent_to_path():
         # a subsequent call_dsl against the loaded env resolves (the path-based
         # test_router_roundtrip already covers the path branch).
         result = skin.initialize(dsl_sources={"router": source})
-        assert result["protocol"] == "1.9"
+        assert result["protocol"] == "1.10"
         print("PASS: inline dsl_sources loads equivalently to a path load")
     finally:
         skin.shutdown()
@@ -1476,6 +1498,8 @@ if __name__ == "__main__":
     test_read_params_conjugate_readback()
     print()
     test_logistic_reaction_kernel()
+    print()
+    test_truncated_gaussian_prior()
     print()
     test_centered_power_claim_eu()
     print()

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -48,7 +48,7 @@ export Functional, Identity, Projection, NestedProjection, Tabular, LinearCombin
 export Prevision, TestFunction, Indicator, apply
 export params
 export CenteredPower, CenteredSquare, GeometricTail
-export BetaPrevision, TaggedBetaPrevision, GaussianPrevision, GammaPrevision
+export BetaPrevision, TaggedBetaPrevision, GaussianPrevision, TruncatedGaussianPrevision, GammaPrevision
 export CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, LabelledCategoricalPrevision
 export ProductPrevision, MixturePrevision, ExchangeablePrevision, decompose
 export ParticlePrevision, QuadraturePrevision

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -22,7 +22,7 @@ using LinearAlgebra: SymTridiagonal, eigen, dot, cholesky, Symmetric
 import ..Previsions: Prevision
 import ..Previsions: TestFunction, Identity, Projection, NestedProjection,
                      Tabular, LinearCombination, OpaqueClosure, FiringChoice, expect
-import ..Previsions: BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision, LabelledCategoricalPrevision
+import ..Previsions: BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, TruncatedGaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision, LabelledCategoricalPrevision
 import ..Previsions: ExchangeablePrevision, decompose
 import ..Previsions: ParticlePrevision, QuadraturePrevision
 import ..Previsions: ConditionalPrevision
@@ -1205,6 +1205,45 @@ log_density_at(m::BetaMeasure, x) = (m.alpha - 1) * log(x) + (m.beta - 1) * log(
 log_density_at(m::GammaMeasure, x) = (m.alpha - 1) * log(x) - m.beta * x
 log_density_at(m::TaggedBetaMeasure, x) = log_density_at(m.beta, x)
 log_density_at(m::GaussianMeasure, x) = -0.5 * ((x - m.mu) / m.sigma)^2
+
+# ── TruncatedGaussianPrevision: a continuous bounded prior, integrated over [lo,hi] engine-side ──
+# The truncation is the model's SUPPORT (not a grid); the engine chooses the quadrature internally.
+log_density_at(p::TruncatedGaussianPrevision, x) = -0.5 * ((x - p.mu) / p.sigma)^2
+
+# The engine's quadrature grid over the support [lo,hi] — the MIDPOINT rule (O(h²), no endpoint
+# over-counting). This grid is the engine's internal computation, invisible to the declared model.
+_trunc_grid(p::TruncatedGaussianPrevision, n::Int) =
+    [p.lo + (k - 0.5) * (p.hi - p.lo) / n for k in 1:n]
+
+# Conditioning is always non-conjugate (truncation breaks Normal-Normal) → quadrature over [lo,hi].
+function condition(p::TruncatedGaussianPrevision, k::Kernel, observation; n::Int = 64)
+    grid = _trunc_grid(p, n)
+    logw = Float64[]
+    for h in grid
+        ll = density(k, h, observation)
+        !isnan(ll) || error("density returned NaN conditioning a TruncatedGaussianPrevision")
+        push!(logw, log_density_at(p, h) + ll)
+    end
+    QuadraturePrevision(grid, logw)
+end
+
+# Expectations over the (unconditioned) truncated prior: quadrature on [lo,hi].
+function expect(p::TruncatedGaussianPrevision, f::Function; n::Int = 64)
+    grid = _trunc_grid(p, n)
+    lw = [log_density_at(p, x) for x in grid]
+    mx = maximum(lw)
+    w = exp.(lw .- mx)
+    w ./= sum(w)
+    sum(w[i] * f(grid[i]) for i in eachindex(grid))
+end
+expect(p::TruncatedGaussianPrevision, tf::TestFunction; kwargs...) = expect(p, x -> apply(tf, x); kwargs...)
+
+# Marginal likelihood ∫ p(x)·P(obs|x) dx over [lo,hi] (the `condition` verb's log_marginal) — a
+# direct quadrature, mirroring `_predictive_ll(::BetaMeasure)`; no wrap-in-measure needed.
+function log_predictive(p::TruncatedGaussianPrevision, k::Kernel, obs)
+    val = expect(p, h -> exp(density(k, h, obs)))
+    log(max(val, 1e-300))
+end
 log_density_at(m::DirichletMeasure, x) = sum((m.alpha[i] - 1) * log(x[i]) for i in eachindex(m.alpha))
 
 function log_density_at(m::NormalGammaMeasure, x)

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -30,7 +30,7 @@ module Previsions
 
 export Prevision, TestFunction, Indicator, apply, expect
 export Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure, FiringChoice
-export BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision, LabelledCategoricalPrevision
+export BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, TruncatedGaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision, LabelledCategoricalPrevision
 export ExchangeablePrevision, decompose
 export ParticlePrevision, QuadraturePrevision
 export ConditionalPrevision
@@ -329,6 +329,27 @@ The `GaussianMeasure` view wraps a `GaussianPrevision` and forwards
 struct GaussianPrevision <: Prevision
     mu::Float64
     sigma::Float64
+end
+
+"""
+    TruncatedGaussianPrevision(mu, sigma, lo, hi) <: Prevision
+
+A Gaussian N(μ, σ²) restricted to the support `[lo, hi]` — a CONTINUOUS bounded prior, NOT a
+discretisation grid. `[lo, hi]` are the model's *support bounds* (e.g. a sign-constrained utility
+`u_wrong ≤ 0`); the engine integrates over them by an internal quadrature when conditioning or
+taking expectations. Conditioning is always non-conjugate (the truncation breaks Normal-Normal),
+so it yields a `QuadraturePrevision` over `[lo, hi]`. Replaces a host-side Gaussian-on-a-grid.
+"""
+struct TruncatedGaussianPrevision <: Prevision
+    mu::Float64
+    sigma::Float64
+    lo::Float64
+    hi::Float64
+    function TruncatedGaussianPrevision(mu::Float64, sigma::Float64, lo::Float64, hi::Float64)
+        sigma > 0 || throw(ArgumentError("TruncatedGaussianPrevision: sigma > 0, got $sigma"))
+        lo < hi || throw(ArgumentError("TruncatedGaussianPrevision: lo < hi, got [$lo, $hi]"))
+        new(mu, sigma, lo, hi)
+    end
 end
 
 """

--- a/test/test_truncated_gaussian.jl
+++ b/test/test_truncated_gaussian.jl
@@ -1,0 +1,60 @@
+# test_truncated_gaussian.jl — a CONTINUOUS bounded prior (antipattern disposal, Phase A). The
+# utility latents are Gaussians on a stated support [lo,hi] (a sign/range constraint, e.g.
+# u_wrong ≤ 0); the body declares `{type:truncated_gaussian, mu, sigma, lo, hi}` — the bounds are
+# model SUPPORT, not a discretisation grid — and the engine integrates over [lo,hi] by an internal
+# midpoint quadrature (invisible to the model). Asserts:
+#   (1) the truncated prior mean/variance match a dense hand-quadrature (the engine's 64-pt grid);
+#   (2) conditioning is non-conjugate → a QuadraturePrevision whose support stays within [lo,hi];
+#   (3) a Gaussian elicitation pulls the posterior toward the observation but respects the bound;
+#   (4) the bound BINDS — truncating N(-4,3) to [-10,0] (≈9% mass cut above 0) moves the mean below
+#       the untruncated -4.
+#
+# Run from repo root:  julia test/test_truncated_gaussian.jl
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: TruncatedGaussianPrevision, GaussianPrevision, condition, expect, Identity, mean,
+                variance, Kernel, Euclidean, PushOnly, QuadraturePrevision, weights
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+approx(a, b; atol = 1e-9) = abs(a - b) <= atol
+
+println("="^64)
+println("TruncatedGaussianPrevision — a continuous bounded prior (Phase A)")
+println("="^64)
+
+p = TruncatedGaussianPrevision(-4.0, 3.0, -10.0, 0.0)
+
+# ── (1) prior moments ≈ a dense hand-quadrature over [lo,hi] ──
+xs = range(-10.0, 0.0, length = 200001)
+lw = [-0.5 * ((x + 4.0) / 3.0)^2 for x in xs]
+w = exp.(lw); w ./= sum(w)
+ref_mean = sum(w[i] * xs[i] for i in eachindex(xs))
+ref_var = sum(w[i] * (xs[i] - ref_mean)^2 for i in eachindex(xs))
+check("truncated prior mean ≈ dense hand-quadrature", approx(mean(p), ref_mean; atol = 1e-3),
+      "$(mean(p)) vs $ref_mean")
+check("truncated prior variance ≈ dense hand-quadrature", approx(variance(p), ref_var; atol = 1e-2),
+      "$(variance(p)) vs $ref_var")
+
+# ── (4) the bound BINDS: the truncated mean is below the untruncated -4 (upper tail cut) ──
+check("truncation binds — mean < the untruncated -4", mean(p) < -4.0, string(mean(p)))
+
+# ── (2)+(3) Gaussian elicitation (gaussian_known_var): non-conjugate → quadrature, bounded ──
+elicit = Kernel(Euclidean(1), Euclidean(1), μ -> error("ng"), (μ, o) -> -0.5 * (o - μ)^2 / 4.0;
+                params = Dict{Symbol, Any}(:sigma_obs => 2.0), likelihood_family = PushOnly())
+post = condition(p, elicit, -6.0)
+check("elicitation posterior is a QuadraturePrevision (non-conjugate, truncation breaks NormalNormal)",
+      post isa QuadraturePrevision, string(typeof(post)))
+m_post = expect(post, Identity())
+check("elicitation pulls the mean toward the observation (−6), past the prior", m_post < mean(p),
+      "$m_post vs prior $(mean(p))")
+check("elicitation posterior stays within the support [lo,hi]", m_post > -10.0 && m_post <= 0.0,
+      string(m_post))
+check("posterior support ⊆ [lo, hi] (the quadrature grid is on the bound)",
+      all(-10.0 <= g <= 0.0 for g in post.grid), "grid spans $(extrema(post.grid))")
+
+println("="^64)
+println("ALL PASSED")
+println("="^64)


### PR DESCRIPTION
A continuation of "the engine owns the grid" (#154): the utility latents are Gaussians on a stated
support `[lo,hi]` (a sign/range constraint — e.g. `u_wrong ≤ 0`, ~9% of the prior mass cut), not
full Gaussians. The proper continuous model is a **`TruncatedGaussianPrevision`**: the body declares
`{mu, sigma, lo, hi}` where `[lo,hi]` is model **support** (not a discretisation grid), and the
engine integrates over `[lo,hi]` by an internal midpoint quadrature — invisible to the model.

Conditioning is non-conjugate (truncation breaks NormalNormal) → a `QuadraturePrevision` over
`[lo,hi]`; `expect`/`mean`/`variance`/`log_predictive` quadrature the support. This unblocks the
Phase A body rewire (declare continuous bounded utility latents instead of the host
gaussian-on-a-grid).

Protocol **1.9 → 1.10** (additive belief-spec).

## Verification
- `test/test_truncated_gaussian.jl` — prior mean/variance match a 200k-pt hand-quadrature (the
  64-pt midpoint grid is accurate); the bound **binds** (mean < the untruncated μ); conditioning
  pulls toward the observation but stays within `[lo,hi]`.
- `test_skin.py` `test_truncated_gaussian_prior` — create + condition + mean over the wire, no grid
  declared.
- `test_core` green; `check apps/` clean (180); header == const (1.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)