### PR TITLE
feat: sequential conditioning on a QuadraturePrevision (continuous latent, two observations)

### DIFF
--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -869,6 +869,32 @@ function expect(p::QuadraturePrevision, f::Function)
     sum(w[i] * f(p.grid[i]) for i in eachindex(w))
 end
 
+# Sequential conditioning on a quadrature posterior. The support is already fixed by the FIRST
+# (continuous → quadrature) condition; a further observation only reweights mass WITHIN that
+# support, so we multiply the new kernel's likelihood into the existing grid — no re-gridding.
+# This is what lets a continuous latent absorb MULTIPLE non-conjugate observations (e.g. a
+# Gaussian elicitation THEN a logistic reaction) and stay on the engine's one grid. Conjugate
+# latents never reach here — they update in closed form and stay parametric; quadrature is the
+# fallback, and once a latent is on a grid it stays on that grid for subsequent evidence.
+function condition(p::QuadraturePrevision, k::Kernel, observation)
+    logw = similar(p.log_weights)
+    for i in eachindex(p.grid)
+        ll = density(k, p.grid[i], observation)
+        !isnan(ll) || error("density returned NaN conditioning a QuadraturePrevision")
+        logw[i] = p.log_weights[i] + ll
+    end
+    QuadraturePrevision(copy(p.grid), logw)
+end
+
+# Marginal likelihood ∫ p(x)·P(obs|x) dx over the quadrature grid — the `condition` verb's
+# log_marginal for the SECOND (and later) observation. A direct quadrature on the existing grid,
+# mirroring `log_predictive(::TruncatedGaussianPrevision, …)`; the generic `Prevision` fallback
+# routes through `wrap_in_measure`, which a QuadraturePrevision (no carrier Space) has no method for.
+function log_predictive(p::QuadraturePrevision, k::Kernel, obs)
+    val = expect(p, h -> exp(density(k, h, obs)))
+    log(max(val, 1e-300))
+end
+
 # MixturePrevision: linearity of expectation.
 function expect(p::MixturePrevision, f::Function)
     lw = p.log_weights

--- a/test/test_quadrature_sequential_condition.jl
+++ b/test/test_quadrature_sequential_condition.jl
@@ -1,0 +1,106 @@
+# test_quadrature_sequential_condition.jl — a continuous latent that absorbs MULTIPLE non-conjugate
+# observations (antipattern disposal, Phase A). The utility `u_wrong` latent is a truncated Gaussian
+# that is FIRST conditioned by a Gaussian elicitation (`gaussian_known_var`, non-conjugate on the
+# truncated support → a QuadraturePrevision) and THEN by a continuous-τ logistic reaction. The
+# second condition therefore lands on a QuadraturePrevision, not the truncated prior. Narrative never
+# triggered this (BetaBernoulli is conjugate — each update stays a BetaPrevision); the utility fold is
+# the first consumer to condition a continuous latent twice non-conjugately. Asserts:
+#   (1) the second condition multiplies the new likelihood into the EXISTING grid (no re-gridding) —
+#       the engine result is bit-identical to a hand product over the same 64-pt grid;
+#   (2) the two-step posterior moments ≈ a dense independent hand-quadrature of the joint model
+#       (prior × elicitation-likelihood × continuous-τ reaction) — quadrature convergence;
+#   (3) conditioning ORDER is irrelevant (likelihoods commute) — elicit-then-react == react-then-elicit.
+#
+# Run from repo root:  julia test/test_quadrature_sequential_condition.jl
+
+push!(LOAD_PATH, "src")
+using Credence
+using Credence: TruncatedGaussianPrevision, condition, expect, mean, variance, Identity, Kernel,
+                Euclidean, Finite, PushOnly, QuadraturePrevision, LogisticReaction,
+                logistic_reaction_logdensity, log_predictive
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+approx(a, b; atol = 1e-9) = abs(a - b) <= atol
+
+println("="^64)
+println("QuadraturePrevision sequential conditioning — a continuous latent, two observations")
+println("="^64)
+
+# u_wrong ~ TruncatedNormal(-3, 4; [-10, 0]); the support encodes u(wrong) ≤ 0.
+prior_mu, prior_sigma, lo, hi = -3.0, 4.0, -10.0, 0.0
+p = TruncatedGaussianPrevision(prior_mu, prior_sigma, lo, hi)
+
+# Elicitation: gaussian_known_var(variance=4), stated value -8.
+noise_var, stated = 4.0, -8.0
+elicit = Kernel(Euclidean(1), Euclidean(1), μ -> error("ng"), (μ, o) -> -0.5 * (o - μ)^2 / noise_var;
+                likelihood_family = PushOnly())
+# Reaction: continuous-τ logistic, sign -1, threshold 0, τ ~ TruncatedNormal(1, 0.5; [0.5, 2]).
+fam = LogisticReaction(-1.0, 0.0, 1.0, 0.5, 0.5, 2.0)
+react = Kernel(Euclidean(1), Finite([0.0, 1.0]), x -> error("ng"),
+               (x, o) -> logistic_reaction_logdensity(fam, x, o); likelihood_family = fam)
+
+p1 = condition(p, elicit, stated)           # truncated → QuadraturePrevision
+check("first (elicitation) condition yields a QuadraturePrevision", p1 isa QuadraturePrevision,
+      string(typeof(p1)))
+p2 = condition(p1, react, 1.0)              # QuadraturePrevision → QuadraturePrevision (the new path)
+check("second (reaction) condition on a QuadraturePrevision yields a QuadraturePrevision",
+      p2 isa QuadraturePrevision, string(typeof(p2)))
+check("the second condition keeps the same grid (no re-gridding)", p2.grid == p1.grid,
+      "grid changed under a sequential condition")
+
+# the SECOND condition's log_marginal: log ∫ p1(x)·P(react|x) dx — the skin needs this on a
+# QuadraturePrevision (the generic fallback routes through wrap_in_measure, which it has no Space
+# for). Bit-exact to a hand quadrature over p1's grid.
+lp = log_predictive(p1, react, 1.0)
+w1 = exp.(p1.log_weights .- maximum(p1.log_weights)); w1 ./= sum(w1)
+hand_lp = log(sum(w1[i] * exp(logistic_reaction_logdensity(fam, p1.grid[i], 1.0))
+                  for i in eachindex(p1.grid)))
+check("second-condition log_predictive is bit-exact to a hand quadrature over the grid",
+      approx(lp, hand_lp; atol = 1e-12), "$lp vs $hand_lp")
+
+m2, v2 = mean(p2), variance(p2)
+
+# ── (1) bit-exact to a hand product over the engine's OWN 64-pt midpoint grid ──
+grid = p1.grid
+logw = [(-0.5 * ((x - prior_mu) / prior_sigma)^2) +              # truncated-normal prior kernel
+        (-0.5 * (stated - x)^2 / noise_var) +                    # gaussian elicitation
+        logistic_reaction_logdensity(fam, x, 1.0)                # continuous-τ reaction
+        for x in grid]
+wm = maximum(logw); w = exp.(logw .- wm); w ./= sum(w)
+hand_mean = sum(w[i] * grid[i] for i in eachindex(grid))
+hand_var = sum(w[i] * (grid[i] - hand_mean)^2 for i in eachindex(grid))
+check("two-step mean is bit-exact to a hand product over the SAME grid",
+      approx(m2, hand_mean; atol = 1e-12), "$m2 vs $hand_mean")
+check("two-step variance is bit-exact to a hand product over the SAME grid",
+      approx(v2, hand_var; atol = 1e-12), "$v2 vs $hand_var")
+
+# ── (2) ≈ a dense independent hand-quadrature of the joint model (convergence) ──
+xs = range(lo, hi, length = 40001)
+dlw = [(-0.5 * ((x - prior_mu) / prior_sigma)^2) + (-0.5 * (stated - x)^2 / noise_var) +
+       logistic_reaction_logdensity(fam, x, 1.0) for x in xs]
+dm = maximum(dlw); dw = exp.(dlw .- dm); dw ./= sum(dw)
+dense_mean = sum(dw[i] * xs[i] for i in eachindex(xs))
+dense_var = sum(dw[i] * (xs[i] - dense_mean)^2 for i in eachindex(xs))
+check("two-step mean ≈ dense independent quadrature (64-pt convergence)",
+      approx(m2, dense_mean; atol = 1e-2), "$m2 vs $dense_mean")
+check("two-step variance ≈ dense independent quadrature", approx(v2, dense_var; atol = 1e-2),
+      "$v2 vs $dense_var")
+
+# the evidence is informative: elicitation -8 + a reaction that fires for low x pulls the mean below
+# the prior mean and the elicitation respects the bound.
+check("evidence moves the mean below the prior mean", m2 < mean(p), "$m2 vs $(mean(p))")
+check("posterior stays within the support", lo <= m2 <= hi, string(m2))
+
+# ── (3) conditioning order is irrelevant — likelihoods commute on the shared grid ──
+q1 = condition(p, react, 1.0)               # react first (truncated → quadrature)
+q2 = condition(q1, elicit, stated)          # then elicit (quadrature → quadrature)
+check("order independence: react-then-elicit mean == elicit-then-react mean",
+      approx(mean(q2), m2; atol = 1e-12), "$(mean(q2)) vs $m2")
+check("order independence: react-then-elicit variance == elicit-then-react variance",
+      approx(variance(q2), v2; atol = 1e-12), "$(variance(q2)) vs $v2")
+
+println("="^64)
+println("ALL PASSED")
+println("="^64)


### PR DESCRIPTION
## What

Adds `condition(::QuadraturePrevision, ::Kernel, obs)` — the missing path for a **continuous latent that absorbs more than one non-conjugate observation**.

The first non-conjugate condition turns a `TruncatedGaussian`/`Gaussian` prior into a `QuadraturePrevision` (an engine grid + log-weights). There was no method to condition *that* again, so a second observation hit a `MethodError`. The utility fold is the first consumer to need it: `u_wrong` is conditioned by a Gaussian **elicitation** (`gaussian_known_var`, non-conjugate on the truncated support → quadrature) and **then** by a continuous-τ **logistic reaction**. Narrative never triggered it — `BetaBernoulli` is conjugate, so each update stays a parametric `BetaPrevision`.

## How

Standard sequential-quadrature update. The support is already fixed by the first condition, so a further observation only reweights mass *within* it: multiply the new kernel's likelihood into the existing grid, no re-gridding. Once a latent is on a grid it stays on that grid for subsequent evidence; conjugate latents never reach here (they update in closed form).

```julia
function condition(p::QuadraturePrevision, k::Kernel, observation)
    logw = similar(p.log_weights)
    for i in eachindex(p.grid)
        ll = density(k, p.grid[i], observation)
        !isnan(ll) || error("density returned NaN conditioning a QuadraturePrevision")
        logw[i] = p.log_weights[i] + ll
    end
    QuadraturePrevision(copy(p.grid), logw)
end
```

## Verification

`test/test_quadrature_sequential_condition.jl` asserts:
1. **Bit-exact (1e-12)** to a hand product over the engine's own 64-pt grid — the mechanism does exactly weight × likelihood at the fixed grid.
2. **≈ a dense independent 40k-pt quadrature** of the joint model `prior × elicitation × continuous-τ reaction` — quadrature convergence.
3. **Order independence** — react-then-elicit == elicit-then-react (likelihoods commute on the shared grid).

`test_truncated_gaussian`, `test_continuous_reaction`, `test_core` all still pass; `credence-lint check apps/` clean. **No protocol change** — `condition` is an existing verb; this only fills an internal dispatch gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)