### PR TITLE
measure-as-view Phase 1: expect goes Prevision-primary for scalar families (+ fix latent Gauss-Jacobi α+β=1 hang)

### DIFF
--- a/docs/measure-as-view/DESIGN-DOC-TEMPLATE.md
+++ b/docs/measure-as-view/DESIGN-DOC-TEMPLATE.md
@@ -1,0 +1,83 @@
+# Phase-N design doc template (collapse-towers)
+
+Every `docs/collapse-towers/phase-N-design.md` uses this structure. Reviewers reject design docs that omit the "Open design questions" section, or that fill it with questions whose answer is obvious from this branch's master plan or from the code.
+
+The template exists because design-doc-before-code earns its keep only if the docs surface real arguments rather than restating the implementation prose. If a section feels like sugar around an already-decided implementation, treat that as a signal that the move is either smaller than it looked or already done — not a signal to ship the design doc.
+
+See `docs/precedents.md` — the canonical reference file for recurring patterns and precedent slugs; consult before drafting §5 Open design questions and §6 Risk + mitigation, where most precedents apply. This arc's master plan is `docs/collapse-towers/master-plan.md`.
+
+---
+
+## 1. Purpose
+
+One paragraph. What this move accomplishes; what foundational need it serves; what unblocks once it's in.
+
+Avoid restating the master plan's framing. Reference it instead: "Move N as scoped in the master plan, with the following additions/refinements …"
+
+## 2. Files touched
+
+Exhaustive list. For each file, give:
+- Path and line range (e.g. `src/ontology.jl:561-654`).
+- One-line description of what changes.
+- Whether this is a new file, a modification, or a deletion.
+
+If the move adds a new test file, list it here too.
+
+## 3. Behaviour preserved
+
+What the strata-1, strata-2, and strata-3 tests will assert about pre-/post-refactor equivalence. State the tolerance for each assertion class explicitly:
+
+- Strata-1 (unit equivalence): `isapprox(atol=1e-14)`.
+- Strata-2 conjugate paths: `isapprox(rtol=1e-12)`.
+- Strata-2 particle paths under deterministic seeding: `isapprox(rtol=1e-12)`.
+- Strata-3 end-to-end: `isapprox(rtol=1e-10)` — halt-the-line at greater drift.
+
+If this move legitimately needs looser tolerance for a particular test (e.g. parallelism that didn't exist before reorders particle samples), name the test, the relaxation, and the justification.
+
+## 4. Worked end-to-end example
+
+Trace one representative call through the new dispatch, naming which module owns each step. Pick a call that exercises the move's centrepiece — e.g. a `condition` through the new conjugate registry, an `expect` through the new TestFunction dispatch.
+
+**This section is mandatory** for any move that introduces or extends dual residency (a type, value, or hook present in both an old home and a new home — e.g. Move 5's `FiringByTag` relocation, where the value lives on the kernel side for construction but the routing semantics live on the prevision side). Without the worked example, the design doc fails review.
+
+The worked example should:
+- Pick concrete inputs (e.g. `BetaPrevision(2.0, 3.0)`, `obs = 1`).
+- Trace the full call chain step by step, showing which module/function owns each step.
+- State the result, with the arithmetic that produces it.
+- If dual residency is present, name which home is authoritative at each step.
+
+## 5. Open design questions
+
+1-3 specific points where Claude Code is expected to argue back during review of this design doc. Empty or boilerplate is grounds for revision.
+
+Legitimate question shapes:
+- **Sibling vs derived:** "should X be a sibling primitive or a derived form?"
+- **Option choice:** "we pick (a) cleaner separation or (b) more uniform dispatch?"
+- **Category check:** "is this category-different from the type it would inherit from?"
+- **Scope question:** "should we fold Y into this move or defer to Move N+1?"
+- **Invariant tradeoff:** "preserving X breaks Y; which do we keep?"
+
+Questions whose answer is obvious from the master plan or the code are not real open questions. Surface them as resolved decisions in §1 or §3 instead.
+
+If genuinely no design questions remain — e.g. the move is mechanical type-aliasing — say so explicitly: "No open design questions for this move. The implementation is determined by the master plan; reviewers are invited to challenge that claim."
+
+## 6. Risk + mitigation
+
+What could go wrong; what test catches it.
+
+For each risk, give:
+- The failure mode (e.g. "particle filtering silently reorders samples after the constructor refactor").
+- The blast radius (which test files / which downstream moves break).
+- The mitigation (e.g. "Strata-2 particle test pinned to seeded RNG with 1e-12 tolerance; pre-refactor sample sequence captured in `test/fixtures/particle_seed_42_v1.jls` and asserted byte-equal post-refactor").
+
+Risks the master plan named for this move are repeated here with current-state additions.
+
+**Suggested practice for moves that refactor consumer-visible types:** include a pre-emptive grep step under the relevant risk entry. Run `grep -rn '<pattern>'` across `src/`, `test/`, `apps/`, `docs/`; list each hit and its disposition (mechanical replacement / no edit needed / needs attention). Example: Move 2's grep for `<: Functional`, `isa Functional`, `::Functional` when aliasing the `Functional` hierarchy onto `TestFunction`. Not mandatory — not every risk benefits from a grep — but the default is: if you're renaming or aliasing a type that appears in method signatures or runtime checks, grep for it before the PR opens. Moves that don't touch consumer-visible types (e.g. cosmetic adaptations) don't need the grep.
+
+## 7. Verification cadence
+
+Which test files run at end of the corresponding code PR. Cite the bash invocations explicitly so reviewers can reproduce.
+
+For Moves 3, 4, 6, 7 this section must include the skin smoke test (`python -m skin.test_skin`) — those moves change what crosses the JSON-RPC boundary. For Moves 1, 2, 5, 8 the skin smoke test is optional.
+
+Halt-the-line conditions: any test failure at end-of-PR is a halt. No "will fix in next commit" states; the branch never sleeps with a red suite.

--- a/docs/measure-as-view/master-plan.md
+++ b/docs/measure-as-view/master-plan.md
@@ -1,0 +1,102 @@
+# Credence — Core-library engine arc: *measure-as-view* (master plan)
+
+> Durable, in-repo master plan for the `measure-as-view` branch family. A thematic engine arc
+> (unnumbered, like `collapse-towers` and `decouple`), opened 2026-06-27 *after* collapse-towers
+> closed. Each phase lands design-doc-before-code (template at
+> `docs/measure-as-view/DESIGN-DOC-TEMPLATE.md`), each commit green + bisectable, **stop-and-report
+> at every phase boundary.** Origin: the duplication audit triggered during collapse-towers Phase 2,
+> recorded in `docs/collapse-towers/master-plan.md` ("Follow-on arc"), now promoted to its own arc.
+
+## Context — the engine drifts from "Measure is a declared view over Prevision"
+
+The constitution makes Prevision the frozen primitive and **Measure a declared view over it**
+(precedent `prevision-not-measure`; "Measure binds carrier space, Prevision doesn't"). All 11 Measure
+facades hold a `.prevision`, so the ideal is: Measure methods are thin facades delegating to
+Prevision-primary logic. Three classes of drift violate that ideal today:
+
+1. **Backwards delegation (Prevision → Measure, inverting the constitution).** The non-conjugate
+   fallbacks of `condition`/`_predictive_ll`/`log_predictive` for the scalar conjugate families and
+   `Product` delegate *up* to the Measure facade: `condition(wrap_in_measure(p), k, obs)` at
+   `ontology.jl:1159` (Beta), `:1297`/`:1318` (Gaussian), `:1341` (Gamma); `_predictive_ll(wrap_in_measure(p),…)`
+   at `:1585`/`:1601`/`:1604`/`:1607` and `log_predictive` at `:1618`. The constitutionally-primary
+   object reaches its own behaviour by round-tripping through its view.
+
+2. **A latent CORRECTNESS bug (highest priority) — the primary path is *less accurate* than its view.
+   BETA-ONLY (grounding corrected the memory note's overstatement).** `expect(m::BetaMeasure,
+   f::Function)` uses **Gauss-Jacobi quadrature** (`ontology.jl:553`, exact for polynomials up to
+   degree 2n−1, ~1e-13). `expect(p::BetaPrevision, f::Function)` uses the **old uniform-grid Riemann
+   sum** (`ontology.jl:821`, O(1/n²), ~1e-4) — the very sum the Measure path's comment says it
+   "replaces." **Verified live (2026-06-27):** under Beta(2,5), `E[x³]` is exact `0.0476190476` on the
+   Measure path but `0.0476045236` (Δ=1.45e-5) on the Prevision path; `sqrt`/`sin(3x)` diverge
+   ~1.4–2.0e-4. **Gaussian and Gamma show NO asymmetry** — `expect(::GaussianMeasure,…)` (`:627`) and
+   `expect(::GammaMeasure,…)` (`:638`) use the *same* uniform grid as their Previsions (`:832`/`:843`),
+   so primary and view **agree exactly** (verified Δ=0.0); they are equally inferior, but that is a
+   *shared-inaccuracy* enhancement (add Gauss-Hermite/Gauss-Laguerre), NOT a primary-vs-view
+   constitutional bug. The asymmetry (only structured-Functional paths — `Identity`, `CenteredPower`,
+   `GeometricTail` — are closed-form and agree on both sides; only the **generic-closure fallback**, the
+   path a DSL `lambda` takes, diverges) is **Beta-specific**.
+
+3. **Full structural duplication of the mixture methods.** Mixture `condition`/`prune`/`truncate`/`draw`
+   are verbatim `MixtureMeasure ↔ MixturePrevision` twins. (collapse-towers Phase 2 *attempted* the
+   `condition(MixtureMeasure)`→facade collapse and **reverted** it: a naive facade drops per-component
+   carrier-space context and changes the consumer-visible component type, breaking `wrap_in_measure`/
+   consumer code. The dedup is real but must thread the carrier space.)
+
+## The load-bearing constraint (surfaced by Phase 2)
+
+**Measure binds carrier space; Prevision does not.** Any Measure→Prevision delegation must thread the
+space where the operation needs it. This splits the arc cleanly:
+- **`expect` does NOT use carrier space** (it integrates `f` over the distribution) → inverting its
+  delegation is *safe* and is the natural home of the correctness fix. **This is Phase 1.**
+- **`condition` DOES bind carrier space** (the posterior lives on a declared carrier) → inverting its
+  delegation must thread the space. **Later phases.**
+
+## Phases (design-doc-before-code each; stop-and-report at every boundary)
+
+### Phase 1 — Invert `expect` delegation for the scalar families (fixes the Beta correctness bug)
+Make the **Prevision the primary** for generic-closure `expect` and the Measure facade delegate
+(`expect(m::BetaMeasure, f) → expect(m.prevision, f)`, ditto Gaussian/Gamma). Two outcomes by family:
+- **Beta — fixes item 2.** Relocate the Gauss-Jacobi quadrature (a shared `_gauss_jacobi_expect`
+  helper) to be `expect(p::BetaPrevision, f)`-primary; the Measure path delegates to it. The Prevision
+  generic-closure path gets *more accurate* (the intended, one-directional behaviour change); the
+  Measure path is **bit-preserved** (it routes through the same Gauss-Jacobi it already used).
+- **Gaussian/Gamma — structural inversion only, no behaviour change.** Both sides already use the same
+  uniform grid, so the Measure facade simply delegates to the (identical) Prevision grid — Prevision-
+  primary, **bit-identical** both sides. The accuracy upgrade (Gauss-Hermite / Gauss-Laguerre for the
+  generic-closure path) is a **separate, deferred enhancement** — it adds new quadrature, it is not the
+  primary-vs-view fix, and Phase 1 does not bundle it.
+
+See `phase-1-design.md`. (Open question there: unify at the Measure's Gauss-Jacobi `n=32` so the Beta
+Measure path is bit-preserved, vs the Prevision's old `n=64`.)
+
+### Phase 2 — Invert `condition`/`_predictive_ll` delegation (carrier-space-threading)
+Move the non-conjugate `condition`/`_predictive_ll`/`log_predictive` fallbacks for Beta/Gaussian/Gamma/
+Product to Prevision-primary, threading the carrier space where the posterior needs it; the Measure
+facades become thin delegating views. Capture-before-refactor: posteriors pinned `==` pre-refactor.
+
+### Phase 3 — Collapse the duplicated mixture twins (`condition`/`prune`/`truncate`/`draw`)
+The Phase-2-of-collapse-towers deferral. Thread the per-component carrier space so the
+`MixtureMeasure` facade can delegate to `MixturePrevision` without dropping space context or changing
+the consumer-visible component type. Capture-before-refactor against `test_flat_mixture`/`test_host`/
+`test_core` TEST 53 (the tests the naive facade broke).
+
+## Hard constraints (inherited)
+Spec-first; design-doc-before-code; stop-and-report at every phase boundary; **no new constitutional
+text**; no silent fallbacks; tolerance inside the boolean; no `using Test`; **capture-before-refactor**
+on every behaviour-preserving move (canonical values pinned PRE-refactor, asserted `==`). The
+correctness fix (Phase 1) is the one *intended* behaviour change — captured as an explicit
+before/after, not a silent drift.
+
+## Verification (per phase, from repo root; Julia tests not CI-gated)
+- Phase 1: `julia test/test_measure_view_expect.jl && julia test/test_core.jl && julia test/test_prevision_unit.jl`
+- Each boundary: full `test/test_*.jl` suite green; lint corpus + `check apps/`; skin smoke (Phases 2/3
+  touch `condition`, the wire-relevant path); stop and report.
+
+## Key risks
+1. **Phase 1 `n`-default drift.** The Measure path uses Gauss-Jacobi `n=32`; the Prevision path used a
+   uniform grid `n=64`. Unify at the Measure's `n=32` so the Measure path is **bit-preserved** (the
+   correct reference); the Prevision path changes (the fix). Decide in the design doc.
+2. **Phase 2/3 carrier-space loss.** The naive facade dropped space context (Phase-2 collapse-towers
+   evidence). Every delegation threads the space; capture-before-refactor guards it.
+3. **Generic-closure vs structured-Functional.** Only the generic-closure path is wrong; structured
+   Functionals agree exactly. Tests must cover the generic-closure path specifically.

--- a/docs/measure-as-view/phase-1-design.md
+++ b/docs/measure-as-view/phase-1-design.md
@@ -1,0 +1,136 @@
+# Phase 1 design doc — Invert `expect` delegation for the scalar families (fix the Beta correctness bug)
+
+> Seven-section template (`docs/measure-as-view/DESIGN-DOC-TEMPLATE.md`). Master plan:
+> `docs/measure-as-view/master-plan.md`. Precedents: `docs/precedents.md`.
+
+## 1. Purpose
+
+Phase 1 as scoped in the master plan: make the **Prevision the primary** for generic-closure `expect`
+on the scalar conjugate families and reduce the Measure to a thin delegating view, restoring the
+constitutional direction (`prevision-not-measure`). The move is carrier-space-safe *because* `expect`
+integrates `f` over the distribution and never reads the carrier — unlike `condition` (deferred to
+Phase 2). Two outcomes, by family:
+
+- **Beta — the correctness fix.** Today `expect(m::BetaMeasure, f::Function)` uses Gauss-Jacobi
+  quadrature (`ontology.jl:553`, ~1e-13) while `expect(p::BetaPrevision, f::Function)` uses an inferior
+  uniform grid (`ontology.jl:821`, ~1e-4) — so the **primary path is silently less accurate than its
+  view** (verified: Beta(2,5) `E[x³]` exact `0.0476190476` on the Measure path, `0.0476045236` on the
+  Prevision path). Relocating Gauss-Jacobi to be Prevision-primary fixes it: the Prevision path becomes
+  accurate (the intended, one-directional change); the Measure path is bit-preserved.
+- **Gaussian/Gamma — structural inversion only, zero behaviour change.** Both sides already share the
+  *same* uniform grid (`:627`==`:832`, `:638`==`:843`; verified Δ=0.0), so the Measure facade simply
+  delegates to the identical Prevision grid — Prevision-primary, bit-identical. The Gauss-Hermite /
+  Gauss-Laguerre accuracy upgrade for their shared grid is a **separate deferred enhancement**, NOT
+  bundled here (it adds new quadrature; it is not the primary-vs-view fix).
+
+## 2. Files touched
+
+- **`src/ontology.jl`** — *modify*:
+  - **Extract** `_gauss_jacobi_expect(alpha::Float64, beta::Float64, f, n::Int)::Float64` from the body
+    of `expect(m::BetaMeasure, f::Function)` (`:553`–`:625`, the hand-rolled Golub–Welsch rule). No
+    arithmetic change — a pure extraction.
+  - `expect(p::BetaPrevision, f::Function; n::Int = 32)` — **replace** the uniform-grid body (`:821`)
+    with `_gauss_jacobi_expect(p.alpha, p.beta, f, n)`. (Default `n` 64→32; see §5.)
+  - `expect(m::BetaMeasure, f::Function; n::Int = 32)` — **replace** the Gauss-Jacobi body with the
+    delegation `expect(m.prevision, f; n = n)`. `m.prevision::BetaPrevision` (accessor at `:174`).
+  - `expect(m::GaussianMeasure, f::Function; n::Int = 64) = expect(m.prevision, f; n = n)` — delegate
+    (was the identical grid at `:627`). `expect(p::GaussianPrevision, …)` (`:832`) is unchanged (now the
+    primary).
+  - `expect(m::GammaMeasure, f::Function; n::Int = 64) = expect(m.prevision, f; n = n)` — delegate (was
+    the identical grid at `:638`). `expect(p::GammaPrevision, …)` (`:843`) unchanged (now primary).
+  - The `TaggedBetaMeasure`/`TaggedBetaPrevision` generic-`f` methods (`:625`/`:830`) already delegate to
+    the inner beta — **no change**; they inherit the fix.
+- **`test/test_measure_view_expect.jl`** — *new* (see §7).
+
+No new exports, no signature changes visible to consumers (the `n` kwargs keep defaults). `condition`,
+`_predictive_ll`, the structured-Functional `expect` methods — **untouched** (Phase 2+).
+
+## 3. Behaviour preserved
+
+- **Beta Measure path — bit-preserved.** `expect(m::BetaMeasure, f; n=32)` delegates to
+  `expect(m.prevision, f; n=32)`, which is `_gauss_jacobi_expect(α, β, f, 32)` — the *same* rule, same
+  `n`, the body extracted verbatim. Strata-1 equivalence: `==` against pre-refactor captured values.
+- **Gaussian/Gamma — bit-identical both sides.** The Measure body was character-identical to the
+  Prevision body (modulo `m.`/`p.` field access); delegation routes the Measure through the Prevision
+  grid. Strata-1: `expect(p, f) == expect(wrap_in_measure(p), f)` holds at `Δ=0.0` (already true; stays).
+- **Structured Functionals unchanged.** `Identity`/`CenteredPower`/`GeometricTail`/`LinearCombination`
+  paths are not touched; their closed forms already agree on both sides.
+- **The intended change (NOT preserved, by design):** `expect(p::BetaPrevision, f::Function)` moves
+  from uniform-grid (~1e-4) to Gauss-Jacobi (~1e-13). Captured as an explicit before/after, not silent.
+
+## 4. Worked end-to-end example
+
+`expect(p, f)` with `p = BetaPrevision(2.0, 5.0)`, `f = x -> x^3`:
+- **Before:** `expect(p, f)` → uniform-grid body (`:821`): 64-point midpoint grid, Riemann weights →
+  `0.0476045236` (Δ=1.45e-5 from the exact `24/504 = 0.047619047…`).
+- **After:** `expect(p, f)` → `_gauss_jacobi_expect(2.0, 5.0, f, 32)` *(owner: the extracted helper)* →
+  the 32-node Gauss-Jacobi rule integrates the degree-3 polynomial **exactly** → `0.0476190476`.
+- **Measure view, after:** `expect(wrap_in_measure(p), f)` → `expect(m::BetaMeasure, f; n=32)` →
+  delegates → `expect(m.prevision, f; n=32)` → same `_gauss_jacobi_expect(2.0, 5.0, f, 32)` →
+  `0.0476190476`. Primary and view now **agree, and both are exact**.
+- Dual residency: the Gauss-Jacobi rule had a single home (Measure); Phase 1 moves that home to the
+  Prevision and makes the Measure a one-line delegation — net dual-residency *decreases*.
+
+## 5. Open design questions
+
+1. **Beta Prevision default `n`: 32 (recommended) vs 64?** The Measure path uses `n=32`; to
+   **bit-preserve** it under delegation, the unified default must be `32`. Gauss-Jacobi `n=32` is exact
+   for polynomials up to degree 63 — strictly better than the old uniform `n=64` for every `f` — so
+   dropping the Prevision default from 64 to 32 loses nothing and keeps the Measure reference intact.
+   Recommend **32**. (Alternative: unify at 64 and re-capture the Measure reference — rejected, it
+   perturbs a correct path to no benefit.)
+2. **Scope: does Phase 1 also upgrade Gaussian/Gamma to Gauss-Hermite/Laguerre?** Recommend **no** —
+   keep Phase 1 to the *primary-vs-view* fix (Beta) plus the *zero-behaviour-change* structural
+   inversion (Gaussian/Gamma). Their shared grid inaccuracy is real but symmetric (no constitutional
+   violation), and adding Hermite/Laguerre is new numerics that deserves its own move with its own
+   exactness tests. Fold it in only if you'd rather not leave a known ~1e-4 on those generic-closure
+   paths.
+3. **Is `expect` truly carrier-space-free for these Measures?** The premise of the safe inversion. The
+   bodies read only `α,β` / `μ,σ` — never `m.space`. Confirm by grep (§6); if any scalar `expect` reads
+   the carrier, that family stays Measure-primary and is flagged.
+
+## 6. Risk + mitigation
+
+- **A caller passes `n` to `expect(BetaPrevision, …)` and relies on `n=64`.** *Pre-emptive grep:*
+  `grep -rn 'expect(.*; *n *=' src/ apps/ test/` and `grep -rn 'expect(.*BetaPrevision' …` — list each
+  hit's disposition. The kwarg default change only affects callers that *omit* `n` (they get the more
+  accurate rule); explicit `n=…` callers are unaffected.
+- **`m.prevision` does not round-trip the Measure's parameters exactly.** *Failure mode:*
+  `expect(m::GaussianMeasure, f)` delegating to `m.prevision` would change the value if
+  `m.prevision` reconstructs `μ,σ` lossily. *Mitigation:* the accessors are field reads
+  (`:237`/`:322`); a test asserts `expect(wrap_in_measure(p), f) == expect(p, f)` for Gaussian/Gamma
+  (Δ=0.0) post-refactor, and the Beta Measure path `==` its captured pre-refactor value.
+- **Capture-before-refactor.** Pin, PRE-refactor: (a) `expect(BetaMeasure(α,β), f)` for a grid of
+  `(α,β)` × generic `f` (the Gauss-Jacobi reference, to assert the Measure path is bit-preserved); (b)
+  the *old* `expect(BetaPrevision, f)` uniform-grid values (to assert the Prevision path *changed* and
+  moved *toward* the exact closed form). Both captured as literals in the test.
+- **Pre-emptive grep for carrier-space reads:** `grep -n 'm.space' ontology.jl` within the scalar
+  `expect` bodies — expected empty; if not, that family is excluded from the inversion.
+
+## 7. Verification cadence
+
+End of Phase-1 code (from repo root):
+```
+julia test/test_measure_view_expect.jl
+julia test/test_core.jl
+julia test/test_prevision_unit.jl
+julia test/test_centered_moment.jl
+```
+Then the full `test/test_*.jl` suite + lint corpus self-test + `check apps/`, and **stop and report**.
+Skin smoke is **optional** for Phase 1 (`expect` is not the wire-crossing path; `condition` is — that
+is Phase 2).
+
+`test_measure_view_expect.jl` (repo `check(name, cond, detail)` idiom):
+- **Beta correctness (the fix):** for `(α,β) ∈ {(2,5),(0.5,0.5),(3,3)}` and `f ∈ {x³, √x, sin 3x}`,
+  `expect(BetaPrevision(α,β), f) ≈ expect(wrap_in_measure(p), f)` to `rtol=1e-12` (both Gauss-Jacobi
+  now), AND for the polynomial `f=x^k` the value equals the **exact** closed form
+  `∏_{i=0}^{k-1}(α+i)/(α+β+i)` to `rtol=1e-12` (the strongest property — the old uniform grid failed
+  this at ~1e-4).
+- **Beta Measure bit-preservation:** `expect(BetaMeasure(α,β), f; n=32)` `==` the captured pre-refactor
+  literal (Gauss-Jacobi unchanged).
+- **Gaussian/Gamma structural inversion:** `expect(p, f) == expect(wrap_in_measure(p), f)` (Δ=0.0) for
+  Gaussian/Gamma — bit-identical, primary and view, pre- and post-refactor.
+- **TaggedBeta inherits the fix:** `expect(TaggedBetaPrevision(tag, Beta(α,β)), f)` matches the exact
+  closed form (it routes through the fixed BetaPrevision path).
+
+Halt-the-line: any failure at end-of-PR is a halt; the branch never sleeps red.

--- a/docs/measure-as-view/phase-1-design.md
+++ b/docs/measure-as-view/phase-1-design.md
@@ -85,9 +85,14 @@ No new exports, no signature changes visible to consumers (the `n` kwargs keep d
    violation), and adding Hermite/Laguerre is new numerics that deserves its own move with its own
    exactness tests. Fold it in only if you'd rather not leave a known ~1e-4 on those generic-closure
    paths.
-3. **Is `expect` truly carrier-space-free for these Measures?** The premise of the safe inversion. The
-   bodies read only `α,β` / `μ,σ` — never `m.space`. Confirm by grep (§6); if any scalar `expect` reads
-   the carrier, that family stays Measure-primary and is flagged.
+3. **Is `expect` truly carrier-space-free for these Measures? — VERIFIED (family-specific, not
+   blanket).** The Beta/Gaussian/Gamma `expect` bodies (`:553`/`:627`/`:638`) and the Prevision bodies
+   (`:821`–`:854`) read only `α,β` / `μ,σ` — **never `m.space`** (grepped). So the inversion is safe for
+   exactly these three. **Counterexample worth recording:** `expect(m::CategoricalMeasure, f)` (`:550`)
+   *does* read `m.space.values[i]` — a discrete family is carrier-*bound* (the carrier IS the support).
+   So "`expect` is carrier-space-free" is a property of the *continuous scalar* families, not of `expect`
+   in general; Categorical is correctly outside Phase 1, and any future inversion of a discrete family's
+   `expect` must thread the space (the Phase-2/3 discipline, one move early).
 
 ## 6. Risk + mitigation
 

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -550,7 +550,11 @@ function expect(m::CategoricalMeasure, f::Function)
     sum(w[i] * f(m.space.values[i]) for i in eachindex(w))
 end
 
-function expect(m::BetaMeasure, f::Function; n::Int=32)
+# Gauss-Jacobi quadrature (Golub-Welsch) for E_{Beta(alpha,beta)}[f] with n nodes. The SINGLE home of
+# the rule (measure-as-view Phase 1 relocated it here from the BetaMeasure method, verbatim): the
+# Prevision is its primary caller, the BetaMeasure view delegates. Exact for polynomials up to degree
+# 2n−1; residual ~1e-13. Tested by test/test_measure_view_expect.jl.
+function _gauss_jacobi_expect(alpha::Float64, beta::Float64, f, n::Int)
     # ── Gauss-Jacobi quadrature, hand-rolled via Golub-Welsch ─────────
     #
     # Replaces a uniform-grid Riemann sum (O(1/n²) error) that left
@@ -604,15 +608,22 @@ function expect(m::BetaMeasure, f::Function; n::Int=32)
     # necessity — the cost difference is roughly ~1000 vs ~3000 ops on
     # a tridiagonal eigendecomposition, both negligible compared to
     # BDSL evaluation overhead.
-    a = m.beta - 1.0
-    b = m.alpha - 1.0
+    a = beta - 1.0
+    b = alpha - 1.0
     diag = Vector{Float64}(undef, n)
     offdiag = Vector{Float64}(undef, n - 1)
     diag[1] = (b - a) / (a + b + 2)
     for k in 1:n-1
         s = 2k + a + b
         diag[k + 1] = (b * b - a * a) / (s * (s + 2))
-        β_k = 4 * k * (k + a) * (k + b) * (k + a + b) / (s * s * ((s * s) - 1))
+        # The k=1 off-diagonal carries a removable (1+a+b) factor: the raw form is 0/0 at
+        # a+b=−1 (Beta α+β=1, e.g. the arcsine Beta(0.5,0.5)) → NaN, on which LAPACK's MRRR
+        # eigensolver infinite-loops. Use the analytically-cancelled k=1 form — bit-identical
+        # to the raw form away from the singularity (Beta(2,5)/(3,3) are pinned), finite and
+        # exact on it. Verified by test/test_measure_view_expect.jl (the α+β=1 regression guard).
+        β_k = k == 1 ?
+            4 * (1 + a) * (1 + b) / ((a + b + 2)^2 * (a + b + 3)) :
+            4 * k * (k + a) * (k + b) * (k + a + b) / (s * s * ((s * s) - 1))
         offdiag[k] = sqrt(β_k)
     end
     F = eigen(SymTridiagonal(diag, offdiag))
@@ -622,31 +633,23 @@ function expect(m::BetaMeasure, f::Function; n::Int=32)
     sum(w[i] * f((1.0 + nodes[i]) / 2) for i in eachindex(w)) / s_w
 end
 
+# BetaMeasure is a declared view over BetaPrevision: delegate generic-closure expect to the Prevision
+# (Gauss-Jacobi primary). Bit-preserved vs the old inline method — same rule, same default n=32.
+# `expect` is carrier-space-free, so the inversion is safe. [measure-as-view Phase 1]
+expect(m::BetaMeasure, f::Function; n::Int=32) = expect(m.prevision, f; n=n)
+
 expect(m::TaggedBetaMeasure, f::Function; kwargs...) = expect(m.beta, f; kwargs...)
 
-function expect(m::GaussianMeasure, f::Function; n::Int=64)
-    lo = m.mu - 4 * m.sigma
-    hi = m.mu + 4 * m.sigma
-    grid = range(lo, hi, length=n)
-    logw = [-0.5 * ((x - m.mu) / m.sigma)^2 for x in grid]
-    max_lw = maximum(logw)
-    w = exp.(logw .- max_lw)
-    w ./= sum(w)
-    sum(w[i] * f(grid[i]) for i in eachindex(w))
-end
+# GaussianMeasure is a view: delegate to the (identical-grid) GaussianPrevision. Bit-identical — both
+# sides computed `logw` from the same expression. The Gauss-Hermite accuracy upgrade for this shared
+# uniform grid is a deferred move. [measure-as-view Phase 1 — structural inversion, zero behaviour change]
+expect(m::GaussianMeasure, f::Function; n::Int=64) = expect(m.prevision, f; n=n)
 
-function expect(m::GammaMeasure, f::Function; n::Int=64)
-    μ = m.alpha / m.beta
-    σ = sqrt(m.alpha) / m.beta
-    lo = max(1e-10, μ - 4σ)
-    hi = μ + 6σ
-    grid = range(lo, hi, length=n)
-    logw = [log_density_at(m, x) for x in grid]
-    max_lw = maximum(logw)
-    w = exp.(logw .- max_lw)
-    w ./= sum(w)
-    sum(w[i] * f(grid[i]) for i in eachindex(w))
-end
+# GammaMeasure is a view: delegate to the (identical-grid) GammaPrevision. Bit-identical — the Gamma
+# Prevision inlines the same bare kernel `(α−1)log x − βx` that `log_density_at(::GammaMeasure)`
+# evaluates (same ops, same order), so no last-ULP non-cancellation. The Gauss-Laguerre accuracy
+# upgrade is a deferred move. [measure-as-view Phase 1 — structural inversion, zero behaviour change]
+expect(m::GammaMeasure, f::Function; n::Int=64) = expect(m.prevision, f; n=n)
 
 function expect(m::DirichletMeasure, f::Function; n_samples::Int=1000)
     total = 0.0
@@ -818,14 +821,12 @@ expect(p::DirichletPrevision, ::Identity) = p.alpha ./ sum(p.alpha)
 expect(p::NormalGammaPrevision, ::Identity) = p.μ
 
 # General-function expect on scalar Previsions via quadrature/delegation.
-function expect(p::BetaPrevision, f::Function; n::Int=64)
-    grid = range(1/(2n), 1-1/(2n), length=n)
-    logw = [(p.alpha - 1) * log(x) + (p.beta - 1) * log(1 - x) for x in grid]
-    max_lw = maximum(logw)
-    w = exp.(logw .- max_lw)
-    w ./= sum(w)
-    sum(w[i] * f(grid[i]) for i in eachindex(w))
-end
+# BetaPrevision is PRIMARY for generic-closure expect: Gauss-Jacobi (the shared `_gauss_jacobi_expect`),
+# exact for polynomials up to degree 2n−1. Default n=32 matches the BetaMeasure view that delegates here
+# (keeping that path bit-identical) and replaces the old uniform-grid Riemann sum (~1e-4) — the Beta
+# correctness fix. Structured TestFunctions (Identity/CenteredPower/GeometricTail) keep their closed
+# forms above; only this generic-closure fallback changes. [measure-as-view Phase 1]
+expect(p::BetaPrevision, f::Function; n::Int=32) = _gauss_jacobi_expect(p.alpha, p.beta, f, n)
 
 expect(p::TaggedBetaPrevision, f::Function; kwargs...) = expect(p.beta, f; kwargs...)
 

--- a/test/test_measure_view_expect.jl
+++ b/test/test_measure_view_expect.jl
@@ -1,0 +1,78 @@
+# test_measure_view_expect.jl — Phase 1 of the measure-as-view arc.
+#
+# Inverts generic-closure `expect` delegation for the scalar families to Prevision-primary, fixing the
+# BETA correctness asymmetry: the constitutionally-primary `BetaPrevision` path used an inferior uniform
+# grid (~1e-4) while the `BetaMeasure` *view* used Gauss-Jacobi (~1e-13) — the view was more accurate
+# than the primary. Post-Phase-1: Gauss-Jacobi is Prevision-primary; the Measure path delegates
+# (bit-preserved); Gaussian/Gamma invert with ZERO behaviour change (both sides already shared the
+# uniform grid). The Gaussian/Gamma accuracy upgrade (Hermite/Laguerre) is deferred (a separate move).
+#
+# Capture-before-refactor: the Measure Gauss-Jacobi values are pinned as literals (the bit-preserve
+# target); the OLD Prevision uniform-grid values are pinned to prove the Prevision path CHANGED toward
+# exact. Literals captured pre-refactor via scratchpad/capture.jl.
+#
+# Run from repo root:
+#     julia test/test_measure_view_expect.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, TaggedBetaPrevision,
+                expect, wrap_in_measure
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+
+# Exact Beta moment E[x^k] = ∏_{i=0}^{k-1} (α+i)/(α+β+i).
+beta_moment(α, β, k) = prod((α + i) / (α + β + i) for i in 0:k-1)   # credence-lint: allow — precedent:test-oracle — independent closed form for the GJ rule
+
+println("="^64)
+println("measure-as-view Phase 1 — expect inversion (Beta correctness fix)")
+println("="^64)
+
+# ── (1) BETA — the fix: Prevision now equals Measure (delegation), and matches the EXACT moment ──
+# Beta(0.5,0.5) is the α+β=1 REGRESSION GUARD: the Gauss-Jacobi node recurrence hit a removable
+# 0/0 there (NaN → LAPACK's MRRR eigensolver infinite-loops — a hang, not a wrong number). The
+# cancelled-k=1 form in _gauss_jacobi_expect fixes it; reaching the finite, exact E[x³]=0.3125
+# check below at all is the guard (a hang would never return).
+for (α, β) in ((2.0, 5.0), (0.5, 0.5), (3.0, 3.0))
+    p = BetaPrevision(α, β); m = wrap_in_measure(p)
+    for (nm, f) in (("x^3", x -> x^3), ("sqrt", sqrt), ("sin3x", x -> sin(3x)))
+        check("Beta($α,$β) $nm: Prevision == Measure (both Gauss-Jacobi via delegation)",
+              expect(p, f) == expect(m, f), "p=$(expect(p,f)) m=$(expect(m,f))")
+    end
+    # The property the old uniform grid FAILED (~1e-4): GJ is exact for the degree-3 polynomial.
+    check("Beta($α,$β): expect(Prevision, x^3) == exact moment",
+          isapprox(expect(p, x -> x^3), beta_moment(α, β, 3); rtol = 1e-12),
+          "got $(expect(p, x->x^3)) exact $(beta_moment(α,β,3))")
+end
+
+# ── (2) capture-before-refactor: the Measure path is BIT-PRESERVED (still Gauss-Jacobi n=32) ──
+check("Beta(2,5) sqrt  Measure bit-preserved",
+      expect(wrap_in_measure(BetaPrevision(2.0, 5.0)), sqrt) == 0.51148859847560213)
+check("Beta(2,5) sin3x Measure bit-preserved",
+      expect(wrap_in_measure(BetaPrevision(2.0, 5.0)), x -> sin(3x)) == 0.66723706676609618)
+check("Beta(3,3) sqrt  Measure bit-preserved",
+      expect(wrap_in_measure(BetaPrevision(3.0, 3.0)), sqrt) == 0.69264069302310205)
+
+# ── (3) the Prevision path CHANGED — it no longer equals the OLD uniform-grid value ──
+check("Beta(2,5) sqrt Prevision moved off the old uniform value (the fix landed)",
+      expect(BetaPrevision(2.0, 5.0), sqrt) != 0.51134797934176113)
+
+# ── (4) GAUSSIAN/GAMMA — zero-behaviour-change inversion: Prevision === Measure, bit-identical ──
+for (nm, p) in (("Gaussian(1,2)", GaussianPrevision(1.0, 2.0)), ("Gamma(3,2)", GammaPrevision(3.0, 2.0)))
+    for (fn, f) in (("x^3", x -> x^3), ("smooth", x -> exp(-x^2 / 9)))
+        check("$nm $fn: Prevision === Measure (bit-identical inversion)",
+              expect(p, f) === expect(wrap_in_measure(p), f))
+    end
+end
+check("Gaussian(1,2) x^3 unchanged (captured)", expect(GaussianPrevision(1.0, 2.0), x -> x^3) == 12.989986878098938)
+check("Gamma(3,2) x^3 unchanged (captured)", expect(GammaPrevision(3.0, 2.0), x -> x^3) == 7.4431782434717517)
+
+# ── (5) TaggedBeta inherits the Beta fix (it routes through the inner BetaPrevision) ──
+check("TaggedBetaPrevision inherits the Gauss-Jacobi fix",
+      isapprox(expect(TaggedBetaPrevision(1, BetaPrevision(2.0, 5.0)), x -> x^3), beta_moment(2.0, 5.0, 3); rtol = 1e-12))
+
+println("="^64)
+println("ALL CHECKS PASSED — measure-as-view Phase 1")
+println("="^64)


### PR DESCRIPTION
## measure-as-view — Phase 1

Restores the constitutional principle **"Measure is a declared view over Prevision"** (precedent `prevision-not-measure`) for the one axiom-constrained function where it is *safe and free*: `expect`. `expect` is carrier-space-free, so inverting its delegation binds no extra state — that is why it is Phase 1.

This arc is the follow-on to collapse-towers' "Duplication assessment (Measure-as-view)": the audit found the scalar-family `expect` methods delegating **backwards** (Prevision → Measure), inverting the constitution, and — worse — a latent **correctness asymmetry** behind it.

### The bug this fixes

`expect(m::BetaMeasure, f)` used exact **Gauss-Jacobi** quadrature (~1e-13); the constitutionally-**primary** `expect(p::BetaPrevision, f)` used an inferior **uniform grid** (~1e-4). The view was more accurate than the primitive it is supposed to be a view *of*. `E[x³]` under Beta(2,5): exact `0.04761904…` (Measure) vs `0.04760452…` (Prevision), Δ≈1.45e-5.

### What changes

The scalar-family generic-closure `expect` now delegates Measure → Prevision instead of the reverse:

| family | before | after |
|---|---|---|
| **Beta** | Measure = Gauss-Jacobi; **Prevision = uniform grid (~1e-4)** | both Gauss-Jacobi (~1e-13); Prevision is primary, Measure delegates |
| **Gaussian** | identical uniform grid both sides | Measure delegates → Prevision; **bit-identical** |
| **Gamma** | identical bare-kernel grid both sides | Measure delegates → Prevision; **bit-identical** |

The Gauss-Jacobi rule moves verbatim into a shared `_gauss_jacobi_expect(alpha, beta, f, n)`, with the Prevision as its primary caller. Beta default `n` unifies at **32** (Gauss-Jacobi n=32 is exact to polynomial degree 63 — strictly better than the old uniform n=64, and keeps the Measure path bit-identical to its captured reference).

Gaussian/Gamma keep their shared uniform grid (zero behaviour change). The Gauss-Hermite/Laguerre accuracy upgrade for those families is a **deferred** move, not folded in here.

### Bonus correctness fix — a latent LAPACK hang the inversion would otherwise have shipped

`_gauss_jacobi_expect`'s Golub-Welsch node recurrence hits a **removable 0/0** at the `k=1` off-diagonal for any Beta with **α+β=1** (e.g. the arcsine `Beta(0.5,0.5)`): numerator `(1+a+b)=0` and denominator `(s²−1)=0` → `NaN`, on which LAPACK's MRRR eigensolver (`dstegr_`→`dstemr_`) **infinite-loops** — a hang at 99% CPU, not a wrong number. It was pre-existing but dormant (the structured-Functional paths are closed-form; nobody reached the generic Gauss-Jacobi path at α+β=1). Promoting Gauss-Jacobi to the *primary* Beta path would have converted the old inaccurate-but-returning uniform-grid call into a hang.

Fixed with the **analytically-cancelled k=1 form** `4(1+a)(1+b)/[(a+b+2)²(a+b+3)]` — the `(1+a+b)` factor cancels, so it is **exact, not an approximation**: verified bit-identical to the raw form on the pinned `Beta(2,5)/(3,3)` literals, finite/exact (= 0.5) on the singular line. The core is stdlib-only, so fixing the hand-rolled Golub-Welsch recurrence was the only path (no `FastGaussQuadrature.jl`).

### Tests — `test/test_measure_view_expect.jl` (capture-before-refactor)

- **Beta:** `expect(Prevision, f) == expect(Measure, f)` (delegation) and `≈ exact moment` (rtol 1e-12) over `(2,5)/(0.5,0.5)/(3,3)`. The `(0.5,0.5)` entry is the **α+β=1 regression guard** — reaching its finite `E[x³]=0.3125` check at all is the guard (a hang would never return).
- **Measure bit-preservation:** the Gauss-Jacobi literals pinned pre-refactor (`0.51148859847560213`, `0.66723706676609618`, `0.69264069302310205`).
- **Prevision moved:** no longer equals the old uniform-grid value `0.51134797934176113`.
- **Gaussian/Gamma:** Prevision `===` Measure, bit-identical inversion; captured `12.989986878098938`, `7.4431782434717517`.
- **TaggedBeta:** inherits the Gauss-Jacobi fix through its inner `BetaPrevision`.

### Verification

Full Julia suite (45 files) + lint corpus self-test + `check apps/` (174 files, 0 violations) green. Julia tests are not CI-gated on this repo; run locally on `9bd42da`.

### Arc shape (this PR = Phase 1 only)

- **Phase 1** (this PR): invert `expect` — carrier-space-free, the safe one.
- **Phase 2** (design-doc-gated): invert `condition`/`_predictive_ll` (9 backwards-delegation sites) — binds the carrier space, so it is *not* free.
- **Phase 3**: collapse the duplicated mixture twins (`condition`/`prune`/`truncate`/`draw`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
