### PR TITLE
exploration-budget Move 1: :remove_rule completes the MDL compression pair

### DIFF
--- a/docs/collapse-towers/master-plan.md
+++ b/docs/collapse-towers/master-plan.md
@@ -183,6 +183,12 @@ grammar. Benchmark drift (greedy-vs-random) is intended; update `test_program_sp
    new feature/threshold until it lands), so sequenced as the *immediate, adjacent* successor to this
    arc — shortest possible gap between "breach closed" and "exploration restored."
 
+> **Successors scoped 2026-06-28 → `docs/exploration-budget/master-plan.md`.** Both named successors
+> (Scope B + the EU-priced exploration budget) are folded into one arc, `exploration-budget`, opened
+> after `measure-as-view` closed. Its thesis: price generative-change discovery as compute-budgeted
+> lookahead VOI against the belief's residual, saturation-gated, EU-max (no `rand`, no cap). Thesis
+> pending ratification before the move sequence finalises.
+
 ## Files
 
 **Create:** `src/complexity.jl`, `src/net_value.jl` (and likely `src/family_bma.jl`);

--- a/docs/exploration-budget/DESIGN-DOC-TEMPLATE.md
+++ b/docs/exploration-budget/DESIGN-DOC-TEMPLATE.md
@@ -1,0 +1,83 @@
+# Phase-N design doc template (collapse-towers)
+
+Every `docs/collapse-towers/phase-N-design.md` uses this structure. Reviewers reject design docs that omit the "Open design questions" section, or that fill it with questions whose answer is obvious from this branch's master plan or from the code.
+
+The template exists because design-doc-before-code earns its keep only if the docs surface real arguments rather than restating the implementation prose. If a section feels like sugar around an already-decided implementation, treat that as a signal that the move is either smaller than it looked or already done — not a signal to ship the design doc.
+
+See `docs/precedents.md` — the canonical reference file for recurring patterns and precedent slugs; consult before drafting §5 Open design questions and §6 Risk + mitigation, where most precedents apply. This arc's master plan is `docs/collapse-towers/master-plan.md`.
+
+---
+
+## 1. Purpose
+
+One paragraph. What this move accomplishes; what foundational need it serves; what unblocks once it's in.
+
+Avoid restating the master plan's framing. Reference it instead: "Move N as scoped in the master plan, with the following additions/refinements …"
+
+## 2. Files touched
+
+Exhaustive list. For each file, give:
+- Path and line range (e.g. `src/ontology.jl:561-654`).
+- One-line description of what changes.
+- Whether this is a new file, a modification, or a deletion.
+
+If the move adds a new test file, list it here too.
+
+## 3. Behaviour preserved
+
+What the strata-1, strata-2, and strata-3 tests will assert about pre-/post-refactor equivalence. State the tolerance for each assertion class explicitly:
+
+- Strata-1 (unit equivalence): `isapprox(atol=1e-14)`.
+- Strata-2 conjugate paths: `isapprox(rtol=1e-12)`.
+- Strata-2 particle paths under deterministic seeding: `isapprox(rtol=1e-12)`.
+- Strata-3 end-to-end: `isapprox(rtol=1e-10)` — halt-the-line at greater drift.
+
+If this move legitimately needs looser tolerance for a particular test (e.g. parallelism that didn't exist before reorders particle samples), name the test, the relaxation, and the justification.
+
+## 4. Worked end-to-end example
+
+Trace one representative call through the new dispatch, naming which module owns each step. Pick a call that exercises the move's centrepiece — e.g. a `condition` through the new conjugate registry, an `expect` through the new TestFunction dispatch.
+
+**This section is mandatory** for any move that introduces or extends dual residency (a type, value, or hook present in both an old home and a new home — e.g. Move 5's `FiringByTag` relocation, where the value lives on the kernel side for construction but the routing semantics live on the prevision side). Without the worked example, the design doc fails review.
+
+The worked example should:
+- Pick concrete inputs (e.g. `BetaPrevision(2.0, 3.0)`, `obs = 1`).
+- Trace the full call chain step by step, showing which module/function owns each step.
+- State the result, with the arithmetic that produces it.
+- If dual residency is present, name which home is authoritative at each step.
+
+## 5. Open design questions
+
+1-3 specific points where Claude Code is expected to argue back during review of this design doc. Empty or boilerplate is grounds for revision.
+
+Legitimate question shapes:
+- **Sibling vs derived:** "should X be a sibling primitive or a derived form?"
+- **Option choice:** "we pick (a) cleaner separation or (b) more uniform dispatch?"
+- **Category check:** "is this category-different from the type it would inherit from?"
+- **Scope question:** "should we fold Y into this move or defer to Move N+1?"
+- **Invariant tradeoff:** "preserving X breaks Y; which do we keep?"
+
+Questions whose answer is obvious from the master plan or the code are not real open questions. Surface them as resolved decisions in §1 or §3 instead.
+
+If genuinely no design questions remain — e.g. the move is mechanical type-aliasing — say so explicitly: "No open design questions for this move. The implementation is determined by the master plan; reviewers are invited to challenge that claim."
+
+## 6. Risk + mitigation
+
+What could go wrong; what test catches it.
+
+For each risk, give:
+- The failure mode (e.g. "particle filtering silently reorders samples after the constructor refactor").
+- The blast radius (which test files / which downstream moves break).
+- The mitigation (e.g. "Strata-2 particle test pinned to seeded RNG with 1e-12 tolerance; pre-refactor sample sequence captured in `test/fixtures/particle_seed_42_v1.jls` and asserted byte-equal post-refactor").
+
+Risks the master plan named for this move are repeated here with current-state additions.
+
+**Suggested practice for moves that refactor consumer-visible types:** include a pre-emptive grep step under the relevant risk entry. Run `grep -rn '<pattern>'` across `src/`, `test/`, `apps/`, `docs/`; list each hit and its disposition (mechanical replacement / no edit needed / needs attention). Example: Move 2's grep for `<: Functional`, `isa Functional`, `::Functional` when aliasing the `Functional` hierarchy onto `TestFunction`. Not mandatory — not every risk benefits from a grep — but the default is: if you're renaming or aliasing a type that appears in method signatures or runtime checks, grep for it before the PR opens. Moves that don't touch consumer-visible types (e.g. cosmetic adaptations) don't need the grep.
+
+## 7. Verification cadence
+
+Which test files run at end of the corresponding code PR. Cite the bash invocations explicitly so reviewers can reproduce.
+
+For Moves 3, 4, 6, 7 this section must include the skin smoke test (`python -m skin.test_skin`) — those moves change what crosses the JSON-RPC boundary. For Moves 1, 2, 5, 8 the skin smoke test is optional.
+
+Halt-the-line conditions: any test failure at end-of-PR is a halt. No "will fix in next commit" states; the branch never sleeps with a red suite.

--- a/docs/exploration-budget/master-plan.md
+++ b/docs/exploration-budget/master-plan.md
@@ -1,0 +1,191 @@
+# Credence — Core-library engine arc: *exploration-budget* (master plan)
+
+> Durable, in-repo master plan for the `exploration-budget` branch family. A thematic engine arc
+> (unnumbered, like `collapse-towers`, `decouple`, `measure-as-view`). It **discharges the two named
+> successors collapse-towers deferred** (`docs/collapse-towers/master-plan.md` §"Named successors"):
+> **Scope B (`:remove_rule`)** and the **EU-priced exploration budget**. Phase-5 of collapse-towers
+> retired the `rand` breach by shipping *Scope A* (`:add_rule` only, depth-one prior VOC) and explicitly
+> named this arc as the *immediate, adjacent* successor — because Scope A leaves the agent unable to
+> discover **any** new feature or threshold until it lands. Each move: design-doc-before-code
+> (`docs/exploration-budget/DESIGN-DOC-TEMPLATE.md`), each commit green + bisectable, **stop-and-report at
+> every move boundary.**
+>
+> **STATUS: DRAFT — thesis pending ratification (2026-06-28).** Per the thesis-first discipline, the move
+> sequence below is *provisional*; it is not finalised until §3 (the thesis) and §5 (open questions) are
+> ratified. Do not open Move 1's design doc until then.
+
+## 1. Context — what Scope A left undone, and why it is hard
+
+After collapse-towers, `perturb_grammar(g, freq_table, available_features; compute_cost)` is **prior-only
+and depth-one** (`perturbation.jl`). It does exactly one thing: `:add_rule` — define a frequent posterior
+subtree as a nonterminal when `net_voc = Δcomplexity_logprior − compute_cost > 0`. This is the
+**compression class** — it re-describes the *same* hypotheses more compactly (a prior effect), and
+depth-one VOC over `(g, freq_table)` can value it exactly (`net_payoff`).
+
+Everything that grows the agent's *expressiveness* was deferred, for a reason that is structural, not
+incidental (collapse-towers Phase-5 R2, ratified): the **generative-change class** —
+`:modify_threshold`, `:add_feature`, `:remove_feature` — changes *which* hypotheses the grammar
+generates. Its value is a **likelihood effect over programs not in the current ensemble** — the
+escape-mass / Cromwell frontier — and is **invisible to depth-one prior-only VOC by construction**. You
+cannot price the value of a hypothesis you have not yet entertained from the prior alone; the prior over
+the un-entertained region is exactly what the complexity prior truncates so the tower does not regress
+(SPEC §1.3). Phase-5's resolution was honest: exclude the three, defer them, *never* re-introduce `rand`
+or an arbitrary deterministic tiebreak (that only launders the breach).
+
+Concretely, today (Explore audit, 2026-06-28):
+- **Features** are `Set{Symbol}` in `Grammar`, fixed for the grammar's life; **no path adds one.**
+- **Thresholds** are a hard-coded `const THRESHOLDS = [0.1,0.3,0.5,0.7,0.9]` (`enumeration.jl:9`),
+  applied uniformly; **no path refines them.** A threshold constant is complexity-invariant
+  (`expr_complexity(::GTExpr)=1`), so `:modify_threshold` leaves the prior *identically* unchanged — it
+  is purely a fit effect.
+- `available_features` is **accepted but unused** in Scope A — the placeholder hook for this arc.
+- The `freq_table` is **lossy at `min_complexity=2`** (drops bare-reference programs), which is the
+  precise reason Scope B (`:remove_rule`) is blocked: it cannot supply a *sound* nonterminal reference
+  count, only an estimable-not-provably-sound one (the stall gate's concern).
+
+## 2. The architectural crux (R1, redux) — exploration is belief-aware; compression is not
+
+Phase-5 R1 established that `perturb_grammar` is prior-only *by signature*: it receives no belief, no
+utilities, no programs, no re-conditioning — so it can only price the prior. **That is exactly why the
+generative-change class cannot live inside it.** The value of expanding the alphabet is realised only
+against the **belief's predictive residual** — where the current posterior-weighted ensemble
+*mispredicts the data* — and measuring it requires re-enumeration + re-conditioning (the very forward
+inference the metalevel is deciding whether to spend). So the load-bearing structural decision of this
+arc:
+
+> **The exploration budget is a *belief-aware* meta-action, categorically distinct from the prior-only
+> compression op.** Compression (Scope A/B) stays in `perturb_grammar` (prior currency, depth-one,
+> wire-stable). Exploration (thresholds, features) is a *new* belief-aware entry that does
+> **compute-budgeted lookahead** against the residual. The host orchestrates the two; they are never
+> conflated.
+
+This is the `measure-as-view` lesson transposed: just as carrier-bound ops are Measure-resident (not a
+wart but the view relationship working), **belief-dependent value is belief-level (host/belief-aware),
+not prior-level** — and the bright line between them is the architecture, not a defect.
+
+## 3. The thesis (the falsifiable claim — RATIFY FIRST)
+
+> **Generative-change grammar discovery can be made EU-max — not random, not capped — by pricing
+> alphabet expansion as *compute-budgeted lookahead value-of-information against the belief's predictive
+> residual*, gated on *saturation* of the current discrete partition.**
+
+Mechanism. Depth-one prior-only VOC cannot see generative-change value (R2). So the agent spends a
+**compute budget** to do **depth-≥1 lookahead**: for a candidate threshold/feature, *actually* expand
+the grammar, re-enumerate, re-condition against the (residual of the) belief, and measure the **realised
+value gain**. How much lookahead to spend — how many candidates, how deep — is itself `argmax EU` with
+**compute in the utility** (resource-rational, graceful degradation, *no hard cap* — the standing
+metareason-not-cliff direction). **Saturation is the precondition**: explore only when compression has
+exhausted *and* the residual has plateaued within the current alphabet, because that is exactly when
+expansion has positive expected VOI. The escalation is **fine-before-coarse** (the discrete partition
+must demonstrably saturate before continuous features are admissible): compress → saturate → refine
+thresholds (finer partition *within* features) → add features (new dimensions) → (far future) continuous
+features / embeddings.
+
+This is not new doctrine. It is the heuristics-inside-EU-max clause (CLAUDE.md Invariant 1: *"when
+computational cost enters the utility … it is the optimal strategy"*) and the complexity-prior /
+escape-mass framing (SPEC §1.3/§1.4) applied to the *metalevel's own* discovery problem. Exploration
+strategies (UCB/Thompson/ε-greedy) are *not forbidden as concepts* — but they must **emerge** as
+EU-optimal under the compute-priced VOI, never be hard-coded.
+
+**Falsifiable predictions (the empirical gates):**
+1. **Discovery:** on a task whose optimal predicate is *outside* the initial alphabet, the
+   saturation-gated residual-driven explorer finds it; Scope A alone provably cannot (it never expands).
+2. **Dominance:** it beats both (a) the retired *random* exploration and (b) a *fixed-schedule /
+   fixed-budget* baseline, on sample-efficiency or final realised value.
+3. **Graceful degradation:** under a tighter compute budget it explores *less* (fewer/shallower
+   lookaheads) and the explore/exploit split moves *smoothly* with the budget — never a cliff, never a
+   crash, never a hard cap.
+
+If the thesis does not survive review — in particular if no cheap-enough residual signal or lookahead
+makes prediction 3 hold without a cap — the arc **stalls at this master plan**; we do not ship a guess
+(the same stall gate Phase 5 honoured).
+
+## 4. Provisional move skeleton (pending §3/§5 ratification)
+
+Scope B and the exploration budget are **one arc** (coupled: they share the perturbation machinery, and
+Scope B completes the compression pair that makes *saturation* precisely definable — the precondition for
+exploration). Five provisional moves:
+
+- **Move 1 — Complete the compression pair: Scope B (`:remove_rule`) + a sound reference count.**
+  Discharge the Scope-B deferral. Fix the lossy-`freq_table` blocker so the nonterminal reference count
+  is *provably sound* (OQ-4). With add+remove, the dictionary is hygiene-complete and **saturation gets a
+  precise prior-side definition** (no compression op improves the prior). Prior-only, depth-one — extends
+  the existing `net_voc`. Foundational; no belief needed yet.
+- **Move 2 — The saturation signal (the belief-aware meta-level entry).** Define + implement saturation:
+  compression exhausted (Move 1) **and** the belief's predictive residual plateaued. This is the first
+  belief-aware meta computation; it establishes the entry point exploration will hang off, and it makes
+  *explore-vs-exploit* an EU comparison (expected compression value vs expected exploration VOI).
+- **Move 3 — Compute-budgeted lookahead VOI for threshold refinement.** The cheapest, safest
+  generative-change op: adaptive thresholds (the hard-coded grid becomes refinable *within* existing
+  features). Establishes the lookahead-VOC mechanism (re-enumerate/re-condition a candidate, measure
+  realised gain, EU-max over how much lookahead, saturation-gated). Fine-before-coarse: refine before
+  adding.
+- **Move 4 — Feature discovery (`:add_feature` / `:remove_feature`).** Add a feature from
+  `available_features`, priced by the Move-3 lookahead-VOC, gated on threshold-refinement saturating.
+  `:remove_feature` reuses Move 1's reference-count soundness.
+- **Move 5 — The combined single-currency `argmax` (close the collapse-towers headline).** Fold
+  compression (exploit, prior currency) and exploration (expand, lookahead-utility currency) into **one**
+  `argmax EU` with compute in the utility — the *"combined single-currency `argmax` over object-and-meta
+  space"* Phase-5 named as "the next escape-mass frontier." This makes the metalevel literally one
+  `optimise`, completing collapse-towers' headline. May fold into Move 4 or stand alone (OQ-5).
+
+Each move lands design-doc-then-code; the empirical predictions (§3) are checked at Moves 3–5 on a
+purpose-built task (a paper-style figure, per the paper-as-gating-artifact discipline if this feeds a
+publication).
+
+## 5. Open design questions (ratify before finalising the move sequence)
+
+1. **The valuation mechanism (the thesis's heart).** Compute-budgeted **lookahead** (actually
+   re-enumerate/re-condition candidates — honest VOI, exact, expensive, budget-bounded) **vs** a cheaper
+   **surrogate** (a hyper-prior over feature relevance + an emergent-from-EU bandit). *Recommendation:
+   lookahead* — it is the honest value-of-information, the budget bounds the cost, and a surrogate risks
+   smuggling in a non-EU exploration rule (the thing Invariant 1 forbids unless it *emerges*). Counter to
+   weigh: lookahead may be too expensive to make prediction-3 (graceful degradation) hold cheaply.
+2. **The architectural home (R1 redux, §2).** A *new belief-aware entry* (`explore_grammar(belief, g,
+   available_features; compute_budget)`, separate from prior-only `perturb_grammar`) **vs** extending
+   `perturb_grammar` to optionally carry the belief/residual. *Recommendation: separate entry* — keeps
+   compression prior-only and wire-stable, and reflects the compression-is-prior / exploration-is-belief
+   distinction. Counter: two entry points the host must orchestrate vs one.
+3. **The saturation definition / residual metric.** Compression-exhausted *alone* (prior-only, simple)
+   **vs** compression-exhausted *+ residual-plateau* (belief-aware, the real precondition per the
+   saturation-precondition direction). If the latter: *which* residual metric — predictive log-loss
+   plateau, posterior-entropy plateau, or held-out fit? *Recommendation: the belief-aware definition*
+   (saturation must be *demonstrated*, not assumed); metric TBD in Move 2's design doc, leaning
+   predictive-log-loss-plateau on recent observations.
+4. **The Scope-B soundness fix (OQ-4).** Lower `min_complexity` for reference-scanning (cheap, but
+   changes `freq_table` semantics for everyone) **vs** thread an explicit nonterminal reference count
+   through enumeration (cleaner, more work, sound by construction). *Recommendation: explicit reference
+   count* — Scope B was deferred *precisely* because the estimate wasn't provably sound; a real count
+   removes the stall-gate concern rather than papering it.
+5. **Does Move 5 actually close the headline?** Is "the metalevel is one `argmax EU`" achievable once
+   exploration has a (lookahead-derived) utility-currency value commensurable with compression's prior
+   value — or does the currency gap Phase-5 flagged remain, leaving Move 5 a *named* frontier rather than
+   a *closed* one? *Recommendation: attempt it at Move 5; if the commensurability doesn't hold honestly,
+   stop and name it* (do not force a fake common currency — the Phase-5 precedent).
+
+## 6. Hard constraints (inherited)
+
+Spec-first; design-doc-before-code; stop-and-report at every move boundary; **no new constitutional
+text** (if a move seems to need it, stop and report); **no `rand` / no arbitrary tiebreak in action
+selection** (the breach Phase 5 closed stays closed — exploration is EU-max or it does not ship); **no
+hard compute cap** (metareason fidelity against a budget — graceful degradation); heuristics live
+*inside* EU-max, never alongside it; no silent approximations (an approximation ships only if a strict
+Bayesian/EU argument validates it — else stall); tolerance inside the boolean; no `using Test`;
+**capture-before-refactor** on every behaviour-preserving step (canonical values pinned PRE-change,
+asserted `==`); seeded-RNG `==` for any sampling lookahead. `λ` per-axis (program axis pinned `ln 2`).
+
+## 7. Key risks
+
+1. **Lookahead too expensive / prediction-3 fails (the stall risk).** If compute-budgeted lookahead
+   cannot degrade gracefully without a cap, the thesis fails — *stall at this plan*, do not cap.
+   Mitigation: Move 2's saturation gate sharply bounds *when* lookahead runs (only post-saturation), and
+   the budget bounds *how much*; if even that is too costly, escalate rather than approximate.
+2. **Scope-B reference-count unsoundness (OQ-4).** A rule referenced only in low-complexity contexts
+   misread as dead → `:remove_rule` corrupts the dictionary. Mitigation: a *sound* count (recommendation
+   3 above), or do not ship Scope B (keep the deferral honest).
+3. **Benchmark drift / capability-vs-cleanliness.** Restoring exploration changes grid_world /
+   email_agent trajectories (intended — it restores a capability Scope A removed). Capture-before-refactor
+   pins the *mechanism*; the *behavioural* change is the point and is documented per move.
+4. **Over-scoping (the thesis-first risk this plan guards against).** Five moves is the *ceiling*; if the
+   thesis ratifies a cheaper mechanism (OQ-1 surrogate, OQ-5 no combined argmax), the arc shrinks. The
+   skeleton is provisional precisely so it can.

--- a/docs/exploration-budget/master-plan.md
+++ b/docs/exploration-budget/master-plan.md
@@ -10,9 +10,10 @@
 > (`docs/exploration-budget/DESIGN-DOC-TEMPLATE.md`), each commit green + bisectable, **stop-and-report at
 > every move boundary.**
 >
-> **STATUS: DRAFT — thesis pending ratification (2026-06-28).** Per the thesis-first discipline, the move
-> sequence below is *provisional*; it is not finalised until §3 (the thesis) and §5 (open questions) are
-> ratified. Do not open Move 1's design doc until then.
+> **STATUS: RATIFIED 2026-06-28 (author).** Thesis ratified — and sharpened: the selection/generation
+> seam (§3.1) scopes what each move may *claim*. All five open questions ratified as recommended, with the
+> reasoning strengthened from "preferred" to "forced" where it is forced (§5). The move sequence is final.
+> Move 1's design doc may open.
 
 ## 1. Context — what Scope A left undone, and why it is hard
 
@@ -100,11 +101,58 @@ If the thesis does not survive review — in particular if no cheap-enough resid
 makes prediction 3 hold without a cap — the arc **stalls at this master plan**; we do not ship a guess
 (the same stall gate Phase 5 honoured).
 
-## 4. Provisional move skeleton (pending §3/§5 ratification)
+### 3.1 What is EU-max here, and what is the irreducible residue (selection vs generation)
 
-Scope B and the exploration budget are **one arc** (coupled: they share the perturbation machinery, and
-Scope B completes the compression pair that makes *saturation* precisely definable — the precondition for
-exploration). Five provisional moves:
+The thesis makes candidate **selection** EU-max — lookahead VOI *ranks* candidates. It presupposes a
+candidate *set* to rank, and where that set comes from — candidate **generation** — is not itself priced
+by the lookahead. The two halves of the arc differ exactly here, and the victory must be scoped to match:
+
+- **Thresholds — EU-max *generative* discovery, claimed without hedging.** A threshold only matters at an
+  *observed* value, so the observed values **are** the complete, finite candidate set. Generation is
+  trivial and exhaustive; lookahead ranks all of them; the selection *is* the generation. For thresholds
+  the frontier closes fully — this is the move that earns the arc's headline.
+- **Features — EU-max *selection over a residual-proposed set*; novel-feature synthesis is the standing
+  frontier.** A feature is an arbitrary function of the observations, so the candidate set is unbounded
+  and something must **propose** which features to look ahead over. That proposer is doing hypothesis
+  *construction* — and (as established in the founding exchange) metareasoning *allocates inference over a
+  hypothesis space; it does not build one*. A proposer that enumerates **combinations of existing
+  features** (products, conjunctions, feature×threshold predicates) stays tractable and near-complete and
+  is legitimately within EU-max selection. The moment a proposer must synthesise a *genuinely novel
+  dimension*, it is at the **creative floor**, and no pricing makes that step EU-derived. **Move 4 may
+  therefore claim "EU-max selection among proposed features," never "EU-max feature generation"**; novel
+  synthesis is named as a permanent frontier — the same floor the project's first exchange identified, now
+  made architectural. (This is *why* fine-before-coarse: threshold refinement is fully closable, feature
+  combination is closable, novel features are not — the escalation is ordered by how much of generation
+  the lookahead can absorb.)
+
+### 3.2 The two-tier resource-rational structure (why the regress terminates)
+
+The expensive lookahead is made tractable by a cheap belief-aware *screen*. The four mechanisms divide
+the labour and truncate the metalevel regress at the right place:
+
+> **residual screens *where* · saturation gates *when* · the compute budget bounds *how many* · lookahead
+> evaluates the survivors.**
+
+Without the residual screen the lookahead would range over everything and the regress would not terminate;
+the residual is the cheap signal that nominates a *small* survivor set for the expensive exact evaluation.
+
+### 3.3 Gate 3 is the one that will bite — and the cap is forbidden
+
+Predictions 1–2 (discovery, dominance) are almost certainly demonstrable. Prediction 3 (smooth
+degradation without a cap) depends on the candidate-VOI distribution having **no cliff**, which cannot be
+guaranteed a priori — so the stall gate is *genuine* and *will be tested under pressure*: the agent cannot
+explore **at all** until this lands, so there will be a strong pull to ship a *capped* version and call it
+graceful. **Do not.** A hard cap is the non-EU lever the constitution forbids (metareason fidelity against
+a budget, never a cliff). "We shipped something" is *worse* than "we stalled honestly" here, because a
+capped explorer that *looks* like it works is harder to dislodge than an absent one. If gate 3 cannot hold
+without a cap, stall and escalate.
+
+## 4. Move sequence (ratified 2026-06-28)
+
+Scope B and the exploration budget are **one arc** — and the coupling is causal, not cosmetic: **Scope B
+*enables* Move 2.** "Compression is exhausted" — half of the saturation gate — is *undefinable* until the
+compression pair (add + remove) is complete, so Scope B is a genuine precondition, not a rider. Five
+moves:
 
 - **Move 1 — Complete the compression pair: Scope B (`:remove_rule`) + a sound reference count.**
   Discharge the Scope-B deferral. Fix the lossy-`freq_table` blocker so the nonterminal reference count
@@ -116,24 +164,59 @@ exploration). Five provisional moves:
   belief-aware meta computation; it establishes the entry point exploration will hang off, and it makes
   *explore-vs-exploit* an EU comparison (expected compression value vs expected exploration VOI).
 - **Move 3 — Compute-budgeted lookahead VOI for threshold refinement.** The cheapest, safest
-  generative-change op: adaptive thresholds (the hard-coded grid becomes refinable *within* existing
-  features). Establishes the lookahead-VOC mechanism (re-enumerate/re-condition a candidate, measure
-  realised gain, EU-max over how much lookahead, saturation-gated). Fine-before-coarse: refine before
-  adding.
-- **Move 4 — Feature discovery (`:add_feature` / `:remove_feature`).** Add a feature from
-  `available_features`, priced by the Move-3 lookahead-VOC, gated on threshold-refinement saturating.
-  `:remove_feature` reuses Move 1's reference-count soundness.
-- **Move 5 — The combined single-currency `argmax` (close the collapse-towers headline).** Fold
-  compression (exploit, prior currency) and exploration (expand, lookahead-utility currency) into **one**
-  `argmax EU` with compute in the utility — the *"combined single-currency `argmax` over object-and-meta
-  space"* Phase-5 named as "the next escape-mass frontier." This makes the metalevel literally one
-  `optimise`, completing collapse-towers' headline. May fold into Move 4 or stand alone (OQ-5).
+  generative-change op, and the one that **fully closes EU-max *generative* discovery** (§3.1): a threshold
+  matters only at *observed* values, so the observed values *are* the complete finite candidate set —
+  generation is exhaustive, lookahead ranks all of it. Establishes the lookahead-VOC mechanism
+  (re-enumerate/re-condition a candidate, measure realised gain, EU-max over how much lookahead,
+  saturation-gated). This move earns the arc's headline; claim it without hedging.
+- **Move 4 — Feature discovery (`:add_feature` / `:remove_feature`).** Add a feature from a
+  **residual-proposed candidate set** — proposals are *combinations of existing features* (products,
+  conjunctions, feature×threshold predicates), which keeps generation tractable and near-complete — priced
+  by the Move-3 lookahead-VOC, gated on threshold-refinement saturating. **Claim: "EU-max *selection* among
+  proposed features," never "EU-max feature *generation*"** (§3.1); novel-dimension synthesis is named as
+  the standing creative frontier, not implemented. `:remove_feature` reuses Move 1's reference-count
+  soundness.
+- **Move 5 — The combined single-currency `argmax`: attempt, expect to stop (close-or-name the headline).**
+  Exploration's lookahead VOI is *already* in utility (realised value gain), so it unifies with the object
+  level for free — the lone outlier is **compression**, priced in prior nats. So the combined `argmax`
+  faces *one* question, not two currencies: can compression's nats become utility? The prediction is **no,
+  and stopping is correct**: compression is cheap *because* it is depth-one prior-priced; pricing it in
+  utility means pricing it by lookahead, which makes it as expensive as exploration and **destroys the
+  cheap-screen-first ordering the whole design rests on**. So the currency gap is not a representational
+  accident to convert away — it is the **signature of the two compute tiers** (cheap prior screen vs
+  expensive utility lookahead). Move 5 attempts the unification, and on hitting this, **names it a permanent
+  frontier with that reasoning** (Phase-5 precedent — do not force a fake common currency). May fold into
+  Move 4 (OQ-5).
 
 Each move lands design-doc-then-code; the empirical predictions (§3) are checked at Moves 3–5 on a
 purpose-built task (a paper-style figure, per the paper-as-gating-artifact discipline if this feeds a
 publication).
 
-## 5. Open design questions (ratify before finalising the move sequence)
+## 5. Open design questions
+
+> **All five RATIFIED as recommended 2026-06-28 (author), reasoning strengthened:**
+> - **Q1 — lookahead, *forced* not merely preferred.** The surrogate is not just "risks a non-EU rule" —
+>   it is **unsound by the same R2 argument that motivates the arc**: a hyper-prior over the relevance of
+>   features *outside* the current alphabet is a prior over the un-entertained region, exactly what the
+>   complexity prior truncates so the tower does not regress. There is no sound surrogate there *by
+>   construction*; lookahead is the only honest valuation. If it is too costly → **stall**, never fall back
+>   to the unsound surrogate.
+> - **Q2 — new `explore_grammar`, *forced* by R1.** Threading a belief into prior-only `perturb_grammar`
+>   breaks the wire and collapses the prior/belief seam the design rests on. Two entry points is not a cost
+>   — it is **the seam made visible in the types** (the measure-as-view transposition: carrier-free
+>   Prevision / carrier-bound Measure ↦ prior-only compression / belief-aware exploration).
+> - **Q3 — compression-exhausted *and* residual-plateau.** Tie "compression-exhausted" to the existing
+>   `net_voc ≤ 0` so the **prior-side half is free**; Move 2's real work is the *belief-side* plateau metric.
+>   Compression-exhausted-alone assumes what must be shown.
+> - **Q4 — explicit reference count.** This is precisely what "blocked on a sound reference count" was
+>   waiting for. The lossy `freq_table` cannot supply soundness; lowering `min_complexity` changes
+>   `freq_table` semantics for *every* consumer (non-local blast radius for a local need). Thread the count
+>   — sound by construction.
+> - **Q5 — attempt, expect to stop; the currency gap *is* the architecture** (see Move 5, §4). Name it a
+>   permanent frontier with the two-compute-tiers reasoning, rather than forcing a conversion that would
+>   quietly defeat cheap compression.
+>
+> The prose below is retained as the rationale of record.
 
 1. **The valuation mechanism (the thesis's heart).** Compute-budgeted **lookahead** (actually
    re-enumerate/re-condition candidates — honest VOI, exact, expensive, budget-bounded) **vs** a cheaper

--- a/docs/exploration-budget/move-1-design.md
+++ b/docs/exploration-budget/move-1-design.md
@@ -1,0 +1,189 @@
+# Move 1 design doc — Complete the compression pair: `:remove_rule` + a sound reference count
+
+> Move 1 of the `exploration-budget` arc (`docs/exploration-budget/master-plan.md`). Seven-section
+> template. Discharges collapse-towers' **Scope B** named successor. Prior-only, depth-one — extends the
+> existing `net_voc` machinery; **no belief, no lookahead yet** (those start at Move 2).
+
+## 1. Purpose
+
+Scope A made `perturb_grammar` monotonic: it only ever *grows* the dictionary (`:add_rule`), never prunes.
+Move 1 completes the **MDL compression pair** by adding `:remove_rule` — drop a nonterminal that the
+posterior has abandoned — and the **sound nonterminal reference count** that collapse-towers deferred it
+on (Scope B was blocked precisely because the lossy `freq_table` could not tell "referenced" from "dead"
+soundly; Q4-ratified fix: thread an explicit count through the analysis). Two payoffs:
+
+1. **Dictionary hygiene** — a rule no posterior-support program references is pure dead weight; removing it
+   raises the complexity prior (`Δcomplexity_logprior > 0`) at **zero fit cost** (no support program
+   changes), so it is genuinely prior-only and `net_voc`-rankable — the symmetric partner of `:add_rule`.
+2. **It *enables* Move 2.** "Compression is exhausted" — the prior-side half of the saturation gate — is
+   *undefinable* until the compression pair is complete. After Move 1, `perturb_grammar`'s no-op (returns
+   `g` unchanged) **is** the prior-saturation signal: no `:add_rule` and no `:remove_rule` raises the
+   prior. Move 2 conjoins that with the belief-side residual plateau.
+
+**Strict, by ratified default (`always strict`).** A rule is removable iff **zero posterior-support
+programs reference it** — strict structural reference, counted exactly by a full-AST walk. The weighted
+"Σ-weight < ε" variant is an unvalidated fit approximation and is out by construction. "Posterior support"
+reuses the engine's *existing* support floor (`w > 1e-15`, the filter `analyse_posterior_subtrees` already
+applies, `perturbation.jl:28`) — not a new approximation but the engine's own definition of the
+ensemble; strict-strict `w > 0` is *degenerate* (enumeration always re-references a dictionary rule with
+some sub-floor weight, so it would never fire), so "strict over the posterior support" is the strict
+reading that is not vacuous. Removal is therefore prior-only **with respect to the belief's support** —
+exact, since only sub-floor programs reference the removed rule and those are not in the belief.
+
+## 2. Files touched
+
+- **`src/program_space/types.jl`** — *modify*: add a fourth field `referenced_nonterminals::Set{Symbol}`
+  to `SubprogramFrequencyTable` (the set of NT names referenced by ≥1 posterior-support program). Add an
+  inner/convenience constructor defaulting it to `Set{Symbol}()` so the existing 3-arg
+  `SubprogramFrequencyTable(subtrees, freqs, sources)` call sites (tests that hand-build tables) keep
+  compiling and get the **Scope-A-preserving** default (empty ⇒ every rule "referenced-unknown" ⇒ no rule
+  removable ⇒ `:add_rule`-only behaviour bit-for-bit).
+- **`src/program_space/perturbation.jl`** — *modify*:
+  - `analyse_posterior_subtrees`: add a reference-counting pass. For each program with `w > 1e-15` (the
+    *same* filter the subtree loop uses), walk the full AST collecting `NonterminalRef` names at **all
+    depths** (not the depth-≥`min_complexity` `extract_subtrees` — that lossiness is exactly what made the
+    old count unsound). Union into `referenced_nonterminals`. Populate the new field.
+  - **Add** `_removal_payoff(g, freq_table) → Vector{Tuple{ProductionRule, Int}}`: for each rule `r` with
+    `r.name ∉ freq_table.referenced_nonterminals`, the dictionary-shrink saving is
+    `net_payoff = 1 + expr_complexity(r.body)` symbols (the rule's full cost, recovered). Referenced rules
+    are **not** candidates (removing them is generative-change — deferred).
+  - **Generalise** `perturb_grammar` from "the single `:add_rule` candidate" to "the `argmax`-`net_voc`
+    candidate over the **compression class** = {the `:add_rule` candidate} ∪ {`:remove_rule` candidates}".
+    Apply the best iff `net_voc > 0`, else the same structural no-op (return `g`, same id). Determinism
+    preserved (no `rand`); tiebreak per §5-OQ2.
+  - The `:add_rule` path (`_compression_payoff`, the idempotence guard, the no-op-returns-`g` invariant) is
+    **unchanged**; `:remove_rule` is a second candidate source feeding the same `argmax`.
+- **`src/Credence.jl`** — *modify*: export `_removal_payoff` only if a test references it by name
+  (otherwise internal).
+- **`test/test_program_space.jl`** — *modify*: extend the perturbation tests (TEST 14 neighbourhood) with
+  `:remove_rule` cases (see §7); the existing `:add_rule` / determinism assertions stay green unchanged.
+- **`test/test_voc_gate.jl`** — *modify*: add the `:remove_rule` `net_voc` arithmetic + the
+  argmax-over-the-pair determinism case.
+- **`test/test_perturb_consumption.jl`** — *verify unchanged*: the no-op-returns-same-id invariant is
+  untouched (a `:remove_rule` no-op returns `g` identically).
+
+## 3. Behaviour preserved
+
+- **`:add_rule` is bit-exact.** With `referenced_nonterminals` empty (hand-built tables) or with no dead
+  rule (the common case: a freshly-added rule is referenced), `_removal_payoff` returns `[]`, the
+  candidate set is the singleton `:add_rule`, and the `argmax` reduces to today's gate — `===` on the
+  resulting `(feature_set, rules)`. The degenerate reduction.
+- **`net_voc` is unchanged** — `:remove_rule` reuses it (`net_voc(1 + expr_complexity(body), compute_cost)`),
+  no new currency, no new arithmetic.
+- **The no-op invariant holds** — a no-op (no positive-`net_voc` candidate) returns the input `g` (same
+  id), so `add_programs_to_state!`'s id-keyed dedup is unaffected (`test_perturb_consumption`).
+- **Schema-change safety** — the new `Set{Symbol}` field defaults empty; capture-before-refactor: every
+  existing perturbation/program-space test stays green with no edit *except* the new `:remove_rule` cases.
+- Tolerance: strata-1 `==`/`===` on grammar structure (id excluded — `next_grammar_id()` is a counter).
+
+## 4. Worked end-to-end example
+
+A grammar `g` with `feature_set = {:red,:green,:blue}` and `rules = [NT_a → And(GT(:red,0.7), LT(:green,0.3)),
+NT_b → GT(:blue,0.5)]`. The posterior (after conditioning) is concentrated on programs using `NT_a`; the
+programs that used `NT_b` have all dropped below `w = 1e-15`. `compute_cost = 0.0`.
+
+1. `analyse_posterior_subtrees(programs, weights)` walks the support programs (`w > 1e-15`); the
+   reference pass finds `NT_a` referenced, `NT_b` not → `referenced_nonterminals = {:NT_a}`. *(owner:
+   `perturbation.jl`)*
+2. `perturb_grammar(g, freq_table, feats)` → candidate set:
+   - `:add_rule`: `_compression_payoff(freq_table)` — say it finds no subtree with `net_payoff > 0` →
+     no add candidate.
+   - `:remove_rule`: `_removal_payoff(g, freq_table)` — `NT_b ∉ {:NT_a}` → candidate `(remove NT_b,
+     net_payoff = 1 + expr_complexity(GT(:blue,0.5)) = 1 + 1 = 2)`. `NT_a` is referenced → not a candidate.
+3. `net_voc(2, 0.0) = log(2)·2 = 1.386 > 0` → the singleton `argmax` is "remove `NT_b`". *(owner: `net_voc`
+   → `net_value`/`complexity_logprior`)*
+4. Apply → `Grammar({:red,:green,:blue}, [NT_a → …], next_grammar_id())`. The dictionary shrank by the dead
+   rule; **no support program changed** (none referenced `NT_b`), so the belief is untouched — prior-only.
+5. **Determinism:** a second call on the same `(g, freq_table)` runs the identical `argmax` → same
+   `(feature_set, rules)`, different id.
+
+Contrast: had `NT_b` been referenced (`:NT_b ∈ referenced_nonterminals`), it would not be a candidate, and
+with no add candidate `perturb_grammar` returns `g` unchanged — the **prior-saturation no-op** Move 2 reads.
+
+## 5. Open design questions
+
+> **Resolved by ratified defaults (stated, not asked):** the reference-count *home* is
+> `analyse_posterior_subtrees` (Q4 — thread through the analysis); the reference *semantics* is **strict
+> over the posterior support** (`always strict`; `w > 0` is degenerate, §1). These are not open.
+
+1. **Schema change vs a sidecar.** Add the field to `SubprogramFrequencyTable` (recommended — the count is
+   *of* the analysed ensemble, it belongs with the other per-ensemble summaries; one type, one analysis
+   pass) **vs** return a separate `referenced_nonterminals` structure threaded alongside (avoids touching
+   the struct, but splits one analysis into two return values and forces every caller to thread both).
+   *Recommendation: add the field, with the empty-default constructor for backward-compat.* Counter to
+   weigh: does any **serialised** consumer pin `SubprogramFrequencyTable`'s arity? Pre-emptive grep in §6;
+   if `test_persistence` serialises it, the schema bump needs a fixture (it almost certainly does not —
+   the freq_table is transient, recomputed each step).
+2. **Tiebreak when `:add_rule` and a `:remove_rule` have equal `net_voc`.** Determinism (Phase-5) forbids
+   `rand` *and* an arbitrary tiebreak — but a tie here is between two ops of *genuinely equal, exactly
+   computed* prior value, so a *principled stable* order is not "laundering arbitrariness" (the Phase-5
+   concern was tiebreaking *unknown* values). *Recommendation: lexicographic — prefer `:remove_rule` over
+   `:add_rule` on ties (hygiene-first: shrink before grow, all else equal), then by `rule.name` hash for a
+   total order.* Surface because the *direction* (remove-first vs add-first) is a real, if rarely-exercised,
+   choice you may have a view on. Alternative: rank by resulting `grammar.complexity` (identical on a
+   `net_voc` tie, so it does not actually break the tie — rejected).
+3. **One perturbation per call, or all positive-`net_voc` candidates at once?** *Recommendation: one per
+   call (the `argmax`), as today* — the host already loops `perturb_grammar`, each perturbation is
+   independently `net_voc`-gated, and one-at-a-time keeps the no-op/saturation signal crisp (a call is a
+   no-op iff *nothing* improves the prior). Batching would compound multiple structural edits behind one
+   id bump and muddy the saturation read Move 2 depends on.
+
+## 6. Risk + mitigation
+
+- **R1 — unsound reference count removes a live rule.** *Failure mode:* a rule referenced only inside
+  depth-1 / low-complexity contexts is missed → wrongly removed → a support program silently breaks.
+  *Mitigation:* the count walks the **full AST at all depths** (not `extract_subtrees`'s depth-≥`min_c`
+  lossy path — that lossiness is the exact bug Scope B was deferred on); over the **same** `w > 1e-15`
+  support set the analysis already uses. Test: a rule referenced *only* at depth 1 (a bare
+  `NonterminalRef`) is in `referenced_nonterminals` and is **not** removed (the regression the freq_table's
+  `min_complexity=2` would have caused).
+- **R2 — schema bump breaks a hand-built `freq_table` call site.** *Blast radius:* every test/app that
+  constructs `SubprogramFrequencyTable(...)` positionally. *Mitigation:* empty-default constructor keeps
+  the 3-arg form valid (Scope-A-preserving); **pre-emptive grep** `grep -rn 'SubprogramFrequencyTable('
+  src/ apps/ test/` — list each hit, confirm it either uses the 3-arg form (gets the default) or is
+  `analyse_posterior_subtrees` (populates the field). Also `grep -rn 'SubprogramFrequencyTable' test/test_persistence.jl`
+  — confirm it is **not** serialised (no fixture needed); if it is, capture a v-bump fixture.
+- **R3 — benchmark drift (grid_world / email_agent).** *Failure mode:* `:remove_rule` now fires where it
+  never did → enumerated-program sets shift → `test_email_agent` TEST 12 `n_added` / grid_world counts
+  move. *Mitigation:* drift is **intended** (a new capability — dictionary pruning); capture the new
+  deterministic values post-change and assert `==` thereafter; name it in the commit. (Likely *no* drift
+  in practice — removal only fires on posterior-abandoned rules, which the short benchmark runs rarely
+  produce.)
+- **R4 — `:remove_rule` + `:add_rule` thrash** (add a rule, next step remove it, re-add…). *Failure mode:*
+  a rule oscillates in/out across steps. *Mitigation:* it cannot oscillate within the strict semantics —
+  a rule is removed only when *unreferenced by the support*, and `:add_rule` only adds a rule for a
+  *frequent* (referenced-to-be) subtree; the two target disjoint conditions. A test conditions a belief
+  onto a subtree (so `:add_rule` fires), then away (so the rule goes unreferenced and `:remove_rule`
+  fires) and asserts the sequence terminates at a no-op (saturation), not a cycle.
+- **Lint:** `perturb_grammar` stays a canalised stdlib composition (the `argmax`-over-`net_voc` *is* the
+  canalisation); no pragma, no new precedent. Confirm corpus self-test + `check apps/` stay green.
+
+## 7. Verification cadence
+
+End of Move-1 code (from repo root; Julia tests not CI-gated):
+```
+julia test/test_program_space.jl      # :remove_rule cases + :add_rule/determinism unchanged
+julia test/test_voc_gate.jl           # net_voc on the remove payoff + argmax-over-pair determinism
+julia test/test_perturb_consumption.jl
+julia test/test_email_agent.jl        # benchmark drift (if any), captured == thereafter
+```
+Then the **full** `test/test_*.jl` suite + lint corpus self-test (`python tools/credence-lint/credence_lint.py
+test`) + `check apps/`, and **stop and report**. Skin smoke **optional** — `perturb_grammar`'s positional
+signature is unchanged (the new behaviour is internal candidate generation), so the wire verb
+`handle_perturb_grammar` is unaffected; run it anyway as a cheap consumption-surface confirmation.
+
+`test_program_space.jl` / `test_voc_gate.jl` new assertions (repo `check(name, cond, detail)` idiom):
+- **Remove a dead rule:** a grammar with an unreferenced rule + a `freq_table` whose
+  `referenced_nonterminals` omits it ⇒ `perturb_grammar` removes exactly that rule (`==` on resulting
+  rules, id excluded); `net_voc` of the removal `== log(2)·(1 + expr_complexity(body))` (oracle pragma).
+- **Keep a referenced rule:** the same rule, now in `referenced_nonterminals` ⇒ **not** removed
+  (structural no-op or an `:add_rule` instead).
+- **Depth-1 reference is seen (R1):** a rule referenced *only* by a bare `NonterminalRef` is retained.
+- **`:add_rule` degenerate reduction:** with no dead rule, `perturb_grammar` is `===` to today's
+  `:add_rule` result (capture-before-refactor).
+- **Determinism + tiebreak:** two runs on identical `(g, freq_table)` ⇒ structurally identical grammar;
+  an add≡remove `net_voc` tie resolves to the §5-OQ2 order deterministically.
+- **Saturation no-op (the Move-2 hook):** when neither add nor remove has `net_voc > 0`, `perturb_grammar`
+  returns `g` with the **same id** (the prior-saturation signal).
+
+Halt-the-line: any failure at end-of-PR is a halt; the branch never sleeps red.

--- a/docs/exploration-budget/move-1-design.md
+++ b/docs/exploration-budget/move-1-design.md
@@ -32,12 +32,21 @@ exact, since only sub-floor programs reference the removed rule and those are no
 
 ## 2. Files touched
 
-- **`src/program_space/types.jl`** — *modify*: add a fourth field `referenced_nonterminals::Set{Symbol}`
-  to `SubprogramFrequencyTable` (the set of NT names referenced by ≥1 posterior-support program). Add an
-  inner/convenience constructor defaulting it to `Set{Symbol}()` so the existing 3-arg
+- **`src/program_space/types.jl`** — *modify*: add a fourth field
+  `referenced_nonterminals::Union{Nothing, Set{Symbol}}` to `SubprogramFrequencyTable` (the set of NT names
+  referenced by ≥1 posterior-support program, or `nothing` when no analysis has run). Add a 3-arg
+  convenience constructor defaulting it to **`nothing`** so the existing 3-arg
   `SubprogramFrequencyTable(subtrees, freqs, sources)` call sites (tests that hand-build tables) keep
-  compiling and get the **Scope-A-preserving** default (empty ⇒ every rule "referenced-unknown" ⇒ no rule
-  removable ⇒ `:add_rule`-only behaviour bit-for-bit).
+  compiling and get the **Scope-A-preserving** default. **Encoding correction (grounding, 2026-06-28):**
+  the original `Set{Symbol}` default `Set{Symbol}()` does **not** achieve "no rule removable" — the removal
+  predicate is `r.name ∉ referenced`, and `r.name ∉ ∅` is *vacuously true*, so an empty set would make
+  **every** rule removable (the opposite of intent). An empty set also cannot distinguish "analysed, zero
+  references found" (⇒ rules genuinely dead ⇒ remove them) from "not analysed" (⇒ unknown ⇒ remove
+  nothing) — opposite behaviours. `Union{Nothing, Set{Symbol}}` with `nothing` = "not analysed" is the
+  encoding that realises the doc's own intent: `nothing` ⇒ `_removal_payoff` returns `[]` (no candidates);
+  a concrete `Set` (possibly empty — a genuinely-empty analysed set legitimately means "all rules dead") ⇒
+  candidates are rules whose name is absent from it. `analyse_posterior_subtrees` **always** populates a
+  concrete `Set`.
 - **`src/program_space/perturbation.jl`** — *modify*:
   - `analyse_posterior_subtrees`: add a reference-counting pass. For each program with `w > 1e-15` (the
     *same* filter the subtree loop uses), walk the full AST collecting `NonterminalRef` names at **all
@@ -187,3 +196,42 @@ signature is unchanged (the new behaviour is internal candidate generation), so 
   returns `g` with the **same id** (the prior-saturation signal).
 
 Halt-the-line: any failure at end-of-PR is a halt; the branch never sleeps red.
+
+## 8. Ratification + grounding amendments (2026-06-28)
+
+Ratified by the owner. Four binding amendments folded in (the first is the §2 encoding correction above;
+the rest refine §5/§7):
+
+1. **Field encoding → `Union{Nothing, Set{Symbol}}`, default `nothing`** (§2, above). Forced: the
+   empty-`Set` default is vacuously all-removable and conflates "analysed-empty" with "unknown."
+2. **Q1 — resolved *free*, not a capture.** Pre-emptive grep done: `test_persistence.jl` has **zero**
+   references to `SubprogramFrequencyTable` / `freq_table` / `analyse_posterior_subtrees` — the table is
+   transient, recomputed each step. The schema bump needs **no fixture**. The four `SubprogramFrequencyTable(`
+   call sites are `perturbation.jl:53` (the real builder — populates the field) + three hand-built *empty*
+   tables (`test_program_space:530`, `test_perturb_consumption:25`, `test_voc_gate:83`) — all the 3-arg form
+   the `nothing`-default constructor preserves.
+3. **Q2 — total order is lexicographic `rule.name`, NOT `hash(Symbol)`.** Direction stays remove-first
+   (hygiene: shrink before grow), but the within-tie total order is a **string compare on the name**, not a
+   hash. Rationale (owner): Julia's `hash` is stable within a session but **not guaranteed across Julia
+   versions** (the algorithm has changed between releases); since the entire point of the tiebreak is
+   cross-version-reproducible determinism, a lexicographic name compare is stable where the hash is not, at
+   no cost. The Phase-5-safety logic is ratified: the prohibition was on tiebreaking *unknown* values
+   (feigned indifference you can't compute); here the values are *computed and exactly equal*, so any choice
+   is genuinely argmax-optimal and a stable order is honest disambiguation, not laundered arbitrariness.
+   *Owner note (recorded, changes nothing): the direction is consequence-free* — removal is prior-only, so
+   the add and remove classes are independent (doing one never changes whether the other is positive); on a
+   tie **both** fire across successive calls regardless of order, and the saturated fixed point is identical
+   either way. Remove-first wins only on the thin Move-2 ground of keeping the saturated grammar minimal (a
+   cleaner residual-read baseline). Taken on that basis.
+4. **The reference walk is its own full-depth function** `collect_nonterminal_refs!`, recursing to **all
+   depths and all branches** (predicate AND action branches of `IfExpr`), with a method per `ProgramExpr`
+   subtype and **no generic fallback** (fail-loud on a future node type, matching `_extract!` /
+   `expr_complexity`). It is **never** routed through `extract_subtrees(min_complexity)` — that is the exact
+   Scope-B unsoundness (the `min_complexity=2` filter drops bare depth-1 references). Named and separate
+   precisely so a future refactor cannot silently fold it back into the filtered extraction. The R1 test
+   (§7, "depth-1 reference is seen") is the guard that fails against the unsound variant.
+5. **Soundness pin — the prior-only claim is an assertion, not prose** (§7 addition). A `:remove_rule` test
+   verifies, via an **independent oracle** (`show_expr` string-search for the rule name token, *not* the
+   production `collect_nonterminal_refs`), that the removed rule is referenced by **zero** support programs
+   — so the support set (hence the belief, on re-conditioning the same data) is bit-identical across the
+   removal. "Belief untouched" is the whole soundness argument; it is directly testable.

--- a/src/program_space/perturbation.jl
+++ b/src/program_space/perturbation.jl
@@ -22,10 +22,15 @@ function analyse_posterior_subtrees(
     min_complexity::Int=2
 )::SubprogramFrequencyTable
     subtree_map = Dict{String, Tuple{ProgramExpr, Float64, Vector{Int}}}()
+    # The sound nonterminal reference count (exploration-budget Move 1): full-depth walk over the SAME
+    # support set (w > 1e-15) the subtree loop uses, independent of extract_subtrees' min_complexity
+    # filter. A concrete (possibly empty) Set ⇒ analysed; consumed by `_removal_payoff` / `:remove_rule`.
+    referenced = Set{Symbol}()
 
     for (i, prog) in enumerate(programs)
         w = prog_weights[i]
         w > 1e-15 || continue
+        collect_nonterminal_refs!(referenced, prog.expr)
         subtrees = extract_subtrees(prog.expr, min_complexity)
         for st in subtrees
             key = show_expr(st)
@@ -50,7 +55,7 @@ function analyse_posterior_subtrees(
     end
 
     perm = sortperm(freqs, rev=true)
-    SubprogramFrequencyTable(subtrees[perm], freqs[perm], sources[perm])
+    SubprogramFrequencyTable(subtrees[perm], freqs[perm], sources[perm], referenced)
 end
 
 """Extract all subtrees of an expression with complexity ≥ min_c."""
@@ -106,6 +111,43 @@ function _extract!(result, e::IfExpr, min_c)
 end
 
 # ═══════════════════════════════════════
+# Nonterminal reference count — the SOUND, full-depth walk (exploration-budget Move 1)
+# ═══════════════════════════════════════
+
+"""
+    collect_nonterminal_refs!(acc::Set{Symbol}, e::ProgramExpr) → acc
+
+Collect the names of EVERY `NonterminalRef` in `e`, recursing to all depths and into all branches
+(predicate AND action branches of `IfExpr`). The soundness keystone of `:remove_rule`: a rule is
+"referenced" iff some posterior-support program mentions it ANYWHERE, so a missed reference would
+wrongly mark a live rule dead and remove it (silently breaking a support program).
+
+DELIBERATELY SEPARATE from `extract_subtrees`: that function's `min_complexity` filter drops
+complexity-1 (bare `NonterminalRef`) programs — exactly the lossiness that blocked a sound reference
+count (collapse-towers Scope B). This walk MUST NOT be routed through `extract_subtrees`. One method
+per `ProgramExpr` subtype, NO generic fallback — a future node type fails loud (matching `_extract!` /
+`expr_complexity`), because a silently-unwalked node is a silent unsoundness.
+Asserted by test_voc_gate.jl §5b (depth-1 reference is seen).
+"""
+collect_nonterminal_refs!(acc::Set{Symbol}, e::NonterminalRef) = (push!(acc, e.name); acc)
+collect_nonterminal_refs!(acc::Set{Symbol}, ::GTExpr) = acc
+collect_nonterminal_refs!(acc::Set{Symbol}, ::LTExpr) = acc
+collect_nonterminal_refs!(acc::Set{Symbol}, ::ActionExpr) = acc
+collect_nonterminal_refs!(acc::Set{Symbol}, e::AndExpr) =
+    (collect_nonterminal_refs!(acc, e.left); collect_nonterminal_refs!(acc, e.right))
+collect_nonterminal_refs!(acc::Set{Symbol}, e::OrExpr) =
+    (collect_nonterminal_refs!(acc, e.left); collect_nonterminal_refs!(acc, e.right))
+collect_nonterminal_refs!(acc::Set{Symbol}, e::NotExpr) = collect_nonterminal_refs!(acc, e.child)
+collect_nonterminal_refs!(acc::Set{Symbol}, e::PersistsExpr) = collect_nonterminal_refs!(acc, e.child)
+collect_nonterminal_refs!(acc::Set{Symbol}, e::ChangedExpr) = collect_nonterminal_refs!(acc, e.child)
+collect_nonterminal_refs!(acc::Set{Symbol}, e::SinceExpr) =
+    (collect_nonterminal_refs!(acc, e.p); collect_nonterminal_refs!(acc, e.q))
+collect_nonterminal_refs!(acc::Set{Symbol}, e::IfExpr) =
+    (collect_nonterminal_refs!(acc, e.predicate);
+     collect_nonterminal_refs!(acc, e.then_branch);
+     collect_nonterminal_refs!(acc, e.else_branch))
+
+# ═══════════════════════════════════════
 # Compression payoff — the shared description-length arithmetic
 # ═══════════════════════════════════════
 
@@ -151,6 +193,28 @@ function propose_nonterminal(table::SubprogramFrequencyTable)::Union{ProductionR
     isnothing(result) ? nothing : result[1]
 end
 
+"""
+    _removal_payoff(g, table) → Vector{Tuple{ProductionRule, Int}}
+
+The `:remove_rule` candidates: each grammar rule whose name NO posterior-support program references
+(`r.name ∉ table.referenced_nonterminals`). Removing such a rule shrinks the dictionary by its full
+two-part-MDL cost `1 + expr_complexity(r.body)` symbols (the rule def: 1 for the head + the body) at
+ZERO fit cost — no support program referenced it, so the belief is untouched (prior-only). The
+symmetric MDL partner of `_compression_payoff`'s `:add_rule`. Referenced rules are NOT candidates:
+removing them is generative-change (it would change which programs the grammar generates), invisible
+to depth-one prior-only `net_voc` and deferred to a later move.
+
+`table.referenced_nonterminals === nothing` (an un-analysed, hand-built table) ⇒ references unknown ⇒
+no candidates (Scope-A-preserving). A concrete (possibly empty) Set ⇒ analysed; an empty analysed set
+legitimately means every rule is dead. (See the Move 1 design doc on why the sentinel is not an empty
+Set: `name ∉ ∅` is vacuously true, which would make every rule removable.)
+"""
+function _removal_payoff(g::Grammar, table::SubprogramFrequencyTable)::Vector{Tuple{ProductionRule, Int}}
+    refs = table.referenced_nonterminals
+    refs === nothing && return Tuple{ProductionRule, Int}[]
+    [(r, 1 + expr_complexity(r.body)) for r in g.rules if !(r.name in refs)]
+end
+
 # ═══════════════════════════════════════
 # net_voc — Value-of-Computation of a grammar perturbation (collapse-towers Phase 5)
 # ═══════════════════════════════════════
@@ -169,10 +233,11 @@ prior (CLAUDE.md §1.3). A compression saving `net_payoff_symbols` raises the lo
 (the program-axis λ is pinned to `log(2)` by §1.3). The structural twin of `net_voi` (`stdlib.jl`):
 the same `net_value` form, in the prior's currency rather than utility — the third representation,
 after scalar `net_voi` and Functional-offset routing EU. At `compute_cost = 0` the gate `net_voc > 0`
-is exactly `propose_nonterminal`'s `net_payoff > 0`. Governs the COMPRESSION class only (`:add_rule`);
-generative-change ops (`:modify_threshold`, `:add_feature`, `:remove_feature`) change the likelihood
-over un-entertained programs (the escape-mass frontier), invisible here by construction, and are
-deferred to an EU-priced exploration mechanism (master plan, named successor).
+is exactly `propose_nonterminal`'s `net_payoff > 0`. Governs the COMPRESSION class — both `:add_rule`
+(payoff = compression saving) and `:remove_rule` (payoff = the dead rule's reclaimed cost,
+`1 + expr_complexity(body)`); generative-change ops (`:modify_threshold`, `:add_feature`,
+`:remove_feature`) change the likelihood over un-entertained programs (the escape-mass frontier),
+invisible here by construction, and are deferred to an EU-priced exploration mechanism (master plan).
 """
 net_voc(net_payoff_symbols::Real, compute_cost::Real) =
     net_value(complexity_logprior(-net_payoff_symbols; λ = log(2)), compute_cost)
@@ -181,20 +246,40 @@ net_voc(net_payoff_symbols::Real, compute_cost::Real) =
 # Grammar perturbation — deterministic argmax over net_voc (no rand; Invariant 1 canalised)
 # ═══════════════════════════════════════
 
+# Total order on perturbation candidates, for the deterministic argmax. A candidate is the 5-tuple
+# `(voc::Float64, is_remove::Bool, name::String, kind::Symbol, rule::ProductionRule)`. Order:
+# (1) higher `net_voc`; (2) on a tie, prefer `:remove` (hygiene — shrink the dictionary before growing
+# it); (3) on a further tie, lexicographically smaller rule name. No `rand`, no `hash` (Julia's `hash`
+# is not stable across versions — and cross-version-reproducible determinism is the whole point; a name
+# string-compare is stable). A tie is between candidates of EXACTLY-EQUAL computed prior value, so a
+# stable order is honest disambiguation among genuine argmax-optima, not a tiebreak of UNKNOWN values
+# (which Invariant 1 forbids). Asserted by test_voc_gate.jl §5c.
+function _candidate_better(a, b)
+    a[1] != b[1] && return a[1] > b[1]
+    a[2] != b[2] && return a[2]
+    return a[3] < b[3]
+end
+_pick_better(best, cand) = (best === nothing || _candidate_better(cand, best)) ? cand : best
+
 """
     perturb_grammar(g, freq_table, available_features; compute_cost = 0.0) → Grammar
 
-Perturb a grammar by the single compression-class meta-action whose `net_voc` is greatest, applied iff
+Perturb a grammar by the compression-class meta-action whose `net_voc` is greatest, applied iff
 `net_voc > 0`; otherwise a structural no-op — the **input grammar returned unchanged (same id)**, so the
 downstream `add_programs_to_state!` dedup (keyed on `grammar.id`) re-adds nothing. The selection is a
-**deterministic argmax** — the `rand`-based op choice (the Invariant-1 breach Phase 5 retires) is gone. `freq_table` is REQUIRED (the type system enforces posterior analysis before
-nonterminal proposal). `available_features` is retained for signature stability (the deferred
-feature-discovery mechanism will consume it); Scope A does not read it.
+**deterministic argmax** (the `rand`-based op choice — the Invariant-1 breach — is gone). `freq_table`
+is REQUIRED (the type system enforces posterior analysis before nonterminal proposal).
+`available_features` is retained for signature stability (the deferred feature-discovery mechanism will
+consume it); it is not read here.
 
-Scope A (collapse-towers Phase 5): the compression class is `:add_rule` alone — `propose_nonterminal`'s
-proposed rule, gated by `net_voc`. `:remove_rule` (dictionary hygiene) awaits a sound nonterminal
-reference count; the generative-change ops await an EU-priced exploration budget — both named
-successors in `docs/collapse-towers/master-plan.md`.
+The compression class is the **MDL pair** `{:add_rule} ∪ {:remove_rule candidates}` (exploration-budget
+Move 1): `:add_rule` is `_compression_payoff`'s proposed rule (gated by the idempotence guard);
+`:remove_rule` candidates are `_removal_payoff`'s dead rules (referenced by no posterior-support
+program — prior-only, the symmetric MDL partner). The applied meta-action is the `net_voc` argmax over
+the pair, tiebroken by `_candidate_better`. When neither improves the prior, the no-op **is** the
+prior-saturation signal the exploration budget's saturation gate reads (Move 2). The generative-change
+ops (`:modify_threshold`, `:add_feature`, `:remove_feature`) remain deferred — their value is invisible
+to depth-one prior-only `net_voc` (the escape-mass frontier; `docs/exploration-budget/master-plan.md`).
 """
 function perturb_grammar(g::Grammar, freq_table::SubprogramFrequencyTable,
                           available_features::Set{Symbol};
@@ -203,12 +288,27 @@ function perturb_grammar(g::Grammar, freq_table::SubprogramFrequencyTable,
     # `add_programs_to_state!` deduplicates by `grammar.id`, so a fresh-id no-op would defeat the dedup
     # and re-inject every program as a fresh Beta(1,1) duplicate (a silent posterior reset — A3). Same
     # id ⇒ a no-op truly changes nothing. (Tested by test_perturb_consumption.jl.)
-    candidate = _compression_payoff(freq_table)
-    isnothing(candidate) && return g                            # no compressing subtree
-    rule, net_payoff = candidate
-    rule.name in Set(r.name for r in g.rules) && return g       # already present
-    net_voc(net_payoff, compute_cost) > 0 || return g           # VOC gate (forward compute priced in)
-    Grammar(g.feature_set, [g.rules; rule], next_grammar_id())
+    best = nothing  # (voc, is_remove, name, kind, rule) — the running argmax; see _candidate_better
+
+    add = _compression_payoff(freq_table)
+    if !isnothing(add)
+        rule, net_payoff = add
+        if !(rule.name in Set(r.name for r in g.rules))         # idempotence guard (already-present name)
+            v = net_voc(net_payoff, compute_cost)               # VOC gate (forward compute priced in)
+            v > 0 && (best = _pick_better(best, (v, false, string(rule.name), :add, rule)))
+        end
+    end
+    for (rule, net_payoff) in _removal_payoff(g, freq_table)
+        v = net_voc(net_payoff, compute_cost)
+        v > 0 && (best = _pick_better(best, (v, true, string(rule.name), :remove, rule)))
+    end
+
+    best === nothing && return g                                # saturation no-op (the Move-2 signal)
+    if best[4] === :add
+        Grammar(g.feature_set, [g.rules; best[5]], next_grammar_id())
+    else  # :remove — drop the dead rule by name (names are unique under the idempotence guard)
+        Grammar(g.feature_set, [r for r in g.rules if r.name != best[5].name], next_grammar_id())
+    end
 end
 
 # Backward-compatible 2-argument form (default feature set; forwards compute_cost)

--- a/src/program_space/types.jl
+++ b/src/program_space/types.jl
@@ -210,6 +210,17 @@ struct SubprogramFrequencyTable
     subtrees::Vector{ProgramExpr}
     weighted_frequency::Vector{Float64}
     source_programs::Vector{Vector{Int}}  # which program indices contained each subtree
+    # NT names referenced by ≥1 posterior-support program, or `nothing` when no analysis has run.
+    # `:remove_rule` (exploration-budget Move 1) consumes this: a rule absent from a *concrete* set is
+    # dead (removable, prior-only). `nothing` ⇒ references unknown ⇒ no rule removable. The sentinel is
+    # load-bearing: a concrete empty Set means "analysed, every rule dead" — the OPPOSITE of unknown —
+    # because the removal predicate `name ∉ referenced` is vacuously true on the empty set.
+    referenced_nonterminals::Union{Nothing, Set{Symbol}}
 end
 
-# No public constructor — only created by analyse_posterior_subtrees
+# 3-arg convenience constructor: `nothing` references (un-analysed). Hand-built tables (tests) get the
+# Scope-A-preserving default — `_removal_payoff` yields no candidates, so `:remove_rule` never fires.
+# `analyse_posterior_subtrees` is the only site that populates a concrete (possibly empty) Set.
+SubprogramFrequencyTable(subtrees::Vector{ProgramExpr}, weighted_frequency::Vector{Float64},
+                         source_programs::Vector{Vector{Int}}) =
+    SubprogramFrequencyTable(subtrees, weighted_frequency, source_programs, nothing)

--- a/test/test_program_space.jl
+++ b/test/test_program_space.jl
@@ -558,6 +558,50 @@ end
 println()
 
 # ═══════════════════════════════════════
+# TEST 14b: perturb_grammar :remove_rule on ENUMERATED programs — exploration-budget Move 1
+# ═══════════════════════════════════════
+# Complements test_voc_gate.jl §5 (hand-built ASTs) with the real trigger on genuinely-enumerated
+# programs: a rule the POSTERIOR abandoned — every program referencing it drops below the w > 1e-15
+# support floor — is removed, while a rule the support still references is kept. This exercises the
+# full-depth reference walk's sharing of the support filter (the Scope-B fix) end-to-end through the
+# enumeration → analyse → perturb pipeline.
+
+println("=" ^ 60)
+println("TEST 14b: perturb_grammar removes a posterior-abandoned rule (enumerated)")
+println("=" ^ 60)
+
+let
+    g = Grammar(Set([:red, :green]),
+                [ProductionRule(:KEEP, GTExpr(:red, 0.7)), ProductionRule(:DROP, LTExpr(:green, 0.3))], 1)
+    progs = enumerate_programs(g, 3; action_space=[:a, :b])
+    # Support = programs referencing :KEEP but NOT :DROP (weight 1); every :DROP-referencing program is
+    # pushed below the support floor (weight 0 ⇒ filtered), modelling the posterior abandoning :DROP.
+    w = zeros(length(progs))
+    for (i, p) in enumerate(progs)
+        s = show_expr(p.expr)
+        w[i] = (occursin("KEEP", s) && !occursin("DROP", s)) ? 1.0 : 0.0
+    end
+    @assert sum(w) > 0 "fixture precondition: some enumerated program references :KEEP without :DROP"
+    w ./= sum(w)
+    # High min_frequency suppresses any :add_rule candidate, so the perturbation under test is
+    # unambiguously the :remove_rule (the reference count is independent of min_frequency).
+    ft = analyse_posterior_subtrees(progs, w; min_frequency=0.99, min_complexity=2)
+
+    # Preconditions (strongest-property idiom — a broken fixture must fail loud, not pass as a no-op):
+    @assert :KEEP in ft.referenced_nonterminals "fixture: the support must reference :KEEP"
+    @assert !(:DROP in ft.referenced_nonterminals) "fixture: the support must NOT reference :DROP (abandoned)"
+    @assert propose_nonterminal(ft) === nothing "fixture: no :add_rule candidate (removal is the sole action)"
+
+    got = perturb_grammar(g, ft)
+    names = Set(r.name for r in got.rules)
+    @assert !(:DROP in names) "posterior-abandoned :DROP is removed (enumerated support)"
+    @assert :KEEP in names "support-referenced :KEEP is kept"
+    @assert got.id != g.id "a real removal advances the grammar id"
+    println("PASSED: enumerated :remove_rule — abandoned :DROP removed, referenced :KEEP kept")
+end
+println()
+
+# ═══════════════════════════════════════
 # TEST 15: Proposed nonterminals are actual posterior subtrees (enforcement, spec §5.10)
 # ═══════════════════════════════════════
 

--- a/test/test_voc_gate.jl
+++ b/test/test_voc_gate.jl
@@ -21,7 +21,7 @@
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
 using Credence: Grammar, ProductionRule, SubprogramFrequencyTable, Program,
-                GTExpr, LTExpr, AndExpr, NotExpr, IfExpr, ActionExpr, ProgramExpr,
+                GTExpr, LTExpr, AndExpr, NotExpr, IfExpr, ActionExpr, NonterminalRef, ProgramExpr,
                 perturb_grammar, propose_nonterminal, analyse_posterior_subtrees,
                 expr_complexity, show_expr, net_voc
 
@@ -90,12 +90,21 @@ let
 end
 
 # ── (1c) name-collision no-op (path b): a proposed rule whose name already exists ⇒ no-op, and the
-# existing body is never overwritten. This is the idempotence guard that keeps Scope A monotonic —
-# re-perturbing a grammar that already holds the compression does not re-add or clobber it. ──
+# existing body is never overwritten. This is the idempotence guard that keeps the :add_rule path
+# monotonic — re-perturbing a grammar that already holds the compression does not re-add or clobber it.
+# Move-1 note: the colliding rule must be REFERENCED by the support, else it is a dead rule and
+# :remove_rule (correctly) removes it — a different code path. Adding one program that references the
+# nonterminal makes it live, isolating the add-side idempotence guard (this test's sole purpose). ──
 let
-    ft, s = shared_subtree_table(4)                       # net_payoff = 4 > 0 ⇒ would propose a rule for s
-    collide = Symbol("NT_", hash(show_expr(s)))           # the exact (full-hash) name propose_nonterminal generates
+    s = AndExpr(GTExpr(:red, 0.7), LTExpr(:green, 0.3))   # the compressing subtree (expr_complexity 3)
+    collide = Symbol("NT_", hash(show_expr(s)))           # the exact (full-hash) name propose_nonterminal generates for s
     existing_body = GTExpr(:red, 0.9)                     # a DIFFERENT body under that same name
+    # Four programs share s (⇒ :add_rule proposes a rule named `collide`, net_payoff 4 > 0), plus one
+    # program that REFERENCES `collide` (⇒ it is live, not a :remove_rule candidate).
+    progs = Program[Program(IfExpr(s, ActionExpr(:a), ActionExpr(:b)), 6, 1) for _ in 1:4]
+    push!(progs, Program(IfExpr(NonterminalRef(collide), ActionExpr(:a), ActionExpr(:b)), 3, 1))
+    w = fill(1.0 / 5, 5)
+    ft = analyse_posterior_subtrees(progs, w; min_frequency = 0.0, min_complexity = 2)
     g = Grammar(Set([:red, :green]), [ProductionRule(collide, existing_body)], 1)
     got = perturb_grammar(g, ft; compute_cost = 0.0)
     check("name collision ⇒ no-op (no second rule added)", length(got.rules) == 1, "rules=$(rules_str(got))")
@@ -140,6 +149,110 @@ let
         check("$f: no rng entry point on the perturbation path", !occursin(rng, code),
               "an rng call survives in $f")
     end
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# (5) :remove_rule — dictionary hygiene, the symmetric MDL partner of :add_rule
+#     (exploration-budget Move 1). A rule no posterior-support program references is dead weight:
+#     removing it raises the complexity prior at ZERO fit cost (no support program changes), so it is
+#     prior-only and net_voc-rankable. "Referenced" is counted by a FULL-depth AST walk over the
+#     support (w > 1e-15), INDEPENDENT of extract_subtrees' min_complexity filter (the Scope-B fix).
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Independent oracle for "the support references `name`": the rule-name token appears in some support
+# program's show_expr. Deliberately NOT the production collect_nonterminal_refs — this oracle pins the
+# prior-only claim (belief untouched) without circular reference to the function under test.
+references_name(progs, name) =                  # credence-lint: allow — precedent:test-oracle — independent reference check for the prior-only pin
+    any(p -> occursin(string(name), show_expr(p.expr)), progs)
+
+# ── (5a) remove a dead rule; keep a live one; prior-only (belief untouched) pin ──
+let
+    # :LIVE is referenced by the support (a bare NonterminalRef predicate); :DEAD by nobody.
+    g = Grammar(Set([:red, :blue]),
+                [ProductionRule(:LIVE, GTExpr(:red, 0.7)), ProductionRule(:DEAD, GTExpr(:blue, 0.5))], 1)
+    progs = Program[Program(IfExpr(NonterminalRef(:LIVE), ActionExpr(:a), ActionExpr(:b)), 3, 1) for _ in 1:3]
+    w = fill(1.0 / 3, 3)
+    ft = analyse_posterior_subtrees(progs, w; min_frequency = 0.0, min_complexity = 2)
+
+    got = perturb_grammar(g, ft; compute_cost = 0.0)
+    names = Set(r.name for r in got.rules)
+    check("dead rule :DEAD is removed", :DEAD ∉ names, "rules=$(rules_str(got))")
+    check("live rule :LIVE is kept", :LIVE ∈ names, "rules=$(rules_str(got))")
+    check("exactly one rule removed", length(got.rules) == 1, "rules=$(rules_str(got))")
+
+    # The reference pass populated the new field: :LIVE referenced (depth-1), :DEAD not.
+    check("reference pass: referenced == {:LIVE}", ft.referenced_nonterminals == Set([:LIVE]),
+          "got $(ft.referenced_nonterminals)")
+    # net_voc of the removal == log(2)·(1 + expr_complexity(body)) == log(2)·2.
+    check("removal net_voc == log(2)·(1 + complexity(body))",
+          net_voc(1 + expr_complexity(GTExpr(:blue, 0.5)), 0.0) ≈ 2 * log(2))
+
+    # Prior-only / belief-untouched pin (independent oracle): :DEAD is referenced by ZERO support
+    # programs, so the support set — hence the posterior on re-conditioning the same data — is
+    # bit-identical across the removal; :LIVE remains referenced.
+    check("prior-only: removed :DEAD referenced by no support program (belief untouched)",
+          !references_name(progs, :DEAD), "a support program referenced :DEAD")
+    check("prior-only: surviving :LIVE still referenced by the support", references_name(progs, :LIVE))
+end
+
+# ── (5b) depth-1 reference is seen (R1) — the Scope-B unsoundness guard ──
+let
+    # :BARE is referenced ONLY by a bare NonterminalRef (a complexity-1 predicate) — exactly the
+    # depth-1 reference the old extract_subtrees(min_complexity=2) count dropped. :TDEAD: referenced
+    # nowhere. A count routed through extract_subtrees would drop the bare ref and wrongly remove :BARE.
+    g = Grammar(Set([:green, :blue]),
+                [ProductionRule(:BARE, GTExpr(:green, 0.2)), ProductionRule(:TDEAD, GTExpr(:blue, 0.9))], 1)
+    progs = Program[Program(IfExpr(NonterminalRef(:BARE), ActionExpr(:a), ActionExpr(:b)), 3, 1) for _ in 1:2]
+    w = fill(0.5, 2)
+    ft = analyse_posterior_subtrees(progs, w; min_frequency = 0.0, min_complexity = 2)
+
+    check("depth-1 reference is collected (:BARE ∈ referenced)", :BARE ∈ ft.referenced_nonterminals,
+          "got $(ft.referenced_nonterminals)")
+    got = perturb_grammar(g, ft; compute_cost = 0.0)
+    names = Set(r.name for r in got.rules)
+    check("depth-1-referenced :BARE is NOT removed (sound full-depth count)", :BARE ∈ names,
+          "rules=$(rules_str(got))")
+    check("truly-dead :TDEAD is removed", :TDEAD ∉ names, "rules=$(rules_str(got))")
+end
+
+# ── (5c) determinism + tiebreak: add ≡ remove net_voc tie resolves remove-first ──
+let
+    # Exact tie: an :add_rule candidate of payoff 2 (subtree s shared by 3 programs, expr_complexity 3
+    # ⇒ 3·(3−1) − (1+3) = 2) AND a :remove_rule candidate of payoff 2 (dead :D, body complexity 1 ⇒
+    # 1 + 1 = 2). Tiebreak = remove-first (hygiene: shrink before grow): :D removed, s NOT added.
+    s = AndExpr(GTExpr(:red, 0.7), LTExpr(:green, 0.3))
+    progs = Program[Program(IfExpr(s, ActionExpr(:a), ActionExpr(:b)), 6, 1) for _ in 1:3]   # share s; no ref to :D
+    w = fill(1.0 / 3, 3)
+    ft = analyse_posterior_subtrees(progs, w; min_frequency = 0.0, min_complexity = 2)
+    g = Grammar(Set([:red, :green]), [ProductionRule(:D, GTExpr(:blue, 0.5))], 1)
+
+    add_payoff = oracle_net_payoff(ft)          # credence-lint: allow — precedent:test-oracle — confirm the exact tie
+    check("tie precondition: add payoff == remove payoff == 2",
+          add_payoff == 2 && (1 + expr_complexity(GTExpr(:blue, 0.5))) == 2, "add_payoff=$add_payoff")
+
+    got = perturb_grammar(g, ft; compute_cost = 0.0)
+    check("net_voc tie resolves remove-first: :D removed", :D ∉ Set(r.name for r in got.rules),
+          "rules=$(rules_str(got))")
+    check("net_voc tie resolves remove-first: subtree NOT added (remove won)", isempty(got.rules),
+          "rules=$(rules_str(got))")
+    a = perturb_grammar(g, ft; compute_cost = 0.0)
+    b = perturb_grammar(g, ft; compute_cost = 0.0)
+    check("tiebreak is deterministic across runs", rules_str(a) == rules_str(b),
+          "a=$(rules_str(a)) b=$(rules_str(b))")
+end
+
+# ── (5d) saturation no-op — the Move-2 prior-saturation signal ──
+let
+    # Every rule referenced AND no compressing subtree ⇒ no add, no remove ⇒ structural no-op: the
+    # INPUT grammar returned unchanged (same id). This no-op is the prior-saturation signal Move 2 reads.
+    g = Grammar(Set([:red]), [ProductionRule(:ONLY, GTExpr(:red, 0.4))], 7)
+    progs = Program[Program(IfExpr(NonterminalRef(:ONLY), ActionExpr(:a), ActionExpr(:b)), 3, 7) for _ in 1:2]
+    w = fill(0.5, 2)
+    ft = analyse_posterior_subtrees(progs, w; min_frequency = 0.0, min_complexity = 2)
+    got = perturb_grammar(g, ft; compute_cost = 0.0)
+    check("saturation no-op: same grammar id (Move-2 signal)", got.id == g.id, "id=$(got.id)")
+    check("saturation no-op: rules unchanged", Set(r.name for r in got.rules) == Set([:ONLY]),
+          "rules=$(rules_str(got))")
 end
 
 println("="^64)


### PR DESCRIPTION
## The arc

`exploration-budget` discharges the two named successors collapse-towers deferred. Thesis (ratified): price generative-change discovery as **compute-budgeted lookahead VOI against the belief's predictive residual, gated on saturation** — EU-max, no `rand`, no hard cap. The lookahead makes candidate *selection* EU-max, not candidate *generation* (the selection/generation seam). See `docs/exploration-budget/master-plan.md` (§3 the seam + two-tier structure, §4 the five moves, §5 the ratified Q1–Q5).

This PR lands the master plan + **Move 1** (design + code). Move 1 is the prior-only floor — no belief, no lookahead yet (those start at Move 2).

## Move 1 — `:remove_rule` + a sound reference count

Scope A made `perturb_grammar` monotonic (only `:add_rule`). Move 1 completes the **MDL compression pair**: a rule the posterior has abandoned is dropped, and the **sound nonterminal reference count** that Scope B was blocked on lands.

- **Removable iff zero posterior-support programs reference it** — strict structural reference over the engine's existing `w > 1e-15` support floor, counted by the standalone full-depth `collect_nonterminal_refs!` (one method per node type, no fallback). **Deliberately separate from `extract_subtrees`**, whose `min_complexity` filter drops the bare depth-1 references that blocked Scope B.
- **Prior-only**: no support program references the removed rule, so the belief is untouched (pinned by an independent oracle). `net_voc` scores it by the reclaimed two-part-MDL cost `1 + expr_complexity(body)`.
- **`perturb_grammar` is the deterministic `net_voc` argmax** over `{add} ∪ {remove}`, tiebroken **lexicographically by name** (not `hash` — Julia's `hash` isn't stable across versions), remove-first on exact ties.
- **Enables Move 2**: `perturb_grammar`'s no-op is now the prior-saturation signal Move 2 conjoins with the belief-side residual plateau.

## Encoding correction worth a look (§8 of the design doc)

The ratified design defaulted `referenced_nonterminals` to an empty `Set{Symbol}`. Grounding caught that this **fails open** on a destructive op: `name ∉ ∅` is vacuously true, so an empty-set default makes *every* rule removable. Fixed to `Union{Nothing, Set}` — `nothing` (un-analysed, hand-built tables) fails **closed** (no removal); a concrete set (possibly empty — analysed, all rules dead is legitimate) means analysed. `:add_rule` stays bit-exact (never reads the field). Three distinct states where the bare `Set` collapsed two.

## Tests

- `test_voc_gate.jl §5` (hand-built ASTs): removal, depth-1 soundness guard, prior-only pin, add≡remove tiebreak, saturation no-op. 1c updated for Move-1 semantics (a referenced colliding rule isn't a removal target).
- `test_program_space.jl` TEST 14b (enumerated): a posterior-abandoned rule (its programs below the support floor) is removed, a referenced rule kept — the real trigger on genuinely-enumerated programs.
- Full Julia suite **47/47 green** locally; lint corpus self-test + `check apps/` (174 files) clean. (Julia tests are not CI-gated — CI runs the Python/skin unit-tests incl. the wire smoke.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
