### PR TITLE
exploration-budget Move 2 (code): the saturation signal — scale-free residual-plateau regime

### DIFF
--- a/docs/exploration-budget/move-2-design.md
+++ b/docs/exploration-budget/move-2-design.md
@@ -316,3 +316,38 @@ crossing), so a clean ratified-design checkpoint is cheap insurance on the move 
 quietly become the thresholded gate the stall gate exists to refuse. Built scale-free, with `plateau_prob`
 a prior not a gate, Move 2 hands Move 3 a saturation read honest on both sides — demonstrated not assumed,
 and incapable of capping.
+
+### Code-time refinements (2026-06-28, discovered during implementation)
+
+Two refinements the implementation forced, both consistent with the ratified intent:
+
+1. **The scale-free priors are *near-Jeffreys*, and the new conjugate primitive `ZeroMeanGammaPrevision`
+   was added.** Tracing the conjugacy showed `NormalGammaPrevision` cannot soundly encode μ≡0 (its μ
+   carries a κ-weighted prior; κ→∞ is degenerate), so the `:plateaued` regime needed a new exact
+   component — `ZeroMeanGammaPrevision(α, β)` (zero-mean Gaussian, unknown precision; α += 0.5, β += r²/2;
+   zero-centred Student-t marginal) — added to the conjugate registry (constitution-sanctioned). More
+   importantly, a `Gamma(1,1)` precision prior **pins the noise scale to ~1 and false-plateaus slow
+   tasks** — the exact bug the stall gate refuses. The fix is a **near-Jeffreys diffuse precision prior
+   `Gamma(0.01, 0.01) ≈ p(σ²) ∝ 1/σ²`** in both regimes, so the noise floor is the data's (inferred).
+   The `:improving` regime is the clean nested Bayesian t-test (μ free, μ₀=0, κ=0.1 weak ⇒ σ-relative
+   detection). Empirically: consistent-improving → 0.0, flat → 0.86, **slow (Δ≈0.08) → 0.0** (scale-free,
+   the keystone), cold-start → 0.5, decelerating → 0.33 (graceful, intermediate). `test_saturation.jl`
+   pins the slow-improver case as the scale-free guard.
+2. **Host wiring is deferred to Move 3** (mirroring the Q5 skin-exposure deferral — "no consumer yet").
+   The signal is non-causal in Move 2 (nothing reads it for a decision), so wiring it into the host
+   hot-loops now then re-touching them in Move 3 (where `explore_grammar` consumes it) is wire-then-rewire
+   with no payoff and real behaviour-preservation risk. Move 2 ships the **mechanism** —
+   `compression_exhausted`, the scale-free regime model (`initial/update_learning_regime`,
+   `plateau_probability`), the `AgentState` fields + `reset_learning_regime!` — all unit-tested on
+   synthetic series; Move 3 wires `−log_predictive` into the conditioning sites and the reset into the
+   grammar-change sites alongside the consumer. This makes Move 2 strictly additive (no host changes),
+   and the §3 "existing host tests stay green" holds trivially.
+
+### Worked example (corrected to the implemented model — supersedes §4's illustrative numbers)
+
+§4's decelerating series (2.1→0.76) is genuinely *transitional* — its decrements shrink to ~0.02, so the
+model correctly reads it as ~0.33 (leaning improving but approaching plateau), not the illustrative 0.12.
+The clean signal is **consistency**, not mere decrease. Phase A = a *consistent* improver (Δ≈0.3 steady)
+→ `plateau_probability` 0.0 (still improving); Phase B = bouncing flat (≈0.755) → 0.86 (plateaued). The
+ordering and the scale-free slow case (Δ≈0.08 → 0.0) are what the tests assert (direction, not magic
+points).

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -39,7 +39,7 @@ export Space, Finite, Interval, ProductSpace, Simplex, Euclidean, PositiveReals,
 export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeasure, GammaMeasure, ExponentialMeasure, DirichletMeasure, NormalGammaMeasure, EnumerationMeasure, ProductMeasure, MixtureMeasure
 export Kernel, FactorSelector, kernel_source, kernel_target
 export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, WeightedBernoulli, SoftBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
-export NormalNormal, Categorical, NormalGammaLikelihood, Exponential, Poisson
+export NormalNormal, Categorical, NormalGammaLikelihood, ZeroMeanGammaLikelihood, Exponential, Poisson
 export GroupNoisyChannel, group_noisy_channel_logdensity, RhoGroupChannel, rho_group_channel_factor
 export LogisticReaction, logistic_reaction_logdensity
 export MarginReaction, margin_reaction_logdensity
@@ -50,7 +50,7 @@ export Prevision, TestFunction, Indicator, apply
 export params
 export CenteredPower, CenteredSquare, GeometricTail
 export BetaPrevision, TaggedBetaPrevision, GaussianPrevision, TruncatedGaussianPrevision, GammaPrevision
-export CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, LabelledCategoricalPrevision, RhoCategoricalPrevision
+export CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ZeroMeanGammaPrevision, LabelledCategoricalPrevision, RhoCategoricalPrevision
 export ProductPrevision, MixturePrevision, ExchangeablePrevision, decompose
 export ParticlePrevision, QuadraturePrevision, MvQuadraturePrevision
 export ConditionalPrevision
@@ -60,6 +60,7 @@ export condition, expect, push_measure, density, log_density_at, log_predictive,
 export ConjugatePrevision, maybe_conjugate, update
 export StructureBMA, build_structure_model, build_structure_prior, build_structure_prior_dense, structure_observe, structure_observe_soft, belief_at_context, context_from_features, structure_firing_tags, structure_decision_kernel, reconstruct_structure_prior_from_data
 export FamilyCandidate, FamilyBMA, build_family_model, build_family_prior, family_observe, family_posterior
+export initial_learning_regime, update_learning_regime, plateau_probability
 export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next, posterior_accuracy, route_outcome!, decode_correctness, latency_at, route_decide, escalate_decide, routing_belief_readout, reconstruct_latency_from_data, reconstruct_routing_tops_from_data, _ctx_key
 export draw
 export weights, mean, variance, probability, marginal, truncated_mv_quadrature, prune, truncate, logsumexp
@@ -80,9 +81,9 @@ export expr_complexity, expanded_complexity
 export enumerate_programs, enumerate_programs_as_measure
 export compile_kernel, compile_expr, evaluate_predicate
 export analyse_posterior_subtrees, extract_subtrees
-export propose_nonterminal, perturb_grammar, net_voc
+export propose_nonterminal, perturb_grammar, net_voc, compression_exhausted
 export expr_equal
-export AgentState, sync_prune!, sync_truncate!
+export AgentState, sync_prune!, sync_truncate!, reset_learning_regime!
 export aggregate_grammar_weights, top_k_grammar_ids
 export add_programs_to_state!
 export next_grammar_id, reset_grammar_counter!

--- a/src/conjugate.jl
+++ b/src/conjugate.jl
@@ -166,6 +166,23 @@ function update(cp::ConjugatePrevision{NormalGammaPrevision, NormalGammaLikeliho
     ConjugatePrevision(NormalGammaPrevision(κₙ, μₙ, αₙ, βₙ), cp.likelihood)
 end
 
+# ── Pair: (ZeroMeanGammaPrevision, ZeroMeanGammaLikelihood) ──
+# Zero-mean Gaussian, unknown precision. Prior τ = 1/σ² ~ Gamma(α, β); obs r ~ N(0, 1/τ). The mean is
+# fixed at 0 (no μ latent), so the Normal-Gamma update specialises to the precision-only Gamma update:
+# α += 0.5, β += r²/2. (The NormalGamma update above with μ ≡ 0 and the κ-term dropped.)
+
+function maybe_conjugate(p::ZeroMeanGammaPrevision, k::Kernel)
+    if k.likelihood_family isa ZeroMeanGammaLikelihood
+        return ConjugatePrevision(p, k.likelihood_family)
+    end
+    nothing
+end
+
+function update(cp::ConjugatePrevision{ZeroMeanGammaPrevision, ZeroMeanGammaLikelihood}, obs)
+    r = Float64(obs)
+    ConjugatePrevision(ZeroMeanGammaPrevision(cp.prior.α + 0.5, cp.prior.β + r^2 / 2.0), cp.likelihood)
+end
+
 # ── Pair: (GammaPrevision, Exponential) ──
 
 function maybe_conjugate(p::GammaPrevision, k::Kernel)

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -64,6 +64,10 @@ struct Categorical{T} <: LeafFamily
 end
 
 struct NormalGammaLikelihood <: LeafFamily end
+# Zero-mean Gaussian, unknown precision (Gamma prior on τ = 1/σ²): obs r ~ N(0, σ²), conjugate to a
+# `ZeroMeanGammaPrevision(α, β)` (α += 0.5, β += r²/2). The mean is fixed at 0 — no μ latent. Marginal
+# is a zero-centred Student-t. The scale-free `:plateaued` regime of the saturation signal (Move 2).
+struct ZeroMeanGammaLikelihood <: LeafFamily end
 struct Exponential <: LeafFamily end
 # Count likelihood: obs ~ Poisson(λ), conjugate to a Gamma(α, β) prior on the
 # rate λ. One observation t updates Gamma(α, β) → Gamma(α + t, β + 1), so after

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -22,7 +22,7 @@ using LinearAlgebra: SymTridiagonal, eigen, dot, cholesky, Symmetric
 import ..Previsions: Prevision
 import ..Previsions: TestFunction, Identity, Projection, NestedProjection,
                      Tabular, LinearCombination, OpaqueClosure, FiringChoice, expect
-import ..Previsions: BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, TruncatedGaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision, LabelledCategoricalPrevision, RhoCategoricalPrevision
+import ..Previsions: BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, TruncatedGaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ZeroMeanGammaPrevision, ProductPrevision, MixturePrevision, LabelledCategoricalPrevision, RhoCategoricalPrevision
 import ..Previsions: ExchangeablePrevision, decompose
 import ..Previsions: ParticlePrevision, QuadraturePrevision, MvQuadraturePrevision, _mv_points
 import ..Previsions: ConditionalPrevision
@@ -37,7 +37,7 @@ export Measure, CategoricalMeasure, BetaMeasure, TaggedBetaMeasure, GaussianMeas
 export Kernel, FactorSelector, kernel_source, kernel_target, kernel_params
 export LikelihoodFamily, LeafFamily, PushOnly, BetaBernoulli, WeightedBernoulli, SoftBernoulli, Flat, FiringByTag, DispatchByComponent, DepthCapExceeded
 export FAMILY_REGISTRY, register_family!
-export NormalNormal, LinearGaussian, Categorical, NormalGammaLikelihood, Exponential, Poisson
+export NormalNormal, LinearGaussian, Categorical, NormalGammaLikelihood, ZeroMeanGammaLikelihood, Exponential, Poisson
 export GroupNoisyChannel, group_noisy_channel_logdensity, RhoGroupChannel, rho_group_channel_factor
 export LogisticReaction, logistic_reaction_logdensity
 export MarginReaction, margin_reaction_logdensity
@@ -1330,6 +1330,12 @@ function condition(p::NormalGammaPrevision, k::Kernel, observation)
           "space context; use NormalGammaMeasure for non-conjugate kernels")
 end
 
+function condition(p::ZeroMeanGammaPrevision, k::Kernel, observation)
+    cp = maybe_conjugate(p, k)
+    cp !== nothing && return update(cp, observation).prior
+    error("condition(::ZeroMeanGammaPrevision, ...) requires a ZeroMeanGammaLikelihood kernel")
+end
+
 # Prevision-native per-factor-routed product conditioning (measure-as-view Phase 3). The factors are
 # independent: a FiringByTag/DispatchByComponent kernel routes the observation to each factor by its own
 # tag (the firing factor updates via its conjugate, non-firing factors resolve to Flat — the registered
@@ -1651,6 +1657,17 @@ function _predictive_ll(p::NormalGammaPrevision, k::Kernel, obs)
     _loggamma((ν + 1) / 2) - _loggamma(ν / 2) - 0.5 * log(ν * π * s2) - ((ν + 1) / 2) * log1p(z / ν)
 end
 
+# Zero-mean Student-t posterior-predictive (the κ→∞, μ≡0 specialisation of NormalGamma): ν = 2α,
+# scale² = β/α, location 0. The scale-free `:plateaued` regime's marginal likelihood for the BMA.
+function _predictive_ll(p::ZeroMeanGammaPrevision, k::Kernel, obs)
+    k.likelihood_family isa ZeroMeanGammaLikelihood ||
+        return invoke(_predictive_ll, Tuple{Prevision, Kernel, Any}, p, k, obs)
+    ν = 2.0 * p.α
+    s2 = p.β / p.α
+    z = Float64(obs)^2 / s2
+    _loggamma((ν + 1) / 2) - _loggamma(ν / 2) - 0.5 * log(ν * π * s2) - ((ν + 1) / 2) * log1p(z / ν)
+end
+
 # Prevision-primary (measure-as-view Phase 3): the predictive is the exact integral. Carrier-FREE types
 # (Particle/Quadrature/TruncatedGaussian/RhoCategorical/Gamma) have expect(p, ::Function). A genuinely
 # carrier-bound Prevision — CategoricalPrevision has no carrier-free expect over a closure — MethodErrors
@@ -1691,6 +1708,7 @@ end
 # Prevision-native Student-t closed form (measure-as-view Phase 3); log_predictive delegates to
 # _predictive_ll (same quantity — the established log_predictive(::CategoricalMeasure) pattern).
 log_predictive(p::NormalGammaPrevision, k::Kernel, obs) = _predictive_ll(p, k, obs)
+log_predictive(p::ZeroMeanGammaPrevision, k::Kernel, obs) = _predictive_ll(p, k, obs)
 
 # A mixture's marginal likelihood = logsumexp_i(log_weight_i + _predictive_ll(comp_i, k, obs)),
 # routing per-component (each component resolves its own LikelihoodFamily — e.g. a
@@ -2194,6 +2212,9 @@ export StructureBMA, build_structure_model, build_structure_prior,
 # collapse-towers Phase 2.
 include("family_bma.jl")
 export FamilyCandidate, FamilyBMA, build_family_model, build_family_prior, family_observe, family_posterior
+
+include("saturation.jl")
+export initial_learning_regime, update_learning_regime, plateau_probability
 
 include("routing.jl")
 export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next,

--- a/src/prevision.jl
+++ b/src/prevision.jl
@@ -30,7 +30,7 @@ module Previsions
 
 export Prevision, TestFunction, Indicator, apply, expect
 export Identity, Projection, NestedProjection, Tabular, LinearCombination, OpaqueClosure, FiringChoice
-export BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, TruncatedGaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ProductPrevision, MixturePrevision, LabelledCategoricalPrevision, RhoCategoricalPrevision
+export BetaPrevision, TaggedBetaPrevision, SparseStructurePrevision, GaussianPrevision, TruncatedGaussianPrevision, MvGaussianPrevision, GammaPrevision, CategoricalPrevision, DirichletPrevision, NormalGammaPrevision, ZeroMeanGammaPrevision, ProductPrevision, MixturePrevision, LabelledCategoricalPrevision, RhoCategoricalPrevision
 export ExchangeablePrevision, decompose
 export ParticlePrevision, QuadraturePrevision, MvQuadraturePrevision, _mv_points
 export ConditionalPrevision
@@ -532,6 +532,28 @@ struct NormalGammaPrevision <: Prevision
 end
 
 """
+    ZeroMeanGammaPrevision(α, β) <: Prevision
+
+A zero-mean Gaussian with unknown precision: `x ~ N(0, σ²)`, `τ = 1/σ² ~ Gamma(α, β)` (rate β). The
+mean is fixed at 0 — there is NO μ latent and no κ pseudo-count, which is exactly what
+`NormalGammaPrevision` cannot represent (its μ carries a κ-weighted prior; κ→∞ at μ=0 is degenerate).
+Conjugate to `ZeroMeanGammaLikelihood` (one obs `r`: α += 0.5, β += r²/2); the posterior-predictive is
+a zero-centred Student-t (ν = 2α, scale² = β/α). This is the **scale-free `:plateaued` regime** of the
+exploration-budget saturation signal — the noise floor is *inferred* from the data, never set
+(docs/exploration-budget/move-2-design.md §8).
+"""
+struct ZeroMeanGammaPrevision <: Prevision
+    α::Float64
+    β::Float64
+
+    function ZeroMeanGammaPrevision(α::Float64, β::Float64)
+        α > 0 || error("α must be positive")
+        β > 0 || error("β must be positive")
+        new(α, β)
+    end
+end
+
+"""
     ProductPrevision(factors::Vector{<:Prevision}) <: Prevision
 
 Prevision for an independent joint over a product space. Holds factors
@@ -1001,6 +1023,7 @@ params(p::GaussianPrevision)    = (type = :gaussian,    mu = p.mu,       sigma =
 params(p::MvGaussianPrevision)  = (type = :mv_gaussian, mu = copy(p.mu),
                                    sigma = [collect(Float64, r) for r in eachrow(p.Sigma)])
 params(p::GammaPrevision)       = (type = :gamma,       alpha = p.alpha, beta = p.beta)
+params(p::ZeroMeanGammaPrevision) = (type = :zero_mean_gamma, alpha = p.α, beta = p.β)
 params(p::DirichletPrevision)   = (type = :dirichlet,   alpha = copy(p.alpha))
 params(p::CategoricalPrevision) = (type = :categorical, log_weights = copy(p.log_weights))
 

--- a/src/program_space/agent_state.jl
+++ b/src/program_space/agent_state.jl
@@ -19,6 +19,35 @@ mutable struct AgentState
     all_programs::Vector{Program}
     grammars::Dict{Int, Grammar}            # grammar_id → Grammar
     current_max_depth::Int                  # current enumeration depth
+    # Belief-aware saturation signal (exploration-budget Move 2). The residual-plateau regime belief is
+    # a 2-regime BMA — a Measure (state-is-measure), the residual history summarised; `last_residual` is
+    # the previous step's predictive log-loss, a sufficient statistic for the decrement (one scalar
+    # suffices BECAUSE the history lives in the regime posterior). Both reset on grammar change
+    # (reset_learning_regime!). Move 2 is signal-only — nothing reads these for a decision until Move 3.
+    learning_regime::Ontology.MixturePrevision
+    last_residual::Union{Nothing, Float64}
+end
+
+# Backward-compatible 6-arg constructor: defaults the Move-2 saturation fields (uninformative regime, no
+# residual yet) and forwards to the 8-arg auto-constructor. Every existing AgentState(...) call site
+# (hosts, skin, persistence, tests) uses this and is unaffected.
+AgentState(belief, metadata, compiled_kernels, all_programs, grammars, current_max_depth) =
+    AgentState(belief, metadata, compiled_kernels, all_programs, grammars, current_max_depth,
+               initial_learning_regime(), nothing)
+
+"""
+    reset_learning_regime!(state) → state
+
+Reset the residual-plateau regime belief to its uninformative prior AND clear `last_residual`
+(exploration-budget Move 2, Q1b). Call on every grammar change — pre-change residuals were generated
+under a superseded alphabet and are stale; carrying them would drag the fresh inference. Starting the
+residual Measure afresh (not merely re-weighting toward :improving) is the principled response to a
+*caused* change-point (no BOCPD inference needed — the agent knows it changed the alphabet).
+"""
+function reset_learning_regime!(state::AgentState)
+    state.learning_regime = initial_learning_regime()
+    state.last_residual = nothing
+    state
 end
 
 """

--- a/src/program_space/perturbation.jl
+++ b/src/program_space/perturbation.jl
@@ -262,6 +262,46 @@ end
 _pick_better(best, cand) = (best === nothing || _candidate_better(cand, best)) ? cand : best
 
 """
+    _best_compression_candidate(g, freq_table; compute_cost = 0.0) → Union{Nothing, Tuple}
+
+The compression-class `net_voc` argmax over the MDL pair `{:add_rule} ∪ {:remove_rule candidates}`, or
+`nothing` if no candidate clears `net_voc > 0` (the saturation no-op). Returns the winning candidate
+`(voc, is_remove, name, kind, rule)` (see `_candidate_better` for the total order). The single home of
+the candidate logic — `perturb_grammar` applies it, `compression_exhausted` (Move 2) tests it for
+`nothing` — so the two can never disagree (DRY).
+"""
+function _best_compression_candidate(g::Grammar, freq_table::SubprogramFrequencyTable;
+                                     compute_cost::Float64 = 0.0)
+    best = nothing  # (voc, is_remove, name, kind, rule) — the running argmax; see _candidate_better
+
+    add = _compression_payoff(freq_table)
+    if !isnothing(add)
+        rule, net_payoff = add
+        if !(rule.name in Set(r.name for r in g.rules))         # idempotence guard (already-present name)
+            v = net_voc(net_payoff, compute_cost)               # VOC gate (forward compute priced in)
+            v > 0 && (best = _pick_better(best, (v, false, string(rule.name), :add, rule)))
+        end
+    end
+    for (rule, net_payoff) in _removal_payoff(g, freq_table)
+        v = net_voc(net_payoff, compute_cost)
+        v > 0 && (best = _pick_better(best, (v, true, string(rule.name), :remove, rule)))
+    end
+    best
+end
+
+"""
+    compression_exhausted(g, freq_table; compute_cost = 0.0) → Bool
+
+The prior-side half of the exploration budget's saturation signal (Move 2): `true` iff no
+compression-class meta-action improves the prior — i.e. `perturb_grammar` would be a no-op. Shares
+`_best_compression_candidate` with `perturb_grammar` exactly, so "exhausted" ≡ "`perturb_grammar`
+returns `g` unchanged" by construction. Prior-only, cheap (no belief, no lookahead). The belief-side
+half (residual plateau) lives in `saturation.jl`.
+"""
+compression_exhausted(g::Grammar, freq_table::SubprogramFrequencyTable; compute_cost::Float64 = 0.0)::Bool =
+    isnothing(_best_compression_candidate(g, freq_table; compute_cost = compute_cost))
+
+"""
     perturb_grammar(g, freq_table, available_features; compute_cost = 0.0) → Grammar
 
 Perturb a grammar by the compression-class meta-action whose `net_voc` is greatest, applied iff
@@ -288,21 +328,7 @@ function perturb_grammar(g::Grammar, freq_table::SubprogramFrequencyTable,
     # `add_programs_to_state!` deduplicates by `grammar.id`, so a fresh-id no-op would defeat the dedup
     # and re-inject every program as a fresh Beta(1,1) duplicate (a silent posterior reset — A3). Same
     # id ⇒ a no-op truly changes nothing. (Tested by test_perturb_consumption.jl.)
-    best = nothing  # (voc, is_remove, name, kind, rule) — the running argmax; see _candidate_better
-
-    add = _compression_payoff(freq_table)
-    if !isnothing(add)
-        rule, net_payoff = add
-        if !(rule.name in Set(r.name for r in g.rules))         # idempotence guard (already-present name)
-            v = net_voc(net_payoff, compute_cost)               # VOC gate (forward compute priced in)
-            v > 0 && (best = _pick_better(best, (v, false, string(rule.name), :add, rule)))
-        end
-    end
-    for (rule, net_payoff) in _removal_payoff(g, freq_table)
-        v = net_voc(net_payoff, compute_cost)
-        v > 0 && (best = _pick_better(best, (v, true, string(rule.name), :remove, rule)))
-    end
-
+    best = _best_compression_candidate(g, freq_table; compute_cost = compute_cost)
     best === nothing && return g                                # saturation no-op (the Move-2 signal)
     if best[4] === :add
         Grammar(g.feature_set, [g.rules; best[5]], next_grammar_id())

--- a/src/saturation.jl
+++ b/src/saturation.jl
@@ -1,0 +1,72 @@
+# saturation.jl — the belief-aware saturation signal: the residual-plateau regime belief.
+# Exploration-budget Move 2. Included inside module Ontology by ontology.jl, AFTER family_bma.jl.
+#
+# The belief-side half of the saturation signal (the prior-side half is `compression_exhausted` in
+# perturbation.jl). A 2-regime BMA over the per-step DECREMENT Δ = ℓ_prev − ℓ_now of the predictive
+# log-loss (Δ > 0 ⇒ the loss fell ⇒ the belief is still improving):
+#
+#   :plateaued — Δ ~ N(0, σ²), σ² INFERRED  (ZeroMeanGammaPrevision). Improvement is in the noise.
+#   :improving — Δ ~ N(μ, σ²), μ>0 favoured, σ² INFERRED  (NormalGammaPrevision, positive prior mean).
+#
+# SCALE-FREE Bayesian signal detection (the load-bearing ratified refinement, design §8): the noise
+# scale is inferred in BOTH regimes, so a slow-but-CONSISTENT improver stays :improving — its drift is
+# detectable above its own inferred noise, even at Δ ≈ 0.08 — never falsely plateaued by a fixed σ. The
+# carried posterior weight on :plateaued is the signal (average-not-collapse). It is a SOFT prior for
+# Move 3's exploration EU, never a hard gate (Q3). Reuses the Family-BMA machinery — no new mechanism;
+# the BMA reweighting in condition(::MixturePrevision) does the signal detection (evidence comparison).
+
+# Component order = candidate order in `_build_regime_model` (build_family_prior + condition preserve it).
+const _REGIME_PLATEAUED = 1
+const _REGIME_IMPROVING = 2
+
+function _build_regime_model()
+    obs = Euclidean(1)
+    # SCALE-FREE priors (the load-bearing ratified refinement). The precision (1/σ²) prior is
+    # near-Jeffreys diffuse — Gamma(0.01, 0.01) ≈ the scale-invariant reference prior p(σ²) ∝ 1/σ² — in
+    # BOTH regimes, so the noise floor is the DATA's (inferred), never imposed: a slow-but-consistent
+    # improver (Δ≈0.08) is detected above its own tiny noise, not read as plateaued. A Gamma(1,1) would
+    # pin the scale to ~1 and false-plateau slow tasks (the exact bug the design §8 stall gate refuses).
+    # The improving regime is the clean nested Bayesian t-test: μ free (μ₀=0, κ=0.1 weak ⇒ the μ prior
+    # width σ²/κ is σ-relative, so detection is scale-free) vs plateaued's μ≡0 — and the BMA evidence
+    # comparison in condition(::MixturePrevision) IS the signal detection. (μ₀=0 is symmetric: a
+    # sustained NEGATIVE drift — the loss diverging — also reads as "not plateaued". Acceptable for a
+    # SOFT signal, and arguably right: a worsening belief is not a saturated alphabet, so Move 3's
+    # lookahead should be free to consider it rather than be deferred.)
+    plateaued = FamilyCandidate(ZeroMeanGammaLikelihood(),
+                                ZeroMeanGammaPrevision(0.01, 0.01), obs, 0.0)
+    improving = FamilyCandidate(NormalGammaLikelihood(),
+                                NormalGammaPrevision(0.1, 0.0, 0.01, 0.01), obs, 0.0)
+    build_family_model([plateaued, improving])
+end
+
+# Built once at load (the model is stateless; the kernel's DispatchByComponent routes per regime).
+const _REGIME_MODEL = _build_regime_model()
+
+"""
+    initial_learning_regime() → MixturePrevision
+
+The uniform-prior 2-regime belief `{:plateaued, :improving}`. This is also the reset target on every
+grammar change (`reset_learning_regime!`) — pre-change residuals are stale under a new alphabet.
+"""
+initial_learning_regime() = build_family_prior(_REGIME_MODEL)
+
+"""
+    update_learning_regime(regime, ℓ_prev, ℓ_now) → MixturePrevision
+
+Condition the regime belief on the step's decrement `Δ = ℓ_prev − ℓ_now`, through Tier-1 `condition`
+(the BMA reweighting is the signal detection). At cold start (`ℓ_prev === nothing`, fewer than two
+residuals) there is no decrement, so the regime is returned unchanged.
+"""
+function update_learning_regime(regime::MixturePrevision, ℓ_prev, ℓ_now)
+    ℓ_prev === nothing && return regime
+    condition(regime, _REGIME_MODEL.kernel, ℓ_prev - ℓ_now)
+end
+
+"""
+    plateau_probability(regime) → Float64
+
+The carried posterior weight on `:plateaued` — the belief-side saturation signal. A SOFT, overridable
+prior for Move 3's exploration EU, NEVER a hard gate (Q3): "still improving" is not a proof of zero VOI,
+so it may never block a positive-EU explore. Read via the public `weights` accessor.
+"""
+plateau_probability(regime::MixturePrevision)::Float64 = weights(regime)[_REGIME_PLATEAUED]

--- a/test/test_program_space.jl
+++ b/test/test_program_space.jl
@@ -602,6 +602,43 @@ end
 println()
 
 # ═══════════════════════════════════════
+# TEST 14c: reset_learning_regime! starts the residual Measure afresh — exploration-budget Move 2 (Q1b)
+# ═══════════════════════════════════════
+# A grammar change invalidates the residual history (it was generated under a superseded alphabet), so
+# the reset must clear BOTH the regime belief and last_residual — not merely re-weight toward improving.
+
+println("=" ^ 60)
+println("TEST 14c: reset_learning_regime! clears the residual history")
+println("=" ^ 60)
+
+let
+    g = Grammar(Set([:red]), ProductionRule[], 1)
+    progs = enumerate_programs(g, 2; action_space=[:a, :b])
+    comps = Prevision[TaggedBetaPrevision(i, BetaPrevision(1.0, 1.0)) for i in eachindex(progs)]
+    state = AgentState(MixturePrevision(comps, zeros(length(progs))),
+                       [(1, i) for i in eachindex(progs)],
+                       [compile_kernel(p, g, i) for (i, p) in enumerate(progs)],
+                       progs, Dict(1 => g), 2)
+    # 6-arg constructor defaults the regime to the uniform prior.
+    @assert plateau_probability(state.learning_regime) ≈ 0.5 "fresh AgentState ⇒ uniform regime prior"
+
+    # Drive the regime off uniform with a consistent-improving residual series; set last_residual.
+    prev = nothing
+    for ℓ in [3.0, 2.7, 2.4, 2.1, 1.8]
+        state.learning_regime = update_learning_regime(state.learning_regime, prev, ℓ)
+        prev = ℓ
+    end
+    state.last_residual = 1.8
+    @assert plateau_probability(state.learning_regime) < 0.4 "precondition: regime moved off uniform"
+
+    reset_learning_regime!(state)
+    @assert plateau_probability(state.learning_regime) ≈ 0.5 "reset returns the regime to the uniform prior"
+    @assert state.last_residual === nothing "reset clears last_residual (residual Measure afresh)"
+    println("PASSED: reset clears the regime belief AND last_residual")
+end
+println()
+
+# ═══════════════════════════════════════
 # TEST 15: Proposed nonterminals are actual posterior subtrees (enforcement, spec §5.10)
 # ═══════════════════════════════════════
 

--- a/test/test_saturation.jl
+++ b/test/test_saturation.jl
@@ -1,0 +1,112 @@
+# test_saturation.jl — the belief-aware saturation signal (exploration-budget Move 2).
+# Covers: the ZeroMeanGammaPrevision conjugate primitive (the scale-free :plateaued regime), the
+# compression_exhausted prior-side half (≡ perturb_grammar no-op), and the 2-regime BMA plateau signal
+# — including the SCALE-FREE slow-improver test (the one a fixed-σ model fails) and the no-hard-gate
+# contract (Q3). The reset-clears-history test lives in test_program_space.jl (it needs AgentState).
+#
+# Run: julia test/test_saturation.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: ZeroMeanGammaPrevision, ZeroMeanGammaLikelihood, condition, log_predictive, params,
+                weights, Kernel, Euclidean, PositiveReals, wrap_in_measure, GaussianPrevision,
+                Grammar, ProductionRule, SubprogramFrequencyTable, Program, GTExpr, LTExpr, AndExpr,
+                IfExpr, ActionExpr, ProgramExpr, analyse_posterior_subtrees, perturb_grammar,
+                compression_exhausted, initial_learning_regime, update_learning_regime, plateau_probability
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+
+println("="^64)
+println("saturation — ZeroMeanGamma primitive + compression_exhausted + regime BMA")
+println("="^64)
+
+# ── (1) ZeroMeanGammaPrevision conjugate primitive (the scale-free :plateaued component) ──
+_zmg_kernel() = Kernel(PositiveReals(), Euclidean(1),
+                       h -> wrap_in_measure(GaussianPrevision(0.0, sqrt(h))),
+                       (h, o) -> -0.5 * o^2 / h;
+                       likelihood_family = ZeroMeanGammaLikelihood())
+let
+    p = ZeroMeanGammaPrevision(1.0, 1.0)
+    k = _zmg_kernel()
+    post = condition(p, k, 2.0)
+    check("ZeroMeanGamma conjugate update: α+=0.5, β+=r²/2", post.α == 1.5 && post.β == 3.0,
+          "got $(params(post))")
+    p2 = condition(condition(p, k, 1.0), k, 1.0)
+    check("ZeroMeanGamma accumulates: α=2.0, β=1+0.5+0.5=2.0", p2.α == 2.0 && p2.β == 2.0,
+          "got $(params(p2))")
+    # Zero-mean Student-t PROPERTIES (oracle-free): symmetric about 0 (the defining zero-mean property,
+    # which a μ≠0 NormalGamma would break), and peaked at 0 (decreasing in |r|).
+    check("log_predictive symmetric about 0 (zero-mean)", log_predictive(p, k, 0.7) ≈ log_predictive(p, k, -0.7))
+    check("log_predictive peaked at 0 (decreasing in |r|)", log_predictive(p, k, 0.5) > log_predictive(p, k, 3.0))
+end
+
+# ── (2) compression_exhausted ≡ perturb_grammar no-op (the prior-side half, Move-1 reuse) ──
+let
+    g = Grammar(Set([:red, :green]), ProductionRule[], 1)
+    s = AndExpr(GTExpr(:red, 0.7), LTExpr(:green, 0.3))
+    progs = Program[Program(IfExpr(s, ActionExpr(:a), ActionExpr(:b)), 6, 1) for _ in 1:3]
+    ft = analyse_posterior_subtrees(progs, fill(1 / 3, 3); min_frequency = 0.0, min_complexity = 2)
+    check("compressing table ⇒ NOT exhausted", compression_exhausted(g, ft) == false)
+    check("not-exhausted ⇒ perturb adds a rule", length(perturb_grammar(g, ft).rules) == 1)
+
+    empty_ft = SubprogramFrequencyTable(ProgramExpr[], Float64[], Vector{Int}[])
+    check("empty table ⇒ exhausted", compression_exhausted(g, empty_ft) == true)
+    check("exhausted ⇒ perturb is a no-op (same grammar object)", perturb_grammar(g, empty_ft) === g)
+    check("compute_cost above payoff·log2 ⇒ exhausted", compression_exhausted(g, ft; compute_cost = 100.0) == true)
+end
+
+# ── (3)+(4) the regime BMA — directional, and SCALE-FREE ──
+function run_regime(losses)
+    regime = initial_learning_regime()
+    prev = nothing
+    for ℓ in losses
+        regime = update_learning_regime(regime, prev, ℓ)
+        prev = ℓ
+    end
+    regime
+end
+let
+    # Cold start: < 2 residuals ⇒ uniform prior (not saturated).
+    check("cold start: plateau_probability at uniform prior", plateau_probability(run_regime([2.0])) ≈ 0.5)
+
+    # Phase A — CONSISTENT improvement (steady positive decrements) ⇒ improving ⇒ low plateau prob.
+    # (A *decelerating* series — big drops then tiny — correctly reads as transitional/plateauing; the
+    # clean "improving" signal is consistency, not mere decrease.)
+    phaseA = Float64[3.0]
+    for i in 1:8
+        push!(phaseA, phaseA[end] - (iseven(i) ? 0.31 : 0.29))   # Δ ≈ 0.3 steady
+    end
+    pA = plateau_probability(run_regime(phaseA))
+    check("Phase A (consistent improvement) ⇒ low plateau probability", pA < 0.3, "got $pA")
+
+    # Phase B — bouncing flat ⇒ plateaued ⇒ high plateau prob.
+    phaseB = [0.755, 0.758, 0.752, 0.757, 0.754, 0.756, 0.753, 0.755, 0.754, 0.756]
+    pB = plateau_probability(run_regime(phaseB))
+    check("Phase B (flat) ⇒ high plateau probability", pB > 0.7, "got $pB")
+    check("ordering: plateaued ≫ improving (B ≫ A)", pB > pA, "pA=$pA pB=$pB")
+
+    # SCALE-FREE: a slow-but-CONSISTENT improver (Δ ≈ 0.08, far below Phase A's 0.3–1.3 drops, small
+    # bounce) stays improving — its drift is detectable above its OWN inferred noise. A fixed-σ model
+    # calibrated to the big drops would falsely call this plateaued; assert it does NOT.
+    slow = Float64[3.0]
+    for i in 1:11
+        push!(slow, slow[end] - (iseven(i) ? 0.09 : 0.07))   # decrements alternate 0.07/0.09 (mean 0.08)
+    end
+    pslow = plateau_probability(run_regime(slow))
+    check("slow-but-consistent improver ⇒ NOT plateaued (scale-free)", pslow < 0.3, "got $pslow")
+end
+
+# ── (5) determinism + the no-hard-gate contract (Q3) ──
+let
+    series = [1.0, 0.8, 0.78, 0.781, 0.779, 0.78]
+    check("regime conditioning is deterministic",
+          plateau_probability(run_regime(series)) == plateau_probability(run_regime(series)))
+    # Q3: Move 2 exposes the COMPONENTS (compression_exhausted, plateau_probability), no hard veto.
+    check("no hard-gate `saturated` veto is exported", !isdefined(Credence, :saturated))
+end
+
+println("="^64)
+println("ALL CHECKS PASSED — saturation")
+println("="^64)


### PR DESCRIPTION
## Move 2 code — the saturation signal (the belief-aware meta-level entry)

The code for Move 2, stacked on the merged design (#167). The arc's **first belief-aware** move. **Mechanism only** — the consumer (`explore_grammar`) is Move 3 — so this is strictly additive / behaviour-preserving.

`saturated = compression-exhausted (prior-side) ∧ residual-plateaued (belief-side)`.

### What landed

- **Prior-side (Move-1 reuse, bit-exact):** `_best_compression_candidate` factored out of `perturb_grammar` (DRY); `compression_exhausted = isnothing(best)` — "exhausted" ≡ "`perturb_grammar` is a no-op" by construction.
- **Belief-side:** a 2-regime BMA `{:plateaued, :improving}` over the per-step decrement `Δ = ℓ_prev − ℓ_now` of the predictive log-loss, conditioned each step via the existing `condition(::MixturePrevision)`. The carried weight on `:plateaued` is the signal (`average-not-collapse`); a **soft prior** for Move 3's EU, never a hard gate (Q3 — components exposed, no `saturated()` veto). History-as-Measure (`state-is-measure`): `last_residual` is one sufficient-statistic scalar *because* the history lives in the posterior.
- **`reset_learning_regime!`** starts the residual Measure afresh on a grammar change (Q1b).

### The scale-free keystone (design §8)

A `Gamma(1,1)` precision prior pins the noise scale to ~1 and **false-plateaus slow tasks** — the exact bug the stall gate refuses. Two forced refinements:

1. **New exact conjugate primitive `ZeroMeanGammaPrevision`** (zero-mean Gaussian, unknown precision; α += 0.5, β += r²/2; zero-centred Student-t marginal). `NormalGammaPrevision` cannot soundly encode μ≡0 (κ→∞ degenerate). Constitution-sanctioned ("named distributions may be added").
2. **Near-Jeffreys `Gamma(0.01,0.01)` precision prior in both regimes** ⇒ the noise floor is the *data's* (inferred). The `:improving` regime is the clean nested Bayesian t-test (μ free, μ₀=0, κ=0.1 ⇒ σ-relative detection).

Empirically: consistent-improving → 0.0, flat → 0.86, **slow Δ≈0.08 → 0.0** (scale-free), cold-start → 0.5, decelerating → 0.33 (graceful). The slow-improver is pinned as the scale-free guard.

### Deferred to Move 3

**Host wiring** (compute `−log_predictive` at the conditioning sites; `reset_learning_regime!` at grammar-change sites) — mirrors the Q5 skin-exposure deferral ("no consumer yet"); avoids wire-then-rewire and hot-loop risk. The signal mechanism is complete and unit-tested without it.

### Tests

- `test_saturation.jl` — ZeroMeanGamma conjugate update + zero-mean Student-t properties; `compression_exhausted` ≡ no-op; regime direction (improving/flat); **the slow-improver scale-free keystone**; determinism; the no-hard-gate contract.
- `test_program_space.jl` TEST 14c — `reset_learning_regime!` clears both the regime belief and `last_residual`.
- Full Julia suite **48/48 green**; lint corpus + `check apps/` + new `src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
