### PR TITLE
Harden the perturbation consumption path (3 pre-existing findings)

### DIFF
--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -1472,8 +1472,11 @@ function handle_perturb_grammar(params)
     grammar = state.grammars[grammar_id]
 
     w = weights(state.belief)
+    # min_frequency is a posterior-weight threshold (weighted_frequency ≤ 1), so it must live in [0,1];
+    # the prior `2` was unsatisfiable and made every wire perturbation a no-op. Match the hosts' 0.01.
+    # (Finding 4, PR #160 adversarial review.)
     freq_table = analyse_posterior_subtrees(state.all_programs, w;
-        min_frequency=2, min_complexity=2)
+        min_frequency=0.01, min_complexity=2)
 
     new_grammar = perturb_grammar(grammar, freq_table, all_features)
     state.grammars[new_grammar.id] = new_grammar

--- a/src/program_space/perturbation.jl
+++ b/src/program_space/perturbation.jl
@@ -130,7 +130,12 @@ function _compression_payoff(table::SubprogramFrequencyTable)::Union{Tuple{Produ
     expr_c = expr_complexity(best_expr)
     net_payoff = n_sources * (expr_c - 1) - (1 + expr_c)
     net_payoff > 0 || return nothing
-    name = Symbol("NT_", hash(show_expr(best_expr)) % 10000)
+    # Full hash (not % 10000): the name must be injective on the subtree body. It identifies the rule
+    # for downstream `NonterminalRef` lookup, AND `perturb_grammar`'s idempotence guard recognises an
+    # already-abstracted subtree by name. A narrow modulus collides (birthday ~100 nonterminals),
+    # which would alias two distinct subtrees to one name (an ambiguous reference) and silently drop
+    # the second, genuinely-new compression at the guard. (Finding 2, PR #160 adversarial review.)
+    name = Symbol("NT_", hash(show_expr(best_expr)))
     (ProductionRule(name, best_expr), net_payoff)
 end
 
@@ -180,9 +185,9 @@ net_voc(net_payoff_symbols::Real, compute_cost::Real) =
     perturb_grammar(g, freq_table, available_features; compute_cost = 0.0) → Grammar
 
 Perturb a grammar by the single compression-class meta-action whose `net_voc` is greatest, applied iff
-`net_voc > 0`; otherwise a structural no-op (a fresh grammar id over the same feature_set + rules).
-The selection is a **deterministic argmax** — the `rand`-based op choice (the Invariant-1 breach this
-phase retires) is gone. `freq_table` is REQUIRED (the type system enforces posterior analysis before
+`net_voc > 0`; otherwise a structural no-op — the **input grammar returned unchanged (same id)**, so the
+downstream `add_programs_to_state!` dedup (keyed on `grammar.id`) re-adds nothing. The selection is a
+**deterministic argmax** — the `rand`-based op choice (the Invariant-1 breach Phase 5 retires) is gone. `freq_table` is REQUIRED (the type system enforces posterior analysis before
 nonterminal proposal). `available_features` is retained for signature stability (the deferred
 feature-discovery mechanism will consume it); Scope A does not read it.
 
@@ -194,12 +199,15 @@ successors in `docs/collapse-towers/master-plan.md`.
 function perturb_grammar(g::Grammar, freq_table::SubprogramFrequencyTable,
                           available_features::Set{Symbol};
                           compute_cost::Float64 = 0.0)::Grammar
-    noop() = Grammar(g.feature_set, g.rules, next_grammar_id())
+    # A structural no-op returns the INPUT grammar (same id) — not a fresh-id copy. Downstream,
+    # `add_programs_to_state!` deduplicates by `grammar.id`, so a fresh-id no-op would defeat the dedup
+    # and re-inject every program as a fresh Beta(1,1) duplicate (a silent posterior reset — A3). Same
+    # id ⇒ a no-op truly changes nothing. (Tested by test_perturb_consumption.jl.)
     candidate = _compression_payoff(freq_table)
-    isnothing(candidate) && return noop()                       # no compressing subtree
+    isnothing(candidate) && return g                            # no compressing subtree
     rule, net_payoff = candidate
-    rule.name in Set(r.name for r in g.rules) && return noop()  # already present
-    net_voc(net_payoff, compute_cost) > 0 || return noop()      # VOC gate (forward compute priced in)
+    rule.name in Set(r.name for r in g.rules) && return g       # already present
+    net_voc(net_payoff, compute_cost) > 0 || return g           # VOC gate (forward compute priced in)
     Grammar(g.feature_set, [g.rules; rule], next_grammar_id())
 end
 

--- a/test/test_email_agent.jl
+++ b/test/test_email_agent.jl
@@ -535,7 +535,7 @@ println()
 # ═══════════════════════════════════════
 
 println("=" ^ 60)
-println("TEST 12: execute_meta_action!(:perturb_grammar) adds components")
+println("TEST 12: execute_meta_action!(:perturb_grammar) is duplication-free (Finding 1)")
 println("=" ^ 60)
 
 let
@@ -576,7 +576,14 @@ let
     n_after = length(state.belief.components)
     n_grammars_after = length(state.grammars)
 
-    @assert n_grammars_after > n_grammars_before "Perturbation should add new grammars"
+    # The unconditioned seed posterior at depth 2 has no compressing subtree, so each grammar's
+    # perturbation is a deterministic no-op. Post-Finding-1 (PR #160 adversarial review), a no-op
+    # returns the SAME grammar id, so add_programs_to_state! deduplicates it away: NO new grammars, NO
+    # duplicate components, NO belief reset. Before the fix, every fresh-id no-op silently re-injected
+    # the whole program set as Beta(1,1) duplicates and reported it as progress.
+    @assert n_added == 0 "non-compressing posterior ⇒ clean no-op (no fresh-Beta duplicates — Finding 1)"
+    @assert n_grammars_after == n_grammars_before "a no-op perturbation adds no new grammar (same id)"
+    @assert n_after == n_before "a no-op perturbation adds no components (no duplication)"
     # Parallel arrays must remain aligned
     @assert length(state.metadata) == n_after
     @assert length(state.compiled_kernels) == n_after
@@ -584,7 +591,7 @@ let
 
     println("  Before: $n_before components, $n_grammars_before grammars")
     println("  After: $n_after components, $n_grammars_after grammars (+$n_added)")
-    println("PASSED: execute_meta_action! adds components and grammars, arrays aligned")
+    println("PASSED: execute_meta_action!(:perturb_grammar) is a clean no-op — arrays aligned, no duplication")
 end
 println()
 

--- a/test/test_perturb_consumption.jl
+++ b/test/test_perturb_consumption.jl
@@ -1,0 +1,99 @@
+# test_perturb_consumption.jl — the perturbation consumption path (hardening follow-up to
+# collapse-towers Phase 5; adversarial review of PR #160, Finding 1).
+#
+# A structural no-op `perturb_grammar` must return the grammar with its id UNCHANGED. The downstream
+# `add_programs_to_state!` deduplicates by `grammar.id`, so a no-op that mints a FRESH id defeats the
+# dedup and re-injects the entire program set as fresh Beta(1,1) duplicates — a silent posterior reset
+# (an unsanctioned belief modification, A3) reported as progress. The fix: no-op returns the input
+# grammar (same id), so a no-op truly changes nothing.
+#
+# Run from repo root:
+#     julia test/test_perturb_consumption.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: Grammar, ProductionRule, SubprogramFrequencyTable, ProgramExpr, Program,
+                AndExpr, GTExpr, LTExpr, ActionExpr, IfExpr,
+                perturb_grammar, analyse_posterior_subtrees, enumerate_programs, compile_kernel,
+                add_programs_to_state!, AgentState, weights, show_expr
+using Credence: TaggedBetaPrevision, BetaPrevision, MixturePrevision, CompiledKernel
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+
+empty_table() = SubprogramFrequencyTable(ProgramExpr[], Float64[], Vector{Int}[])
+
+# Build a minimal AgentState holding one grammar's enumerated programs (mirrors the host setup).
+function state_with_grammar(g::Grammar, depth::Int, action_space::Vector{Symbol})
+    programs = enumerate_programs(g, depth; action_space=action_space)
+    comps = TaggedBetaPrevision[]
+    lw = Float64[]
+    meta = Tuple{Int, Int}[]
+    ck = CompiledKernel[]
+    progs = Program[]
+    for (pi, p) in enumerate(programs)
+        push!(comps, TaggedBetaPrevision(pi, BetaPrevision(1.0, 1.0)))
+        push!(lw, -g.complexity * log(2) - p.complexity * log(2))
+        push!(meta, (g.id, pi))
+        push!(ck, compile_kernel(p, g, pi))
+        push!(progs, p)
+    end
+    AgentState(MixturePrevision(comps, lw), meta, ck, progs, Dict(g.id => g), depth)
+end
+
+println("="^64)
+println("perturbation consumption — no-op idempotence (Finding 1)")
+println("="^64)
+
+# ── (1) unit: a structural no-op preserves the grammar id (the precise fix) ──
+let
+    g = Grammar(Set([:red, :green]), ProductionRule[], 7)
+    noop = perturb_grammar(g, empty_table())
+    check("no-op preserves the grammar id (so dedup-by-id re-adds nothing)", noop.id == g.id,
+          "g.id=$(g.id) noop.id=$(noop.id)")
+    check("no-op preserves feature_set + rules", noop.feature_set == g.feature_set && isempty(noop.rules))
+
+    # net_payoff = 0 (n_sources=2, expr_c=3) is also a no-op and must preserve the id.
+    s = AndExpr(GTExpr(:red, 0.7), LTExpr(:green, 0.3))
+    progs = Program[Program(IfExpr(s, ActionExpr(:a), ActionExpr(:b)), 6, g.id) for _ in 1:2]
+    ft0 = analyse_posterior_subtrees(progs, fill(0.5, 2); min_frequency=0.0, min_complexity=2)
+    check("net_payoff≤0 no-op also preserves the id", perturb_grammar(g, ft0).id == g.id)
+end
+
+# ── (2) integration: a no-op perturbation re-adds ZERO programs (no duplication, no belief reset) ──
+let
+    g = Grammar(Set([:red, :green]), ProductionRule[], 1)
+    state = state_with_grammar(g, 2, Symbol[:a, :b])
+    n_before = length(state.belief.components)
+    @assert n_before > 0 "fixture must enumerate some programs"
+
+    noop_g = perturb_grammar(g, empty_table())
+    state.grammars[noop_g.id] = noop_g
+    n_added = add_programs_to_state!(state, noop_g, 2; action_space=Symbol[:a, :b])
+
+    check("no-op perturbation adds ZERO programs (dedup intact)", n_added == 0, "n_added=$n_added")
+    check("no-op leaves the component count unchanged (no fresh-Beta duplicates)",
+          length(state.belief.components) == n_before,
+          "before=$n_before after=$(length(state.belief.components))")
+end
+
+# ── (3) min_frequency threshold semantics (Finding 4): weighted_frequency is a sum of posterior
+# weights (≤ 1), so any threshold > 1 is unsatisfiable and silently empties the freq_table. The skin
+# server (handle_perturb_grammar) used min_frequency=2 — making every wire perturbation a no-op; the
+# hosts (and now the skin) use 0.01. ──
+let
+    s = AndExpr(GTExpr(:red, 0.7), LTExpr(:green, 0.3))
+    progs = Program[Program(IfExpr(s, ActionExpr(:a), ActionExpr(:b)), 6, 1) for _ in 1:4]
+    w = fill(0.25, 4)                                     # normalised posterior weights, sum = 1
+    ft_ok  = analyse_posterior_subtrees(progs, w; min_frequency = 0.01, min_complexity = 2)
+    ft_bad = analyse_posterior_subtrees(progs, w; min_frequency = 2.0,  min_complexity = 2)
+    check("min_frequency=0.01 finds the shared subtree", !isempty(ft_ok.subtrees),
+          "expected a non-empty table")
+    check("min_frequency=2 (>1) is unsatisfiable ⇒ empty table (the Finding-4 bug)",
+          isempty(ft_bad.subtrees), "a >1 weighted-frequency threshold cannot be met")
+end
+
+println("="^64)
+println("ALL CHECKS PASSED — perturbation consumption (no-op idempotence)")
+println("="^64)

--- a/test/test_voc_gate.jl
+++ b/test/test_voc_gate.jl
@@ -94,7 +94,7 @@ end
 # re-perturbing a grammar that already holds the compression does not re-add or clobber it. ──
 let
     ft, s = shared_subtree_table(4)                       # net_payoff = 4 > 0 ⇒ would propose a rule for s
-    collide = Symbol("NT_", hash(show_expr(s)) % 10000)   # the exact name propose_nonterminal generates
+    collide = Symbol("NT_", hash(show_expr(s)))           # the exact (full-hash) name propose_nonterminal generates
     existing_body = GTExpr(:red, 0.9)                     # a DIFFERENT body under that same name
     g = Grammar(Set([:red, :green]), [ProductionRule(collide, existing_body)], 1)
     got = perturb_grammar(g, ft; compute_cost = 0.0)


### PR DESCRIPTION
## Harden the perturbation consumption path — 3 pre-existing findings from the PR #160 review

Follow-up to the collapse-towers Phase 5 adversarial review. These are **pre-existing** program-space consumption-path bugs, independent of the `rand` retirement; the review surfaced them. Each fixed with TDD.

### Finding 1 — silent posterior reset (was rated CRITICAL)
A structural no-op `perturb_grammar` minted a **fresh** grammar id. `add_programs_to_state!` deduplicates by `grammar.id`, so a fresh-id no-op defeated the dedup and re-injected the **entire program set as fresh `Beta(1,1)` duplicates** — an unsanctioned belief reset (A3), reported as progress (`n_added > 0`). Verified pre-existing (the old `perturb_grammar` minted a fresh id on every branch), so it did not block PR #160; fixed here.

**Fix:** the no-op returns the input grammar (same id) → a no-op truly changes nothing.
**Tests:** new `test_perturb_consumption.jl` (unit: id preserved; integration: zero re-adds, stable component count). `test_email_agent` TEST 12 rewritten from the buggy fresh-id artifact (`n_grammars_after > before`) to the real-domain no-duplication guard.

### Finding 2 — silently dropped compression
`NT_` rule names used `hash(...) % 10000`, colliding after ~100 nonterminals. A collision aliases two distinct subtrees to one name (an ambiguous `NonterminalRef`), and `perturb_grammar`'s idempotence guard then silently drops the second, genuinely-new compression.

**Fix:** full hash — injective on the subtree body. Collision test updated.

### Finding 4 — skin perturb always no-ops
`handle_perturb_grammar` used `min_frequency=2`, but `weighted_frequency` is a sum of posterior weights (≤ 1), so the threshold was unsatisfiable → the `freq_table` was always empty → the wire `perturb_grammar` verb always no-op'd.

**Fix:** `0.01`, matching the hosts. Unit test pins the threshold semantics (a `>1` weighted-frequency threshold is unsatisfiable).

### Scoped out (named, not fixed here)
A deeper **cross-grammar duplication** — a *real* compression also mints a fresh id and re-adds the base programs as copies under it — is a separate BMA modelling question, **not** the same bug: those copies carry a distinct (higher-complexity) prior and are down-weighted, unlike the no-op's exact-duplicate reset. Flagged for a separate investigation.

### Verification
Julia **44/44** green (incl. new `test_perturb_consumption.jl`) · lint corpus + `check apps/` clean · skin wire smoke · Python **587 passed, 8 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
