### PR TITLE
measure-as-view Phase 2: condition/_predictive_ll go Prevision-primary for the scalar families

### DIFF
--- a/docs/measure-as-view/master-plan.md
+++ b/docs/measure-as-view/master-plan.md
@@ -69,16 +69,30 @@ Make the **Prevision the primary** for generic-closure `expect` and the Measure 
 See `phase-1-design.md`. (Open question there: unify at the Measure's Gauss-Jacobi `n=32` so the Beta
 Measure path is bit-preserved, vs the Prevision's old `n=64`.)
 
-### Phase 2 — Invert `condition`/`_predictive_ll` delegation (carrier-space-threading)
-Move the non-conjugate `condition`/`_predictive_ll`/`log_predictive` fallbacks for Beta/Gaussian/Gamma/
-Product to Prevision-primary, threading the carrier space where the posterior needs it; the Measure
-facades become thin delegating views. Capture-before-refactor: posteriors pinned `==` pre-refactor.
+### Phase 2 — Invert `condition`/`_predictive_ll` for the continuous-scalar families
+**Scope refined by the carrier-space gate (design doc §1, ratified 2026-06-28):** the master plan's
+"all 9 backwards-delegation sites" split **5 clean / 4 binding** along the **structural-vs-data carrier
+seam**. The *continuous* families (Beta/Gaussian/Gamma) have a *type-recoverable* support
+(`Interval(0,1)`/`Euclidean(1)`/`PositiveReals`, read off the Prevision type), so their non-conjugate
+`condition` + the deterministic Beta/Gaussian `_predictive_ll` invert Prevision-primary with a thin
+**carrier re-bind at the Measure facade** — no live carrier threaded. Capture-before-refactor reuses the
+existing `particle_canonical_v1.jls` fixture (`==`, no new capture). See `phase-2-design.md`.
 
-### Phase 3 — Collapse the duplicated mixture twins (`condition`/`prune`/`truncate`/`draw`)
-The Phase-2-of-collapse-towers deferral. Thread the per-component carrier space so the
-`MixtureMeasure` facade can delegate to `MixturePrevision` without dropping space context or changing
-the consumer-visible component type. Capture-before-refactor against `test_flat_mixture`/`test_host`/
-`test_core` TEST 53 (the tests the naive facade broke).
+The four **binding** sites — `condition(::ProductPrevision)` (per-factor data carrier, returns a
+`MixtureMeasure`) and the three generic catch-alls (`_predictive_ll(::Prevision)`,
+`log_predictive(::Prevision)`, `condition(::Measure)`) — bind because their support is *data*: the
+discrete families' category values live in `m.space.values`, unrecoverable from type
+(`CategoricalPrevision` has no carrier-free `draw`). They **defer to Phase 3** and, since Phase 3
+adjacency is not guaranteed, each carries an explicit `# NOTE:` tracking marker citing the Phase 3 issue
+(#163; the half-state is owned, not silent). Product is **not** pulled into Phase 2.
+
+### Phase 3 — Give the data-valued carrier a Prevision-native home (mixture twins + the 4 binding sites)
+The Phase-2-of-collapse-towers deferral, now seen for what it is: the discrete/per-component carrier is
+*data*, and giving it a carrier-free home is *the same act* as collapsing the duplicated mixture twins
+(`condition`/`prune`/`truncate`/`draw`). Thread the per-component carrier so the `MixtureMeasure` facade
+delegates to `MixturePrevision` without dropping space context or changing the consumer-visible component
+type; in the same move, invert the four binding sites Phase 2 marked. Capture-before-refactor against
+`test_flat_mixture`/`test_host`/`test_core` TEST 53 (the tests the naive facade broke).
 
 ## Hard constraints (inherited)
 Spec-first; design-doc-before-code; stop-and-report at every phase boundary; **no new constitutional

--- a/docs/measure-as-view/phase-2-design.md
+++ b/docs/measure-as-view/phase-2-design.md
@@ -1,0 +1,298 @@
+# Phase 2 design doc — Invert `condition`/`_predictive_ll` delegation for the scalar families (carrier-space re-bind)
+
+> Seven-section template (`docs/measure-as-view/DESIGN-DOC-TEMPLATE.md`). Master plan:
+> `docs/measure-as-view/master-plan.md`. Precedents: `docs/precedents.md`.
+
+## 1. Purpose
+
+Phase 2 as scoped in the master plan ("invert `condition`/`_predictive_ll` delegation, threading the
+carrier space"), **with one refinement forced by the carrier-space gate** (§5 Q1): the inversion is
+scoped to the **five named continuous-scalar methods**, and `Product` + the three generic catch-alls
+are deferred to Phase 3.
+
+The master plan's Phase 1/Phase 2 boundary was drawn on the premise "`expect` does *not* bind the
+carrier (Phase 1, safe); `condition` *does* bind it (Phase 2, must thread the space)." Running the
+gate (`grep -n '\.space'` across the delegated-to methods, then classifying each read) **refines that
+premise**: for the continuous-scalar families the carrier is *not* live state — every `m.space` read is
+either (a) **result-wrapper reconstruction** discarded the moment `.prevision` is extracted, or (b) a
+**type-constant** (`Interval(0,1)` / `Euclidean(1)` / `PositiveReals`) the Prevision recovers from its
+own type, or (c) a **DSL-declared space** the facade simply re-attaches. So the scalar inversion threads
+the carrier through a thin **re-bind** at the Measure facade (`Measure binds carrier; Prevision does
+not`), not through any per-component plumbing.
+
+Where the premise *does* hold in full force — `condition(::ProductPrevision)` (threads per-factor
+`cat.space.values`/`factor.space` and **returns a different type**, `MixtureMeasure`) and the generic
+catch-alls (`_predictive_ll(::Prevision)`, `log_predictive(::Prevision)`, `condition(::Measure)`, whose
+`draw`/`expect` need the carrier for the *discrete* families `Categorical`/`Dirichlet`) — the work is
+identical to Phase 3's per-component-carrier-space remit and moves there.
+
+What unblocks: after Phase 2 the five scalar primitives reach their own non-conjugate behaviour
+**Prevision-first** (no `wrap_in_measure` round-trip through their own view), and the correctness
+direction (`prevision-not-measure`) is restored for `condition`/`_predictive_ll` on the families that
+carry no live carrier — leaving Phase 3 a *single* coherent problem (per-component/discrete carrier
+threading) instead of that problem entangled with five trivial inversions.
+
+**The seam the gate found (why the split lands here, not at the master plan's line).** The 5/4 split is
+not arbitrary — it is the **structural-vs-data carrier seam**. The continuous families invert cleanly
+because their support is *type-recoverable*: `Interval(0,1)`, `Euclidean(1)`, `PositiveReals` are read
+off the Prevision's *type*, so `draw`/`expect` produce values with no carrier in hand. The discrete
+families bind because their support is *data*: the category values are arbitrary (`{:red,:green,:blue}`,
+a vector of reals, anything), unrecoverable from type, and they live in `m.space.values`, not in the
+Prevision — confirmed by `CategoricalPrevision` holding only `log_weights` (the probabilities) with **no
+`draw(::CategoricalPrevision)` method at all** (only `draw(::CategoricalMeasure)`, `:1856`): a categorical
+Prevision can give you an index distribution but not an outcome. So `condition` is carrier-free exactly
+when the carrier is determined by structure, and must be handed the carrier exactly when the carrier *is*
+the data. This is the constitution's "Bayes charges you for the model" reappearing one level down:
+`condition` charges you for the carrier precisely when the carrier is data. Giving the discrete families
+a carrier-free home is therefore *the same act* as collapsing the mixture twins — which is why the four
+binding sites belong to Phase 3, and why the rescope is a discovery (the right dividing line) rather than
+a retreat.
+
+## 2. Files touched
+
+- **`src/ontology.jl`** — *modify*:
+  - **Relocate the grid helper to Prevision-native.** New `_condition_by_grid(p::BetaPrevision, k, obs;
+    n=64)` and `_condition_by_grid(p::GaussianPrevision, k, obs; n=64)` returning a
+    `QuadraturePrevision` (the body of the current `_condition_by_grid(m::BetaMeasure)` `:1346`–`:1357`
+    and `(m::GaussianMeasure)` `:1359`–`:1372`, verbatim, with `m.space.lo/.hi` → the constants `0.0/1.0`
+    for Beta and `m.mu±4m.sigma` → `p.mu±4p.sigma` for Gaussian). The current
+    `_condition_by_grid(m::Measure)` methods are reduced to **thin re-bind facades**:
+    `_condition_by_grid(m::BetaMeasure, k, obs; n=64) = (q = _condition_by_grid(m.prevision, k, obs; n);
+    CategoricalMeasure(Finite(q.grid), q))`, ditto Gaussian. (Preserves both direct callers in
+    `test_prevision_particle.jl` and the `CategoricalMeasure(Finite(grid), qp)` result shape.)
+  - **Relocate the particle helper to Prevision-native (scalar).** New `_condition_particle(p::Prevision,
+    k, obs; n_particles=1000, seed=0)` returning a `ParticlePrevision` (body of `_condition_particle`
+    `:1814`–`:1819`, with `draw(m)` → `draw(p)`; `draw(p::GammaPrevision)` exists at `:1998`). The
+    existing `_condition_particle(m::Measure, …)` (`:1814`) is **left in place unchanged** — it is the
+    Phase-3 catch-all (arbitrary `m`, `draw(m)` over discrete carriers). Only the scalar
+    `condition(p::…)` methods call the new Prevision overload.
+  - `condition(p::BetaPrevision, k, obs; n=64)` (`:1155`) — **replace** the `wrap_in_measure` fallback
+    (`:1160`) with the Bernoulli fast-path (relocated from `condition(m::BetaMeasure)` `:1069`–`:1075`,
+    `BetaMeasure(m.space, …)` → `BetaPrevision(…)`) then `_condition_by_grid(p, k, obs; n)`. Conjugate arm
+    (`:1156`–`:1158`) unchanged (already Prevision-primary).
+  - `condition(p::GaussianPrevision, k, obs; n=64)` (`:1293`) — **replace** the `wrap_in_measure`
+    fallback (`:1298`) with `_condition_by_grid(p, k, obs; n)`. Conjugate arm unchanged.
+  - `condition(p::GammaPrevision, k, obs; n_particles=1000)` (`:1314`) — **replace** the
+    `wrap_in_measure` fallback (`:1319`) with `_condition_particle(p, k, obs; n_particles)`. Conjugate
+    arm unchanged.
+  - `condition(m::BetaMeasure / m::GaussianMeasure / m::GammaMeasure)` (`:1063`/`:1100`/`:1144`) —
+    **reduce to a thin facade** `_rebind(m, condition(m.prevision, k, obs; kwargs…))` where `_rebind`
+    re-attaches the carrier (the conjugate/Bernoulli result `→ FamilyMeasure(m.space, …)`; the
+    grid/particle result `QuadraturePrevision`/`ParticlePrevision → CategoricalMeasure(Finite(...), p)`,
+    i.e. `wrap_in_measure` where it exists). Threads `m.space` (see §5 Q3).
+  - `_predictive_ll(p::BetaPrevision, k, obs)` (`:1585`) — **replace** the `wrap_in_measure` delegation
+    with the body of `_predictive_ll(m::BetaMeasure)` (`:1538`): `val = expect(p, h ->
+    exp(k.log_density(h, obs))); log(max(val, 1e-300))`. (`expect(p::BetaPrevision)` is Prevision-primary
+    as of Phase 1 — the two expressions are now the *same* call.) `_predictive_ll(m::BetaMeasure)` reduces
+    to `_predictive_ll(m.prevision, k, obs)`.
+  - `_predictive_ll(p::GaussianPrevision, k, obs)` (`:1601`) — **replace** the `wrap_in_measure`
+    delegation with the NormalNormal closed form (body of `_predictive_ll(m::GaussianMeasure)` `:1521`–
+    `:1526`, `m.prevision` → `p`); the non-NormalNormal branch falls to the generic
+    `_predictive_ll(p::Prevision)` (still backwards-delegating — deferred, §5 Q1).
+    `_predictive_ll(m::GaussianMeasure)` reduces to `_predictive_ll(m.prevision, k, obs)`.
+  - **Deferred to Phase 3 — logic untouched, but each gains a one-line tracking marker (§5 Q1 ratified):**
+    the four live backwards-delegation sites — `condition(p::ProductPrevision)` (`:1341`),
+    `_predictive_ll(p::GammaPrevision)` (`:1604`, sampling, no fixture), `_predictive_ll(p::Prevision)`
+    (`:1607`), `log_predictive(p::Prevision)` (`:1618`) — each get a `# NOTE: measure-as-view Phase 3
+    (#163) — backwards delegation; <one-line why it binds: Product returns a MixtureMeasure / discrete
+    families lack a carrier-free draw>` immediately above the `wrap_in_measure` call. (`condition(m::Measure)`
+    /`_condition_particle(m::Measure)` at `:1821`/`:1814` are the Phase-3 catch-all *targets*, not
+    backwards-delegation themselves — no marker; left byte-for-byte.) Mixture twins unchanged.
+- **`test/test_measure_view_condition.jl`** — *new* (see §7).
+- **`test/fixtures/particle_canonical_v1.jls`** — *reused, not modified* (the capture-before-refactor
+  reference; §3/§6).
+
+No new exports. No new constitutional text. The `; n` / `; n_particles` kwargs are preserved exactly
+where the inverted methods replace paths that had them.
+
+## 3. Behaviour preserved
+
+Tolerance classes (per template §3), mapped to this move:
+
+- **Strata-1 / Strata-2 grid + particle — fixture `==` (the load-bearing guard).**
+  `particle_canonical_v1.jls` (source SHA `173411b`, `==` tolerance, README §`particle_canonical_v1`)
+  pins the *exact* outputs of all three scalar non-conjugate fallbacks. `test_prevision_particle.jl`
+  already asserts the **Measure** entry points `==` these (green under Julia 1.12.6 as of this writing).
+  Phase 2 keeps those assertions untouched and **adds Prevision-entry assertions against the same
+  canonical values** (no new capture): `condition(GammaPrevision(2,3), k_pushonly, 2.5; n_particles=50)`
+  under `seed!(42)` yields a `ParticlePrevision` whose `.samples == :gamma_generic_samples` and
+  `.log_weights == :gamma_generic_logw`; `condition(BetaPrevision(2,3), k_pushonly, 0.5)` /
+  `condition(GaussianPrevision(0,1), k_pushonly, 1.5)` yield `QuadraturePrevision`s whose `.grid` /
+  `.log_weights` `==` `:beta_grid_*` / `:gaussian_grid_*`. The RNG-op sequence is preserved because
+  `draw(p::GammaPrevision)` (`:1998`) and `draw(m::GammaMeasure)` (`:1932`) issue **identical**
+  operations (`_draw_gamma(α)/β` on the same α,β), so the relocation is bit-exact under fixed seed.
+- **Conjugate paths — `===`, untouched.** The conjugate arms of the scalar `condition`s are *already*
+  Prevision-primary (`maybe_conjugate(p, k)` + `update(cp).prior`); Phase 2 does not touch them.
+- **Bernoulli fast-path — `==`.** Relocating `BetaMeasure(m.space, m.α+1, m.β)` → `BetaPrevision(m.α+1,
+  m.β)` is the same integer-offset arithmetic; the Measure facade re-binds `m.space`, reproducing the
+  old `BetaMeasure(m.space, …)` exactly.
+- **`_predictive_ll` Beta/Gaussian — `==`.** Beta becomes literally `expect(p, …)` (post-Phase-1 the
+  Measure path *already* routed through `expect(p)`); Gaussian becomes the identical NormalNormal closed
+  form with `m.prevision.{mu,sigma}` → `p.{mu,sigma}` (field reads, lossless).
+- **Carrier preserved.** The shared-reference contract tests in `test_prevision_particle.jl`
+  (`cm.logw === pp.log_weights`, `cm.space.values === qp.grid`) continue to hold — the facade builds the
+  same `CategoricalMeasure(Finite(prevision-vector), prevision)`, so the reference identity the shield
+  guarantees is unchanged.
+- **Strata-3 end-to-end — `rtol=1e-10`.** A multi-observation `condition` fold through the skin
+  (`condition` is the wire-crossing verb) on a Gaussian prior reproduces the pre-refactor posterior
+  mean/variance.
+
+No *intended* behaviour change in Phase 2 (unlike Phase 1's Beta accuracy fix). This is a pure
+structural inversion: every assertion is `==`/`===`/`rtol` equivalence, captured pre-refactor.
+
+## 4. Worked end-to-end example
+
+`condition(m, k, 1.5)` with `m = wrap_in_measure(GaussianPrevision(0.0, 1.0))` (a `GaussianMeasure` on
+`Euclidean(1)`) and `k` the non-conjugate `k_pushonly` kernel (`likelihood_family = PushOnly()`, the
+fixture's Case 3) — the centrepiece, because it exercises the grid fallback *and* the carrier re-bind.
+
+- **Before (backwards delegation).** `condition(m::GaussianMeasure, k, 1.5)` *(owner: Measure)* →
+  `maybe_conjugate(m.prevision, k)` returns `nothing` (PushOnly) → `_condition_by_grid(m, k, 1.5)`
+  *(owner: Measure)* → 64-pt grid over `m.mu ± 4m.sigma`, `logw[i] = log_density_at(m, x) + density(k, x,
+  1.5)` → `QuadraturePrevision(grid, logw)` → wrapped `CategoricalMeasure(Finite(grid), qp)`. (The
+  Prevision path `condition(p::GaussianPrevision)` would instead `wrap_in_measure(p)` and re-enter this
+  very method — the round-trip the arc removes.)
+- **After (Prevision-primary + facade re-bind).**
+  1. `condition(m::GaussianMeasure, k, 1.5)` *(owner: Measure facade)* → `condition(m.prevision, k, 1.5)`.
+  2. `condition(p::GaussianPrevision, k, 1.5)` *(owner: **Prevision**, authoritative)* →
+     `maybe_conjugate` `nothing` → `_condition_by_grid(p, k, 1.5)` *(owner: **Prevision**)* → same 64-pt
+     grid over `p.mu ± 4p.sigma` (`p.{mu,sigma} === m.prevision.{mu,sigma}`, lossless) → returns
+     `QuadraturePrevision(grid, logw)` — **no carrier space involved**.
+  3. `_rebind(m, qp)` *(owner: Measure facade, authoritative for the carrier)* →
+     `CategoricalMeasure(Finite(qp.grid), qp)`.
+- **Result.** Bit-identical `CategoricalMeasure` to "before" — `result.space.values ==
+  :gaussian_grid_values`, `result.logw == :gaussian_grid_logw` (asserted in both
+  `test_prevision_particle.jl`, unchanged, and the new `test_measure_view_condition.jl` via the Prevision
+  entry point).
+- **Dual residency.** The grid arithmetic had one home (Measure); Phase 2 moves it to the Prevision and
+  leaves a one-line facade — net dual-residency **decreases**. The split of authority is the
+  constitutional one: the **Prevision** owns the space-free posterior (`QuadraturePrevision`); the
+  **Measure facade** owns the carrier binding (`Finite(grid)`). That is "Measure binds carrier space;
+  Prevision does not" made literal.
+
+## 5. Open design questions
+
+> **Ratified 2026-06-28 (author).** All three verified against the code (the `CategoricalPrevision`
+> carrier-free-`draw` gap and the `QuadraturePrevision`/`ParticlePrevision` `wrap_in_measure` asymmetry
+> both confirmed). **Q1 — defer, contingency made binding:** the four binding sites move to Phase 3.
+> Because Phase 3 adjacency is *not* guaranteed (the paper / Genesis / credence-pi compete for the next
+> slot), the contingency triggers: the four live `wrap_in_measure` sites **must carry an explicit
+> tracking marker** naming them as a known-incomplete inversion (a one-line `# NOTE:` at each, citing the
+> Phase 3 tracking issue), so the half-state — the constitution asserting "Measure is a view over
+> Prevision" while four sites round-trip a Prevision through its own view — is *owned and visible*, not a
+> trap for the next reader. **Product is NOT swallowed** into Phase 2 (that would merge the hard mixture
+> work into the safe scalar move). **Q2 — local `_rebind` (a).** **Q3 — thread `m.space` (preserve).**
+> The prose below is retained as the rationale of record.
+
+1. **Scope: defer `Product` + the three generic catch-alls to Phase 3, or force them into Phase 2?**
+   The gate classification (§1) splits the 9 backwards-delegation sites **5 clean / 4 binding**. The
+   clean five (`condition` Beta/Gaussian/Gamma, `_predictive_ll` Beta/Gaussian) carry no live carrier and
+   are fixture- or exactness-covered. The binding four —
+   `condition(::ProductPrevision)` (per-factor `cat.space.values`/`factor.space`, **returns a
+   `MixtureMeasure`**, recurses into factor `condition`), `_predictive_ll(::GammaPrevision)` (sampling,
+   routed through the generic Measure sampler, **no fixture**), `_predictive_ll(::Prevision)` and
+   `log_predictive(::Prevision)` and `condition(::Measure)` (catch-alls whose `draw`/`expect` need the
+   carrier for the *discrete* families) — are the **same problem Phase 3 already owns** (per-component /
+   discrete carrier-space threading + Monte-Carlo capture). **Recommendation: defer the four to Phase
+   3.** Two technical reasons: (a) `condition(::ProductPrevision)`'s result-type change to `MixtureMeasure`
+   and its recursion into the mixture machinery make it indivisible from the mixture-twin collapse; (b)
+   the catch-alls' only *new* failure surface is the discrete families, whose `draw(::CategoricalPrevision)`
+   does not exist carrier-free — i.e. the exact gap Phase 3 closes. Counter-argument to weigh: this
+   leaves four `wrap_in_measure` call-sites live after Phase 2, so the arc's "no backwards delegation"
+   end-state lands only at Phase 3 — acceptable if Phase 3 is the immediate successor, a smell if the arc
+   might pause after Phase 2.
+
+2. **Re-bind home for the grid/particle results.** The grid fallback yields a `QuadraturePrevision`,
+   which **deliberately has no `wrap_in_measure` method** (the `:894` stance: "no carrier Space"). Two
+   ways for the facade to re-bind: **(a)** a local `_rebind(m, q::QuadraturePrevision) =
+   CategoricalMeasure(Finite(q.grid), q)` per family (recommended — respects `:894`, keeps the
+   carrier-binding visibly in the facade where the constitution puts it), or **(b)** add
+   `wrap_in_measure(::QuadraturePrevision)` for a uniform `wrap_in_measure(condition(m.prevision, …))`
+   facade — rejected, it reverses a deliberate design stance and would silently re-route the generic
+   `_predictive_ll(::Prevision)`/`condition(::Measure)` fallbacks through a new wrap. Note the particle
+   case is **already** uniform: `wrap_in_measure(::ParticlePrevision)` exists (`:528`) and equals
+   `CategoricalMeasure(Finite(samples), pp)`, so `_rebind(m, pp) = wrap_in_measure(pp)` there.
+   Recommend **(a)** with the particle case using the existing `wrap_in_measure(::ParticlePrevision)`.
+
+3. **Thread `m.space` or canonicalise it?** The conjugate/Bernoulli facade re-bind is
+   `FamilyMeasure(m.space, …)`. `src/eval.jl:489/505/518` construct `BetaMeasure(space, …)` /
+   `GammaMeasure(space, …)` / `GaussianMeasure(space, …)` with a **DSL-declared `space`**, so `m.space`
+   is *not* guaranteed to be the type-canonical constant. **Recommendation: thread `m.space`** (preserve
+   it), not `wrap_in_measure(p2)` (which would force `Interval(0,1)`/`Euclidean(1)`/`PositiveReals` and
+   silently rewrite a DSL-declared carrier). This is both the bit-preserving choice (capture-before-
+   refactor asserts `==` including the space field) and the honest one ("Measure binds *the declared*
+   carrier"). The alternative (canonicalise) is rejected: it changes observable state for any
+   DSL-declared non-canonical space and is not what the pre-refactor conjugate arm did.
+
+## 6. Risk + mitigation
+
+- **R1 — seed-consumption reorder in the particle relocation.** *Failure mode:* moving
+  `_condition_particle`'s `draw` loop from `draw(m)` to `draw(p)` reorders or adds RNG draws → particle
+  samples drift. *Blast radius:* `test_prevision_particle.jl` Case 1 (Measure entry, unchanged) **and**
+  the new Prevision-entry assertion both `==` `:gamma_generic_samples`. *Mitigation:* `draw(p::GammaPrevision)`
+  and `draw(m::GammaMeasure)` are the same `_draw_gamma(α)/β` with identical α,β — verified by reading
+  both (`:1998`, `:1932`); the loop count and order are unchanged; fixture `==` under `seed!(42)` catches
+  any reorder. **The fixture is never regenerated to fix a drift** (README provenance protocol) — a `==`
+  failure is a halt-the-line signal, investigated, not papered over.
+- **R2 — facade re-bind drops or rewrites the carrier.** *Failure mode:* `_rebind` forces a canonical
+  space, or returns the wrong wrapper type, changing `result.space`. *Blast radius:* `test_core`,
+  `test_prevision_unit`, any consumer reading `.space` off a conditioned scalar Measure; the
+  shared-reference contract tests. *Mitigation:* §5 Q3 (thread `m.space`); capture-before-refactor `==`
+  on the full conditioned Measure (space + weights) for a DSL-declared non-canonical-space Beta.
+- **R3 — kwarg threading lost.** *Failure mode:* the inverted `condition(p::…)` drops `; n` / `;
+  n_particles`, so `condition(…; n_particles=50)` silently uses the default 1000. *Blast radius:* the
+  fixture's `n_particles=50` (50 vs 1000 samples — loud length mismatch). *Mitigation:* the inverted
+  signatures declare the same kwargs; the new Prevision-entry test passes `n_particles=50` and asserts
+  the 50-sample `==`.
+- **R4 — a deferred site silently regresses.** *Failure mode:* touching the shared `_condition_particle`
+  /`_condition_by_grid` helper names perturbs the Phase-3 catch-all path. *Mitigation:* the
+  `_condition_particle(m::Measure, …)` catch-all (`:1814`) is **left byte-for-byte unchanged**; only a
+  new `(p::Prevision, …)` overload is added. Pre-emptive grep below confirms the call graph.
+- **Pre-emptive grep (per template suggested practice).** Run before the PR opens; list each hit's
+  disposition (mechanical / no-edit / attention):
+  - `grep -rn 'wrap_in_measure' src/ apps/ test/` — confirm the only removed call-sites are the five
+    scalar fallbacks; the four deferred sites + the `wrap_in_measure(p, space)` constructors stay.
+  - `grep -rn '_condition_by_grid\|_condition_particle' src/ test/` — confirm `test_prevision_particle.jl`
+    is the only external caller and it calls the **Measure** form (preserved as a thin facade) — no edit.
+  - `grep -rn 'condition(.*Prevision' apps/ test/` — confirm no consumer relies on the scalar
+    `condition(p::…)` *returning a Measure* (it returns a Prevision; the facade returns the Measure).
+  - `grep -rn '\.space' src/ontology.jl` within the touched method bodies — confirm post-refactor the
+    Prevision methods read **no** `m.space` (the gate, re-run on the new code).
+
+## 7. Verification cadence
+
+End of Phase-2 code (from repo root; Julia tests not CI-gated):
+```
+julia test/test_measure_view_condition.jl      # new — Prevision-entry == fixture + facade equivalence
+julia test/test_prevision_particle.jl          # the capture-before-refactor fixture guard (== unchanged)
+julia test/test_measure_view_expect.jl         # Phase 1 stays green
+julia test/test_core.jl
+julia test/test_prevision_unit.jl
+```
+Then the **full** `test/test_*.jl` suite + lint corpus self-test (`python tools/credence-lint/credence_lint.py
+test`) + `check apps/`, and **stop and report**.
+
+**Skin smoke — required for Phase 2.** `condition` is the JSON-RPC wire-crossing verb (`apps/skin/server.jl`
+constructs `GaussianMeasure`/`GammaMeasure`/`NormalGammaMeasure` and conditions them server-side), so run
+`JULIA_PROJECT=. uv run python apps/skin/test_skin.py`. Phase 2 changes `condition` internals but **not**
+the wire schema (Measures stay server-side as opaque IDs); the smoke confirms the consumption surface is
+intact.
+
+`test_measure_view_condition.jl` (repo `check(name, cond, detail)` idiom):
+- **Prevision-entry == fixture (reuse, no new capture):** under `Random.seed!(42)`,
+  `condition(GammaPrevision(2,3), k_pushonly, 2.5; n_particles=50).samples == CANONICAL[:gamma_generic_samples]`
+  (and `.log_weights ==` `:gamma_generic_logw`); `condition(BetaPrevision(2,3), k_pushonly, 0.5)` and
+  `condition(GaussianPrevision(0,1), k_pushonly, 1.5)` return `QuadraturePrevision`s whose `.grid`/
+  `.log_weights` `==` the `:beta_grid_*`/`:gaussian_grid_*` canonical vectors.
+- **Facade equivalence:** for each scalar family, `condition(wrap_in_measure(p), k, obs) ==
+  _rebind-of condition(p, k, obs)` — the Measure facade and the Prevision-primary path agree, on both
+  the conjugate arm (`===` family Measure with `m.space` preserved) and the non-conjugate arm
+  (`CategoricalMeasure` over the grid/particle).
+- **DSL-declared space preserved (R2/Q3):** a `BetaMeasure(Interval(0.0,1.0), 2.0, 3.0)` conditioned on
+  a conjugate kernel yields a `BetaMeasure` whose `.space === m.space` (threaded, not canonicalised).
+- **`_predictive_ll` inversion:** `_predictive_ll(BetaPrevision(2,3), k, obs) ==
+  _predictive_ll(wrap_in_measure(p), k, obs)` (both now `expect(p, …)`); same for Gaussian NormalNormal.
+
+Halt-the-line: any failure at end-of-PR is a halt; the branch never sleeps red. The fixture `==` class
+is **not** relaxable to `rtol` (precedents.md §4 — relaxing masks the seed-reorder regression the test
+exists to catch).

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -1060,21 +1060,23 @@ function condition(m::CategoricalMeasure{T}, k::Kernel, observation) where T
     CategoricalMeasure{T}(m.space, new_logw)
 end
 
-function condition(m::BetaMeasure, k::Kernel, observation)
-    cp = maybe_conjugate(m.prevision, k)
-    if cp !== nothing
-        updated = update(cp, observation).prior
-        return BetaMeasure(m.space, updated.alpha, updated.beta)
-    end
-    if k.source isa Interval && k.target isa Finite && length(k.target.values) == 2
-        if observation == 1 || observation == 1.0 || observation == true
-            return BetaMeasure(m.space, m.alpha + 1.0, m.beta)
-        elseif observation == 0 || observation == 0.0 || observation == false
-            return BetaMeasure(m.space, m.alpha, m.beta + 1.0)
-        end
-    end
-    _condition_by_grid(m, k, observation)
-end
+# ── measure-as-view Phase 2: scalar condition is Prevision-primary; the Measure is a re-binding view ──
+# The Prevision computes the space-free posterior; `_rebind_scalar` re-attaches the carrier the Measure
+# owns. Family-staying results (conjugate/Bernoulli) thread `m.space` (Q3 — preserve the DSL-declared
+# carrier from eval.jl); grid/particle results bind a fresh Finite(grid)/Finite(samples) carrier (the
+# QuadraturePrevision/ParticlePrevision is carrier-free). See test/test_measure_view_condition.jl.
+_rebind_scalar(m::BetaMeasure, p::BetaPrevision) = BetaMeasure(m.space, p.alpha, p.beta)
+_rebind_scalar(m::GaussianMeasure, p::GaussianPrevision) = GaussianMeasure(m.space, p.mu, p.sigma)
+_rebind_scalar(m::GammaMeasure, p::GammaPrevision) = GammaMeasure(m.space, p.alpha, p.beta)
+_rebind_scalar(::Measure, q::QuadraturePrevision) = CategoricalMeasure(Finite(q.grid), q)
+_rebind_scalar(::Measure, pp::ParticlePrevision) = wrap_in_measure(pp)  # = CategoricalMeasure(Finite(samples), pp)
+
+# No-kwarg facade (deliberate): an explicit `; n_particles` on a scalar Measure still falls through to the
+# generic particle catch-all (condition(::Measure; n_particles)), as it did pre-Phase-2 — the kwarg
+# selects the particle override over the grid default (test_core TEST 18). The grid `n` is the Prevision
+# method's default; no consumer overrides it on the Measure (grep-verified).
+condition(m::BetaMeasure, k::Kernel, observation) =
+    _rebind_scalar(m, condition(m.prevision, k, observation))
 
 function condition(m::TaggedBetaMeasure, k::Kernel, observation)
     fam = _resolve_likelihood_family(k.likelihood_family, m)
@@ -1097,14 +1099,8 @@ _conjugacy_prevision(p::TaggedBetaPrevision) = p.beta
 # are themselves the conjugacy-keyed type — no unwrapping needed.
 _conjugacy_prevision(p::Prevision) = p
 
-function condition(m::GaussianMeasure, k::Kernel, observation)
-    cp = maybe_conjugate(m.prevision, k)
-    if cp !== nothing
-        updated = update(cp, observation).prior
-        return GaussianMeasure(m.space, updated.mu, updated.sigma)
-    end
-    _condition_by_grid(m, k, observation)
-end
+condition(m::GaussianMeasure, k::Kernel, observation) =
+    _rebind_scalar(m, condition(m.prevision, k, observation))
 
 # Measure-facade for the exact LinearGaussian conjugate. Without this the generic
 # particle fallback (condition(::Measure, …)) would shadow the conjugate when the
@@ -1141,24 +1137,22 @@ function condition(m::NormalGammaMeasure, k::Kernel, observation)
     _condition_particle(m, k, observation)
 end
 
-function condition(m::GammaMeasure, k::Kernel, observation)
-    cp = maybe_conjugate(m.prevision, k)
-    if cp !== nothing
-        updated = update(cp, observation).prior
-        return GammaMeasure(m.space, updated.alpha, updated.beta)
-    end
-    _condition_particle(m, k, observation)
-end
+condition(m::GammaMeasure, k::Kernel, observation) =
+    _rebind_scalar(m, condition(m.prevision, k, observation))
 
 # ── Prevision-level scalar condition methods (Move 7: Move 5 completion) ──
 
-function condition(p::BetaPrevision, k::Kernel, observation)
+function condition(p::BetaPrevision, k::Kernel, observation; n::Int=64)
     cp = maybe_conjugate(p, k)
     if cp !== nothing
         return update(cp, observation).prior
     end
-    conditioned = condition(wrap_in_measure(p), k, observation)
-    conditioned.prevision
+    # Bernoulli fast-path (relocated from the Measure facade): conjugate-shaped integer update on [0,1].
+    if k.source isa Interval && k.target isa Finite && length(k.target.values) == 2
+        (observation == 1 || observation == 1.0 || observation == true)  && return BetaPrevision(p.alpha + 1.0, p.beta)
+        (observation == 0 || observation == 0.0 || observation == false) && return BetaPrevision(p.alpha, p.beta + 1.0)
+    end
+    _condition_by_grid(p, k, observation; n=n)   # Prevision-native grid → QuadraturePrevision (measure-as-view Phase 2)
 end
 
 function condition(p::TaggedBetaPrevision, k::Kernel, observation)
@@ -1290,13 +1284,12 @@ function log_predictive(p::RhoCategoricalPrevision, k::Kernel, reports)
     log(max(after / before, 1e-300))
 end
 
-function condition(p::GaussianPrevision, k::Kernel, observation)
+function condition(p::GaussianPrevision, k::Kernel, observation; n::Int=64)
     cp = maybe_conjugate(p, k)
     if cp !== nothing
         return update(cp, observation).prior
     end
-    conditioned = condition(wrap_in_measure(p), k, observation)
-    conditioned.prevision
+    _condition_by_grid(p, k, observation; n=n)   # Prevision-native grid → QuadraturePrevision (measure-as-view Phase 2)
 end
 
 # A multivariate Gaussian is conditioned only through its LinearGaussian
@@ -1311,13 +1304,12 @@ function condition(p::MvGaussianPrevision, k::Kernel, observation)
           "the kernel with likelihood_family = LinearGaussian(coeffs, sigma_obs).")
 end
 
-function condition(p::GammaPrevision, k::Kernel, observation)
+function condition(p::GammaPrevision, k::Kernel, observation; n_particles::Int=1000)
     cp = maybe_conjugate(p, k)
     if cp !== nothing
         return update(cp, observation).prior
     end
-    conditioned = condition(wrap_in_measure(p), k, observation)
-    conditioned.prevision
+    _condition_particle(p, k, observation; n_particles=n_particles)   # Prevision-native particle → ParticlePrevision (measure-as-view Phase 2)
 end
 
 function condition(p::DirichletPrevision, k::Kernel, observation)
@@ -1338,43 +1330,56 @@ function condition(p::NormalGammaPrevision, k::Kernel, observation)
           "space context; use NormalGammaMeasure for non-conjugate kernels")
 end
 
+# NOTE: measure-as-view Phase 3 (#163) — backwards delegation; Product threads a per-factor DATA carrier
+# (cat.space.values) and returns a MixtureMeasure — inverts with the mixture-twin collapse.
 function condition(p::ProductPrevision, k::Kernel, obs; kwargs...)
     conditioned = condition(wrap_in_measure(p), k, obs; kwargs...)
     conditioned isa MixtureMeasure ? conditioned.prevision : conditioned.prevision
 end
 
-function _condition_by_grid(m::BetaMeasure, k::Kernel, observation; n::Int=64)
-    grid = collect(range(m.space.lo + 1e-10, m.space.hi - 1e-10, length=n))
+# Prevision-native grid quadrature (measure-as-view Phase 2): the space-free posterior over the
+# type-constant support (Beta: Interval(0,1) — `log_density_at` already encodes the [0,1] closed form, so
+# the bounds are the type-constant 0/1; Gaussian: μ±4σ). Returns a carrier-free QuadraturePrevision; the
+# Measure facade re-binds the Finite(grid) carrier.
+function _condition_by_grid(p::BetaPrevision, k::Kernel, observation; n::Int=64)
+    grid = collect(range(0.0 + 1e-10, 1.0 - 1e-10, length=n))
     logw = Float64[]
     for (i, h) in enumerate(grid)
-        lp = log_density_at(m, h)
+        lp = log_density_at(p, h)
         ll = density(k, h, observation)
         !isnan(ll) || error("density returned NaN for hypothesis $i")
         push!(logw, lp + ll)
     end
-    qp = QuadraturePrevision(grid, logw)
-    CategoricalMeasure(Finite(qp.grid), qp)
+    QuadraturePrevision(grid, logw)
 end
+_condition_by_grid(m::BetaMeasure, k::Kernel, observation; n::Int=64) =
+    (q = _condition_by_grid(m.prevision, k, observation; n=n); CategoricalMeasure(Finite(q.grid), q))
 
-function _condition_by_grid(m::GaussianMeasure, k::Kernel, observation; n::Int=64)
-    lo = m.mu - 4 * m.sigma
-    hi = m.mu + 4 * m.sigma
+function _condition_by_grid(p::GaussianPrevision, k::Kernel, observation; n::Int=64)
+    lo = p.mu - 4 * p.sigma
+    hi = p.mu + 4 * p.sigma
     grid = collect(range(lo, hi, length=n))
     logw = Float64[]
     for (i, h) in enumerate(grid)
-        lp = log_density_at(m, h)
+        lp = log_density_at(p, h)
         ll = density(k, h, observation)
         !isnan(ll) || error("density returned NaN for hypothesis $i")
         push!(logw, lp + ll)
     end
-    qp = QuadraturePrevision(grid, logw)
-    CategoricalMeasure(Finite(qp.grid), qp)
+    QuadraturePrevision(grid, logw)
 end
+_condition_by_grid(m::GaussianMeasure, k::Kernel, observation; n::Int=64) =
+    (q = _condition_by_grid(m.prevision, k, observation; n=n); CategoricalMeasure(Finite(q.grid), q))
 
 log_density_at(m::BetaMeasure, x) = (m.alpha - 1) * log(x) + (m.beta - 1) * log(1 - x)
 log_density_at(m::GammaMeasure, x) = (m.alpha - 1) * log(x) - m.beta * x
 log_density_at(m::TaggedBetaMeasure, x) = log_density_at(m.beta, x)
 log_density_at(m::GaussianMeasure, x) = -0.5 * ((x - m.mu) / m.sigma)^2
+
+# Prevision-native log-densities (measure-as-view Phase 2): identical closed forms to the Measure methods
+# above (field-for-field; m.alpha === m.prevision.alpha), so the relocated grid is bit-identical.
+log_density_at(p::BetaPrevision, x) = (p.alpha - 1) * log(x) + (p.beta - 1) * log(1 - x)
+log_density_at(p::GaussianPrevision, x) = -0.5 * ((x - p.mu) / p.sigma)^2
 
 # ── TruncatedGaussianPrevision: a continuous bounded prior, integrated over [lo,hi] engine-side ──
 # The truncation is the model's SUPPORT (not a grid); the engine chooses the quadrature internally.
@@ -1518,12 +1523,7 @@ end
 # families by this marginal, so it MUST be exact — the generic `_predictive_ll(::Measure)` Monte-Carlo
 # fallback is approximate and non-deterministic. Non-conjugate kernels fall back to the generic path
 # (preserving existing behaviour); the exact closed form is added only for the recognised pair.
-function _predictive_ll(m::GaussianMeasure, k::Kernel, obs)
-    k.likelihood_family isa NormalNormal ||
-        return invoke(_predictive_ll, Tuple{Measure, Kernel, Any}, m, k, obs)
-    s2 = m.prevision.sigma^2 + k.likelihood_family.sigma_obs^2     # marginal var = prior var + obs var
-    -0.5 * (log(2π * s2) + (Float64(obs) - m.prevision.mu)^2 / s2) # N(obs | μ₀, √(σ₀²+σ²))
-end
+_predictive_ll(m::GaussianMeasure, k::Kernel, obs) = _predictive_ll(m.prevision, k, obs)  # facade (measure-as-view Phase 2)
 
 function _predictive_ll(m::NormalGammaMeasure, k::Kernel, obs)
     k.likelihood_family isa NormalGammaLikelihood ||
@@ -1535,10 +1535,7 @@ function _predictive_ll(m::NormalGammaMeasure, k::Kernel, obs)
     _loggamma((ν + 1) / 2) - _loggamma(ν / 2) - 0.5 * log(ν * π * s2) - ((ν + 1) / 2) * log1p(z / ν)
 end
 
-function _predictive_ll(m::BetaMeasure, k::Kernel, obs)
-    val = expect(m, h -> exp(k.log_density(h, obs)))
-    log(max(val, 1e-300))
-end
+_predictive_ll(m::BetaMeasure, k::Kernel, obs) = _predictive_ll(m.prevision, k, obs)  # facade (measure-as-view Phase 2)
 
 function _predictive_ll(m::TaggedBetaMeasure, k::Kernel, obs)
     k.log_density(m, obs)
@@ -1582,8 +1579,10 @@ end
 
 # ── Prevision-level _predictive_ll (Move 7: supports MixturePrevision condition) ──
 
+# Prevision-primary (measure-as-view Phase 2): the predictive is an expectation; expect(p) is carrier-free
+# (and, post-Phase-1, the path the Measure facade already routed through).
 _predictive_ll(p::BetaPrevision, k::Kernel, obs) =
-    _predictive_ll(wrap_in_measure(p), k, obs)
+    (val = expect(p, h -> exp(k.log_density(h, obs))); log(max(val, 1e-300)))
 
 _predictive_ll(p::TaggedBetaPrevision, k::Kernel, obs) =
     k.log_density(p, obs)
@@ -1598,12 +1597,22 @@ function _predictive_ll(p::LabelledCategoricalPrevision, k::Kernel, obs)
     logsumexp([lw[i] + categorical_logdensity(fam, i, obs) for i in eachindex(lw)])
 end
 
-_predictive_ll(p::GaussianPrevision, k::Kernel, obs) =
-    _predictive_ll(wrap_in_measure(p), k, obs)
+# Prevision-primary (measure-as-view Phase 2): the NormalNormal closed form; the non-conjugate fallback
+# routes to the generic Measure sampler via invoke (loop-safe — skips this family's own Measure facade).
+function _predictive_ll(p::GaussianPrevision, k::Kernel, obs)
+    k.likelihood_family isa NormalNormal ||
+        return invoke(_predictive_ll, Tuple{Measure, Kernel, Any}, wrap_in_measure(p), k, obs)
+    s2 = p.sigma^2 + k.likelihood_family.sigma_obs^2                # marginal var = prior var + obs var
+    -0.5 * (log(2π * s2) + (Float64(obs) - p.mu)^2 / s2)           # N(obs | μ₀, √(σ₀²+σ²))
+end
 
+# NOTE: measure-as-view Phase 3 (#163) — backwards delegation; Gamma predictive is sampling (no fixture),
+# routed through the generic Measure sampler — inverts with the discrete/sampling catch-alls.
 _predictive_ll(p::GammaPrevision, k::Kernel, obs) =
     _predictive_ll(wrap_in_measure(p), k, obs)
 
+# NOTE: measure-as-view Phase 3 (#163) — backwards delegation; generic catch-all whose draw/expect bind
+# the DATA carrier for the discrete families (CategoricalPrevision has no carrier-free draw).
 function _predictive_ll(p::Prevision, k::Kernel, obs)
     _predictive_ll(wrap_in_measure(p), k, obs)
 end
@@ -1615,6 +1624,8 @@ function log_predictive(m::Measure, k::Kernel, obs)
     log(max(pred, 1e-300))
 end
 
+# NOTE: measure-as-view Phase 3 (#163) — backwards delegation; generic catch-all binding the discrete DATA
+# carrier (see _predictive_ll(::Prevision) above).
 function log_predictive(p::Prevision, k::Kernel, obs)
     log_predictive(wrap_in_measure(p), k, obs)
 end
@@ -1809,6 +1820,16 @@ function condition(m::ProductMeasure, k::Kernel, obs; kwargs...)
     end
 
     MixtureMeasure(m.space, new_components, new_log_wts)
+end
+
+# Prevision-native importance-sampling fallback (measure-as-view Phase 2): draws from the Prevision
+# (draw(p) ≡ draw(m) in RNG ops for the scalar families — bit-identical under fixed seed), returns the
+# carrier-free ParticlePrevision; the Measure facade re-binds Finite(samples). The Measure overload below
+# is the Phase-3 catch-all (arbitrary m, draw over a discrete carrier) — left byte-for-byte unchanged.
+function _condition_particle(p::Prevision, k::Kernel, obs; n_particles::Int=1000, seed::Int=0)
+    samples = [draw(p) for _ in 1:n_particles]
+    log_weights = Float64[k.log_density(s, obs) for s in samples]
+    ParticlePrevision(samples, log_weights, seed)
 end
 
 function _condition_particle(m::Measure, k::Kernel, obs; n_particles::Int=1000, seed::Int=0)

--- a/test/test_measure_view_condition.jl
+++ b/test/test_measure_view_condition.jl
@@ -1,0 +1,137 @@
+# test_measure_view_condition.jl — Phase 2 of the measure-as-view arc.
+#
+# Inverts the BACKWARDS DELEGATION in `condition`/`_predictive_ll` for the continuous-scalar families
+# (Beta/Gaussian/Gamma) to Prevision-primary, restoring "Measure is a declared view over Prevision"
+# (`prevision-not-measure`). Pre-Phase-2 the non-conjugate fallbacks round-tripped `condition(p)` →
+# `wrap_in_measure(p)` → `condition(::Measure)` (the Prevision reaching its own behaviour through its
+# view). Post-Phase-2: the Prevision owns the space-free posterior (grid → QuadraturePrevision, particle
+# → ParticlePrevision); the Measure facade owns the carrier RE-BIND (`Measure binds carrier; Prevision
+# does not`).
+#
+# The 5/4 gate split (design doc §1): the continuous families have a TYPE-RECOVERABLE support
+# (Interval(0,1)/Euclidean(1)/PositiveReals, read off the Prevision type), so they invert here. The
+# discrete/Product/catch-all sites bind a DATA-valued carrier (CategoricalPrevision has no carrier-free
+# `draw`) and defer to Phase 3 (#163).
+#
+# Capture-before-refactor REUSES test/fixtures/particle_canonical_v1.jls (SHA 173411b, `==` tol) — the
+# same canonical vectors test_prevision_particle.jl asserts on the Measure entry points, now asserted on
+# the Prevision entry points. No new capture: `draw(p::GammaPrevision)` ≡ `draw(m::GammaMeasure)` in RNG
+# ops, so the relocation is bit-identical under fixed seed. Per precedents.md §4 the `==` class is NOT
+# relaxable to rtol.
+#
+# Run from repo root:
+#     julia test/test_measure_view_condition.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: BetaPrevision, GaussianPrevision, GammaPrevision, ParticlePrevision,
+                QuadraturePrevision, condition, wrap_in_measure
+using Credence.Ontology: _predictive_ll
+using Random
+using Serialization
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+
+const CANON = open(deserialize, joinpath(@__DIR__, "fixtures", "particle_canonical_v1.jls"))
+
+# Kernels mirror test_prevision_particle.jl EXACTLY so the canonical fixture values apply to the
+# Prevision entry points (non-conjugate → grid/particle fallback).
+const K_GAMMA = Kernel(PositiveReals(), Euclidean(1),
+                       λ -> error("generate not used"), (λ, o) -> -0.5 * (o - λ)^2;
+                       likelihood_family = PushOnly())
+const K_BETA  = Kernel(Interval(0.0, 1.0), Euclidean(1),
+                       θ -> error("generate not used"), (θ, o) -> -0.5 * (o - θ)^2;
+                       likelihood_family = PushOnly())
+const K_GAUSS = Kernel(Euclidean(1), Euclidean(1),
+                       μ -> error("generate not used"), (μ, o) -> log(max(o, 1e-300));
+                       likelihood_family = PushOnly())
+
+println("="^64)
+println("measure-as-view Phase 2 — condition inversion (scalar, carrier re-bind)")
+println("Fixture SHA: $(CANON[:source_sha]); Julia $(CANON[:julia_version])")
+println("="^64)
+
+# ── (1) Prevision-entry non-conjugate == canonical (the inversion, bit-exact, no new capture) ──
+let
+    Random.seed!(42)
+    pg = condition(GammaPrevision(2.0, 3.0), K_GAMMA, 2.5; n_particles = 50)
+    check("condition(GammaPrevision) non-conjugate → ParticlePrevision (Prevision-primary)",
+          pg isa ParticlePrevision, "got $(typeof(pg))")
+    check("Gamma particle samples == canonical (Prevision-entry, ==)",
+          pg.samples == CANON[:gamma_generic_samples])
+    check("Gamma particle log_weights == canonical (Prevision-entry, ==)",
+          pg.log_weights == CANON[:gamma_generic_logw])
+end
+let
+    Random.seed!(42)
+    pb = condition(BetaPrevision(2.0, 3.0), K_BETA, 0.5)
+    check("condition(BetaPrevision) non-conjugate → QuadraturePrevision (Prevision-primary)",
+          pb isa QuadraturePrevision, "got $(typeof(pb))")
+    check("Beta grid values == canonical (Prevision-entry, ==)", pb.grid == CANON[:beta_grid_values])
+    check("Beta grid log_weights == canonical (Prevision-entry, ==)",
+          pb.log_weights == CANON[:beta_grid_logw])
+end
+let
+    Random.seed!(42)
+    pgs = condition(GaussianPrevision(0.0, 1.0), K_GAUSS, 1.5)
+    check("condition(GaussianPrevision) non-conjugate → QuadraturePrevision (Prevision-primary)",
+          pgs isa QuadraturePrevision, "got $(typeof(pgs))")
+    check("Gaussian grid values == canonical (Prevision-entry, ==)",
+          pgs.grid == CANON[:gaussian_grid_values])
+    check("Gaussian grid log_weights == canonical (Prevision-entry, ==)",
+          pgs.log_weights == CANON[:gaussian_grid_logw])
+end
+
+# ── (2) Facade equivalence: Measure-entry still yields the same carrier-bound Measure (== canonical) ──
+let
+    Random.seed!(42)
+    mg = condition(wrap_in_measure(GammaPrevision(2.0, 3.0)), K_GAMMA, 2.5; n_particles = 50)
+    check("Gamma Measure facade .space.values == canonical", mg.space.values == CANON[:gamma_generic_samples])
+    check("Gamma facade wraps a ParticlePrevision", mg.prevision isa ParticlePrevision)
+    check("Gamma facade shared-ref preserved (.prevision.samples === .space.values)",
+          mg.prevision.samples === mg.space.values)
+end
+let
+    Random.seed!(42)
+    mb = condition(wrap_in_measure(BetaPrevision(2.0, 3.0)), K_BETA, 0.5)
+    check("Beta Measure facade .space.values == canonical grid", mb.space.values == CANON[:beta_grid_values])
+    check("Beta facade wraps a QuadraturePrevision", mb.prevision isa QuadraturePrevision)
+end
+
+# ── (3) Conjugate arm: facade threads m.space (Q3 — preserve the DSL-declared carrier, ===) ──
+let
+    k_conj = Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]), _ -> error("not used"),
+                    (h, o) -> o == 1.0 ? log(max(h, 1e-300)) : log(max(1 - h, 1e-300));
+                    likelihood_family = BetaBernoulli())
+    sp = Interval(0.0, 1.0)
+    m = BetaMeasure(sp, 2.0, 3.0)
+    post = condition(m, k_conj, 1.0)
+    check("Beta conjugate facade → BetaMeasure", post isa BetaMeasure, "got $(typeof(post))")
+    check("Beta conjugate exact: α = 3.0 after obs = 1", post.alpha == 3.0, "got $(post.alpha)")
+    check("Beta conjugate exact: β = 3.0 unchanged", post.beta == 3.0, "got $(post.beta)")
+    check("Q3: m.space threaded (===), not canonicalised", post.space === sp)
+    # The Prevision-entry conjugate arm stays Prevision-primary (untouched by Phase 2):
+    pc = condition(BetaPrevision(2.0, 3.0), k_conj, 1.0)
+    check("condition(BetaPrevision) conjugate → BetaPrevision(3,3) (unchanged)",
+          pc isa BetaPrevision && pc.alpha == 3.0 && pc.beta == 3.0)
+end
+
+# ── (4) _predictive_ll inversion: Prevision-entry == Measure-entry (Beta expect, Gaussian NormalNormal) ──
+let
+    pll_p = _predictive_ll(BetaPrevision(2.0, 3.0), K_BETA, 0.5)
+    pll_m = _predictive_ll(wrap_in_measure(BetaPrevision(2.0, 3.0)), K_BETA, 0.5)
+    check("Beta _predictive_ll: Prevision-entry == Measure-entry (==)", pll_p == pll_m, "p=$pll_p m=$pll_m")
+
+    k_nn = Kernel(Euclidean(1), Euclidean(1), μ -> error("unused"), (μ, o) -> -0.5 * (o - μ)^2;
+                  likelihood_family = NormalNormal(1.0))
+    gll_p = _predictive_ll(GaussianPrevision(0.0, 1.0), k_nn, 1.5)
+    gll_m = _predictive_ll(wrap_in_measure(GaussianPrevision(0.0, 1.0)), k_nn, 1.5)
+    check("Gaussian _predictive_ll: Prevision-entry == Measure-entry (NormalNormal, ==)",
+          gll_p == gll_m, "p=$gll_p m=$gll_m")
+end
+
+println("="^64)
+println("ALL CHECKS PASSED — measure-as-view Phase 2")
+println("="^64)


### PR DESCRIPTION
## measure-as-view — Phase 2

Inverts the **backwards delegation** in `condition`/`_predictive_ll` for the continuous-scalar families, restoring **"Measure is a declared view over Prevision"** (`prevision-not-measure`) for the carrier-binding axiom-constrained function. Phase 1 (#162, merged) did the carrier-free `expect`; Phase 2 is the carrier-binding `condition`.

Pre-Phase-2 the non-conjugate fallbacks round-tripped `condition(p)` → `wrap_in_measure(p)` → `condition(::Measure)` — the constitutionally-primary Prevision reaching its own behaviour *through its view*. Now the **Prevision owns the space-free posterior**; the **Measure facade owns the carrier re-bind**.

### The gate refined the scope — the structural-vs-data carrier seam

Running the carrier-space gate (`grep '.space'` across the 9 delegated-to methods, then classifying each read) split them **5 clean / 4 binding**:

- **5 clean** (this PR): the *continuous* families have a **type-recoverable** support — `Interval(0,1)`/`Euclidean(1)`/`PositiveReals`, read off the Prevision type — so `draw`/`expect` produce values with no carrier in hand. They invert with a thin re-bind at the facade.
- **4 binding** (deferred → #163): `condition(::ProductPrevision)` (threads a per-factor **data** carrier `cat.space.values`, returns a `MixtureMeasure`) and the three generic catch-alls, whose `draw`/`expect` need the carrier for the *discrete* families. The seam: **`condition` is carrier-free exactly when the carrier is structure, and must be handed it exactly when the carrier is data** — confirmed by `CategoricalPrevision` holding only `log_weights`, with **no `draw(::CategoricalPrevision)`** (only `draw(::CategoricalMeasure)`). Giving the discrete carrier a Prevision-native home is the same act as collapsing the mixture twins — which is why these belong to Phase 3.

### What changes

- `condition(p::BetaPrevision/GaussianPrevision)` non-conjugate → Prevision-native `_condition_by_grid` → `QuadraturePrevision` (the Bernoulli fast-path relocated to `BetaPrevision`). `condition(p::GammaPrevision)` → Prevision-native `_condition_particle` → `ParticlePrevision`.
- `_predictive_ll(p::BetaPrevision)` → `expect(p, …)` (carrier-free; post-Phase-1 the path the Measure already routed through). `_predictive_ll(p::GaussianPrevision)` → NormalNormal closed form (non-NN fallback via `invoke`, loop-safe).
- `condition`/`_predictive_ll(m::BetaMeasure/GaussianMeasure/GammaMeasure)` reduce to thin facades: `_rebind_scalar(m, condition(m.prevision, …))`. **Family-staying results thread `m.space`** (preserve the DSL-declared carrier from `eval.jl`); grid/particle results bind a fresh `Finite` carrier.

### §5 ratified (2026-06-28)

- **Q1 — defer Product + the 3 catch-alls to Phase 3 (#163).** Adjacency not guaranteed, so each of the 4 live sites carries a `# NOTE: measure-as-view Phase 3 (#163)` marker — the half-state (a Prevision round-tripping its own view) is **owned, not silent**. Product is **not** swallowed into the safe scalar move.
- **Q2 — local `_rebind_scalar`** (respects `QuadraturePrevision`'s deliberate no-`wrap_in_measure` stance; particle case reuses the existing `wrap_in_measure(::ParticlePrevision)`).
- **Q3 — thread `m.space`** (preserve the DSL-declared carrier), not canonicalise.

### One dispatch subtlety, caught and preserved

The *old* no-kwarg scalar Measure methods let `condition(m; n_particles=N)` fall through to the generic particle catch-all (kwarg-compatibility filtering) — TEST 18's particle-override of the grid default. A `; n` kwarg on the facade blocked that fall-through. Fix: the scalar Measure facades stay **no-kwarg**, restoring the exact pre-Phase-2 dispatch; the Prevision methods carry the kwargs. Grep confirms no consumer overrides the grid `n` on a Measure.

### Capture-before-refactor — no new fixture

Reuses the commit-pinned `particle_canonical_v1.jls` (`==` tolerance): `test_measure_view_condition.jl` asserts the **Prevision entry points** reproduce the same canonical grid/particle vectors `test_prevision_particle.jl` asserts on the **Measure entry points** (bit-exact: `draw(p) ≡ draw(m)` in RNG ops under seed 42), plus facade equivalence, `m.space` threading (`===`), and the predictive inversion. Pure structural inversion — every assertion is `==`/`===`/`rtol`, no intended behaviour change.

### Verification

`test_measure_view_condition.jl` 22/22 · **full Julia suite 46/46** (incl. `test_structure_bma`, `test_rho_latent`, `test_product_bma_routing`, `test_family_bma`, `test_flat_mixture`, `test_host`, `test_persistence`, qa_benchmark set) · lint corpus self-test + `check apps/` (0 violations) · **skin wire smoke all passed** (condition over the wire intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
