### PR TITLE
feat(exploration-budget): Move 3 code — lookahead VOI for threshold refinement + host wiring

### DIFF
--- a/apps/julia/email_agent/cost_model.jl
+++ b/apps/julia/email_agent/cost_model.jl
@@ -33,6 +33,7 @@ function default_cost_model(; time_value::Float64=0.02)
         :enumerate_more  => ng(log(0.5)),
         :perturb_grammar => ng(log(0.5)),
         :deepen          => ng(log(1.0)),
+        :explore         => ng(log(2.0)),   # belief-aware lookahead: re-enumerate + re-condition per candidate
         :ask_llm         => ng(log(3.0)),
         :ask_user        => ng(log(10.0)),
         :jmap_fetch      => ng(log(1.0)),

--- a/apps/julia/email_agent/host.jl
+++ b/apps/julia/email_agent/host.jl
@@ -249,6 +249,21 @@ function compute_meta_eu(
         return base - expected_cost(cost_model, :perturb_grammar) - meta_cost_this_turn
     elseif action == :deepen
         return entropy_benefit * 0.4 - expected_cost(cost_model, :deepen) - meta_cost_this_turn
+    elseif action == :explore
+        # Saturation-gated belief-aware threshold refinement (Move 3). Same two-orthogonal-halves
+        # rationale as grid_world: residual-plateau (belief-side SOFT prior, Q3 — scales the EU) ∧
+        # compression-exhausted (prior-side, lazy). Gated on last_residual !== nothing so it is live only
+        # where the residual regime is fed (the single-decision path); a safe -Inf on the episode path.
+        state.last_residual === nothing && return -Inf
+        plateau = plateau_probability(state.learning_regime)
+        eu_explore = plateau * 0.6 - expected_cost(cost_model, :explore) - meta_cost_this_turn
+        eu_explore <= 0.0 && return eu_explore
+        top = top_k_grammar_ids(state, 1)
+        isempty(top) && return -Inf
+        freq_table = analyse_posterior_subtrees(state.all_programs, weights(state.belief);
+                                                min_frequency=0.01, min_complexity=2)
+        compression_exhausted(state.grammars[top[1]], freq_table) || return -Inf
+        return eu_explore
     end
     -Inf
 end
@@ -425,6 +440,7 @@ function execute_meta_action!(
     action::Symbol;
     action_space::Vector{Symbol}=DOMAIN_ACTIONS,
     min_log_prior::Float64=-20.0,
+    explore_buffer::Vector{ExploreObservation}=ExploreObservation[],
     verbose::Bool=false
 )::Int
     if action == :enumerate_more
@@ -466,6 +482,24 @@ function execute_meta_action!(
                 action_space=action_space, min_log_prior=min_log_prior)
         end
         verbose && println("  [Meta: deepen → depth=$(state.current_max_depth), +$n_added components]")
+        return n_added
+
+    elseif action == :explore
+        # Belief-aware threshold refinement (Move 3); see grid_world for the canonical shape. The ONLY
+        # meta-action that resets the residual regime (it expands the threshold alphabet — Q1b). compute_cost
+        # is the predictive-log-loss floor (nats) a refinement must clear, distinct from the meta-time cost.
+        top = top_k_grammar_ids(state, 1)
+        isempty(top) && return 0
+        gid = top[1]
+        new_g = explore_grammar(state.grammars[gid], explore_buffer, state.current_max_depth;
+                                action_space=action_space, compute_cost=0.1)
+        new_g.id == gid && return 0   # no positive-VOI refinement → no-op
+        state.grammars[new_g.id] = new_g
+        n_added = add_programs_to_state!(state, new_g, state.current_max_depth;
+            action_space=action_space, min_log_prior=min_log_prior)
+        reset_learning_regime!(state)
+        empty!(explore_buffer)
+        verbose && println("  [Meta: explore → grammar $gid→$(new_g.id) (threshold refined), +$n_added components]")
         return n_added
     end
     0
@@ -782,6 +816,10 @@ function run_agent(;
     temporal_state = Dict{Symbol, Any}(:recent => Dict{Symbol, Float64}[])
     metrics = EmailMetricsTracker()
 
+    # The explore buffer (Move 3): host-side observations under the current threshold alphabet (data, not
+    # belief — Q2b). Fed in the single-decision path; the lookahead replays it; cleared on refinement.
+    explore_buffer = ExploreObservation[]
+
     # 2. MAIN LOOP
     for (step, email) in enumerate(corpus)
         correct_action = user_pref.decide(email)
@@ -862,7 +900,7 @@ function run_agent(;
                    meta_actions_taken < max_meta_per_step
                     elapsed = @elapsed execute_meta_action!(state, chosen_action;
                         action_space=DOMAIN_ACTIONS, min_log_prior=min_log_prior,
-                        verbose=verbose)
+                        explore_buffer=explore_buffer, verbose=verbose)
                     observe_cost!(cost_model, chosen_action, elapsed)
                     meta_actions_taken += 1
                     meta_cost_this_turn += expected_cost(cost_model, chosen_action)
@@ -905,6 +943,16 @@ function run_agent(;
             w = weights(state.belief)
             eu_correct = compute_eu(state, correct_action, rec_cache, w; ask_cost=ask_cost)
             surprise = -log(max(eu_correct, 1e-300))
+
+            # Feed the residual-plateau regime (the Move-2 saturation signal, wired here in Move 3 —
+            # `surprise` IS ℓ = −log predictive) and accumulate the explore buffer. Belief-conditioning
+            # below is untouched: this only updates the Move-2/3 side state.
+            state.learning_regime = update_learning_regime(state.learning_regime,
+                                                           state.last_residual, surprise)
+            state.last_residual = surprise
+            push!(explore_buffer, ExploreObservation(features,
+                Dict{Symbol, Any}(:recent => copy(get(temporal_state, :recent, Dict{Symbol, Float64}[]))),
+                Set([correct_action]), surprise))
 
             k = build_email_observation_kernel(
                 state.compiled_kernels, features,

--- a/apps/julia/email_agent/preferences.jl
+++ b/apps/julia/email_agent/preferences.jl
@@ -13,7 +13,10 @@ const DOMAIN_ACTIONS = [:archive, :flag_urgent, :schedule_later,
                         :triage_urgent, :silent_archive, :escalate]
 
 # Meta-actions: computational operations evaluated by EU
-const META_ACTIONS = [:enumerate_more, :perturb_grammar, :deepen, :do_nothing]
+# :explore — the belief-aware threshold-refinement budget (exploration-budget Move 3); gated on
+# saturation (compression-exhausted ∧ residual-plateau) and only live where the regime is fed (the
+# single-decision run_agent path), a safe no-op on the episode path (empty buffer).
+const META_ACTIONS = [:enumerate_more, :perturb_grammar, :deepen, :explore, :do_nothing]
 
 # Sensor actions: gather more information before deciding
 const SENSOR_ACTIONS = [:ask_llm]

--- a/apps/julia/grid_world/host.jl
+++ b/apps/julia/grid_world/host.jl
@@ -47,8 +47,11 @@ const GW_META_ACTIONS = [:gw_enumerate_more, :gw_perturb_grammar, :gw_deepen, :g
 const GW_ENUMERATE_COST = 0.05
 const GW_PERTURB_COST = 0.05
 const GW_DEEPEN_COST = 0.10
-const GW_EXPLORE_COST = 0.10   # the lookahead is expensive (re-enumerate + re-condition per candidate)
-const GW_EXPLORE_BASE = 0.6    # the saturation-scaled value the residual-plateau prior multiplies (Q3)
+const GW_EXPLORE_COST = 0.10       # meta-time cost of the explore meta-action (the lookahead is expensive)
+const GW_EXPLORE_BASE = 0.6        # the saturation-scaled value the residual-plateau prior multiplies (Q3)
+const GW_EXPLORE_VOI_FLOOR = 0.10  # min predictive-log-loss gain (nats) a refinement must clear — a
+                                   # DISTINCT currency from GW_EXPLORE_COST (meta-time), passed as the
+                                   # explore_grammar compute_cost (cf. email host's expected_cost vs 0.1)
 
 # ═══════════════════════════════════════
 # Build the observation kernel
@@ -265,7 +268,7 @@ function execute_gw_meta_action!(
         isempty(top) && return 0
         gid = top[1]
         new_g = explore_grammar(state.grammars[gid], explore_buffer, state.current_max_depth;
-                                action_space=gw_action_space, compute_cost=GW_EXPLORE_COST)
+                                action_space=gw_action_space, compute_cost=GW_EXPLORE_VOI_FLOOR)
         new_g.id == gid && return 0   # no positive-VOI refinement → no-op
         state.grammars[new_g.id] = new_g
         n_added = add_programs_to_state!(state, new_g, state.current_max_depth;

--- a/apps/julia/grid_world/host.jl
+++ b/apps/julia/grid_world/host.jl
@@ -24,11 +24,14 @@ using Credence: density, log_density_at, prune, truncate
 using Credence: AgentState, sync_prune!, sync_truncate!
 using Credence: Grammar, Program, CompiledKernel, ProductionRule
 using Credence: enumerate_programs, compile_kernel
-using Credence: analyse_posterior_subtrees, perturb_grammar
+using Credence: analyse_posterior_subtrees, perturb_grammar, compression_exhausted
 using Credence: aggregate_grammar_weights, top_k_grammar_ids, add_programs_to_state!
 using Credence: next_grammar_id, reset_grammar_counter!
 using Credence: show_expr, GTExpr, LTExpr, AndExpr, OrExpr, NotExpr, NonterminalRef, ActionExpr, IfExpr
 using Credence: SubprogramFrequencyTable
+# Move 3 — the belief-aware exploration budget (threshold refinement) + the Move-2 saturation signal.
+using Credence: explore_grammar, ExploreObservation
+using Credence: update_learning_regime, plateau_probability, reset_learning_regime!
 
 include("simulation.jl")
 include("terminals.jl")
@@ -40,10 +43,12 @@ using Random
 # Meta-action constants
 # ═══════════════════════════════════════
 
-const GW_META_ACTIONS = [:gw_enumerate_more, :gw_perturb_grammar, :gw_deepen, :gw_do_nothing]
+const GW_META_ACTIONS = [:gw_enumerate_more, :gw_perturb_grammar, :gw_deepen, :gw_explore, :gw_do_nothing]
 const GW_ENUMERATE_COST = 0.05
 const GW_PERTURB_COST = 0.05
 const GW_DEEPEN_COST = 0.10
+const GW_EXPLORE_COST = 0.10   # the lookahead is expensive (re-enumerate + re-condition per candidate)
+const GW_EXPLORE_BASE = 0.6    # the saturation-scaled value the residual-plateau prior multiplies (Q3)
 
 # ═══════════════════════════════════════
 # Build the observation kernel
@@ -175,6 +180,22 @@ function compute_gw_meta_eu(
         return base - GW_PERTURB_COST - meta_cost_this_turn
     elseif action == :gw_deepen
         return uncertainty_benefit * 0.4 - GW_DEEPEN_COST - meta_cost_this_turn
+    elseif action == :gw_explore
+        # Saturation-gated belief-aware exploration (Move 3). Two orthogonal halves, BOTH required
+        # (master plan §3.2): the residual-plateau (belief-side, the SOFT prior — Q3 — it SCALES the EU
+        # continuously, never a hard threshold) AND compression-exhausted (prior-side — perturb would
+        # no-op; orthogonal because compression is a prior effect, the residual a fit effect). The costly
+        # prior-side check is lazy: skipped unless the belief-side EU is already positive (so the
+        # freq_table is built only when exploration is even viable on the residual).
+        plateau = plateau_probability(state.learning_regime)
+        eu_explore = plateau * GW_EXPLORE_BASE - GW_EXPLORE_COST - meta_cost_this_turn
+        eu_explore <= 0.0 && return eu_explore
+        top = top_k_grammar_ids(state, 1)
+        isempty(top) && return -Inf
+        freq_table = analyse_posterior_subtrees(state.all_programs, weights(state.belief);
+                                                min_frequency=0.01, min_complexity=2)
+        compression_exhausted(state.grammars[top[1]], freq_table) || return -Inf
+        return eu_explore
     end
     -Inf
 end
@@ -186,7 +207,8 @@ Execute a grid-world meta-action. Returns the number of programs added.
 """
 function execute_gw_meta_action!(
     state::AgentState,
-    action::Symbol;
+    action::Symbol,
+    explore_buffer::Vector{ExploreObservation};
     include_temporal::Bool=false,
     verbose::Bool=false
 )::Int
@@ -231,6 +253,26 @@ function execute_gw_meta_action!(
                 action_space=gw_action_space, include_temporal=include_temporal)
         end
         verbose && println("  [Meta: deepen → depth=$(state.current_max_depth), +$n_added components]")
+        return n_added
+
+    elseif action == :gw_explore
+        # Belief-aware threshold refinement (Move 3): refine the top grammar's grid by the candidate whose
+        # lookahead VOI (against the residual buffer) clears compute_cost; no-op if none does. The ONLY
+        # meta-action that resets the residual regime — it expands the threshold alphabet, so pre-change
+        # residuals are stale (Q1b, read precisely as "alphabet expansion" — perturb/deepen/enumerate are
+        # within-alphabet and their effects show up in later residuals, so they do NOT reset).
+        top = top_k_grammar_ids(state, 1)
+        isempty(top) && return 0
+        gid = top[1]
+        new_g = explore_grammar(state.grammars[gid], explore_buffer, state.current_max_depth;
+                                action_space=gw_action_space, compute_cost=GW_EXPLORE_COST)
+        new_g.id == gid && return 0   # no positive-VOI refinement → no-op
+        state.grammars[new_g.id] = new_g
+        n_added = add_programs_to_state!(state, new_g, state.current_max_depth;
+            action_space=gw_action_space, include_temporal=include_temporal)
+        reset_learning_regime!(state)
+        empty!(explore_buffer)
+        verbose && println("  [Meta: explore → grammar $gid→$(new_g.id) (threshold refined), +$n_added components]")
         return n_added
     end
     0
@@ -290,6 +332,11 @@ function run_agent(;
     grammar_dict = Dict{Int, Grammar}(g.id => g for g in grammar_pool)
     state = AgentState(belief, metadata, compiled_kernels, all_programs,
                        grammar_dict, program_max_depth)
+
+    # The explore buffer (Move 3): host-side record of observations under the current threshold alphabet
+    # (data, not belief — brain/body split, Q2b). Fed each conditioning step; the lookahead replays it;
+    # cleared on threshold refinement (alphabet expansion).
+    explore_buffer = ExploreObservation[]
 
     # Temporal state
     temporal_window = TemporalWindow(max_history=10)
@@ -353,11 +400,12 @@ function run_agent(;
 
                 best_meta_eu <= 0.0 && break
 
-                execute_gw_meta_action!(state, best_meta;
+                execute_gw_meta_action!(state, best_meta, explore_buffer;
                     include_temporal=include_temporal, verbose=verbose)
                 meta_actions_taken += 1
                 meta_cost_this_turn += (best_meta == :gw_deepen ? GW_DEEPEN_COST :
                                         best_meta == :gw_perturb_grammar ? GW_PERTURB_COST :
+                                        best_meta == :gw_explore ? GW_EXPLORE_COST :
                                         GW_ENUMERATE_COST)
 
                 sync_prune!(state; threshold=-30.0)
@@ -396,6 +444,16 @@ function run_agent(;
                     LinearCombination(Tuple{Float64, TestFunction}[(-1.0, Identity())], 1.0)))
                 p_obs = is_enemy ? p_enemy_val : (1.0 - p_enemy_val)
                 surprise = -log(max(p_obs, 1e-300))
+
+                # Feed the residual-plateau regime (the Move-2 saturation signal, wired here in Move 3 —
+                # `surprise` IS ℓ = −log predictive) and accumulate the explore buffer. Belief-conditioning
+                # below is untouched: this only updates the Move-2/3 side state.
+                state.learning_regime = update_learning_regime(state.learning_regime,
+                                                               state.last_residual, surprise)
+                state.last_residual = surprise
+                push!(explore_buffer, ExploreObservation(features,
+                    Dict{Symbol, Any}(:recent => copy(get(temporal_state, :recent, Dict{Symbol, Float64}[]))),
+                    Set([true_type]), surprise))
             else
                 surprise = 0.0
                 p_enemy_val = 0.5

--- a/docs/exploration-budget/move-3-design.md
+++ b/docs/exploration-budget/move-3-design.md
@@ -383,3 +383,55 @@ figures travel with the paper (paper-as-gating-artifact).
 (ii) with the predictive-Occam justification recorded as **load-bearing on Q3a**; residual-as-order not
 cutoff; predictive nats; the cap-free sequential stop **with the completeness guard**; scope (b). No
 escalation. The Q1(b)≡Q3(a) coupling and the SPEC §1.3 margin note are part of the design-doc PR.
+
+## 9. Code-time refinements (Move 3 code, ratified 2026-06-29)
+
+Surfaced during implementation and ratified before the host integration. Each is forced by a constraint,
+not chosen.
+
+1. **`explore_grammar` is self-contained in `src/`, not a host replay closure — forced by Invariant 1.**
+   The lookahead's marginal-log-loss accumulation (`Σ −log_predictive`) feeds the explore decision, so it
+   cannot live in `apps/` (the spatial face forbids apps/ summing log-probs to influence behaviour). The
+   replay therefore lives in `src/program_space/exploration.jl`, which required lifting a generic
+   `program_space_observation_kernel` into `src/` — grid_world's + email_agent's `build_observation_kernel`
+   (and email_agent's `build_step_kernel`) are the **same closure**, so the lift is a latent dedup. The
+   host copies are left untouched (a NOTE'd DRY follow-up) to keep the live conditioning trajectories
+   bit-stable.
+
+2. **No live `belief` argument.** Signature: `explore_grammar(g, observations, max_depth; action_space,
+   compute_cost)`. Belief-awareness flows through the buffer's per-observation `residual` (the screen
+   *order*) + the **counterfactual replay** (mll under each candidate grammar) — the lookahead reconstructs
+   beliefs per grammar, so the *current* belief object is not an input. `ExploreObservation(features,
+   temporal_state, correct_actions, residual)` is the host-side buffer (Q2b).
+
+3. **Full-eval-argmax, not a residual-order early-stop — Q3b's provable form.** Residual is the evaluation
+   *order* (Q2a); the result is the global argmax over the finite candidate set → one-sided by
+   construction. The completeness-guard test proves it (0.625 wins even as the lowest-residual candidate).
+   `compute_cost` prices each lookahead (graceful degradation via the cost-gated boundary, which flips
+   continuously at `Δℓ`); budget-*limited* early termination is a future hook (the residual order is its
+   seam).
+
+4. **Reset on alphabet expansion (explore) only — NOT on perturb/deepen/enumerate.** A precise reading of
+   Q1b ("superseded alphabet"): compression is a *prior* effect (fit unchanged), and deepen/enumerate are
+   *within-alphabet* — their effects surface in *subsequent* data residuals, which the regime tracks
+   without reset. Only threshold/feature expansion supersedes the alphabet and resets the regime + clears
+   the buffer. This makes the integration far less invasive (perturb/deepen/enumerate untouched) and is
+   *more* correct than resetting on every grammar-id change.
+
+5. **email_agent scope: the single-decision `run_agent` path (default) is fully wired; the episode path is
+   safely gated off.** `:explore`'s meta-EU returns `-Inf` when `state.last_residual === nothing` — true on
+   the episode path (which does not feed the regime), so `:explore` is never chosen there and
+   `execute_meta_action!`'s empty-buffer default makes it a no-op regardless. The episode-path residual
+   feed is a NOTE'd follow-up; the single-decision path is the canonical email integration, mirroring
+   grid_world.
+
+6. **The saturation gate in the host meta-EU.** `:explore` is admissible only when **both** halves hold
+   (master plan §3.2): `compression_exhausted` (prior-side, lazy — computed only when the belief-side EU is
+   already positive) **and** the residual-plateau, where `plateau_probability` is the **soft prior** (Q3 —
+   it scales the EU continuously, never a hard threshold). The two are orthogonal (prior vs fit), so both
+   are required.
+
+7. **Skin: no wire change.** The `Grammar.thresholds` field is defaulted and not serialised outbound; the
+   3-arg `Grammar(::Set,::Vector,::Int)` constructor is unchanged; `explore` is a host-orchestrated
+   meta-action with no wire verb (a wire-parity follow-up if external apps ever drive exploration). The
+   skin smoke is unaffected.

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -26,6 +26,7 @@ include("program_space/enumeration.jl")
 include("program_space/compilation.jl")
 include("program_space/perturbation.jl")
 include("program_space/agent_state.jl")
+include("program_space/exploration.jl")
 
 using .Parse
 using .Previsions
@@ -82,6 +83,7 @@ export enumerate_programs, enumerate_programs_as_measure
 export compile_kernel, compile_expr, evaluate_predicate
 export analyse_posterior_subtrees, extract_subtrees
 export propose_nonterminal, perturb_grammar, net_voc, compression_exhausted
+export ExploreObservation, explore_grammar, program_space_observation_kernel, default_thresholds
 export expr_equal
 export AgentState, sync_prune!, sync_truncate!, reset_learning_regime!
 export aggregate_grammar_weights, top_k_grammar_ids

--- a/src/program_space/enumeration.jl
+++ b/src/program_space/enumeration.jl
@@ -6,7 +6,8 @@
 # Complexity scoring
 # ═══════════════════════════════════════
 
-const THRESHOLDS = [0.1, 0.3, 0.5, 0.7, 0.9]
+# `THRESHOLDS` (the default per-feature grid seed) now lives in types.jl with `Grammar` — it is
+# grammar-structural data, and enumeration reads each grammar's own `g.thresholds[feat]` below.
 
 function expr_complexity(e::GTExpr) 1 end
 function expr_complexity(e::LTExpr) 1 end
@@ -70,7 +71,7 @@ function enumerate_programs(g::Grammar, max_depth::Int;
 
     atoms = ProgramExpr[]
     for feat in sort(collect(g.feature_set))  # sorted for deterministic enumeration
-        for t in THRESHOLDS
+        for t in g.thresholds[feat]            # per-feature grid (Move 3); default ≡ global THRESHOLDS
             push!(atoms, GTExpr(feat, t))
             push!(atoms, LTExpr(feat, t))
         end

--- a/src/program_space/exploration.jl
+++ b/src/program_space/exploration.jl
@@ -105,10 +105,14 @@ end
 
 The standard program-space BetaBernoulli per-component conditioning kernel: each component (a
 `TaggedBetaPrevision` tagged by program index) evaluates its compiled kernel on `features` → a recommended
-action; the recommendation is "correct" iff it is in `correct_actions`; the per-component Beta updates
-toward correct/incorrect. `correct_actions::Set` generalises the single-outcome hosts (`Set([true_type])`)
-and email_agent's multi-action step (the set of still-needed actions). The `correct_cache` in `params` is
-read by the `BetaBernoulli` condition dispatch for the per-component update direction.
+action; the recommendation is "correct" iff it is in `correct_actions`. The per-program learning is
+carried by the **mixture reweight** — `_predictive_ll` returns `log(p)` for a correct component and
+`log(1−p)` for an incorrect one (the closure's return), so `condition(::MixturePrevision)` shifts weight
+toward programs that predict the outcome. `correct_actions::Set` generalises the single-outcome hosts
+(`Set([true_type])`) and email_agent's multi-action step (the set of still-needed actions). `correct_cache`
+in `params` is populated as a side effect for parity with the host kernels (and a future dedup), but is
+NOT read by the conditioning dispatch: `update(ConjugatePrevision{BetaPrevision, BetaBernoulli}, 1.0)`
+increments α unconditionally — the discrimination is the reweight, not the per-component Beta direction.
 
 This is the engine-level home of logic the hosts currently duplicate (grid_world/email_agent
 `build_observation_kernel` + email_agent `build_step_kernel` are the same closure); the lookahead replay

--- a/src/program_space/exploration.jl
+++ b/src/program_space/exploration.jl
@@ -1,0 +1,261 @@
+"""
+    exploration.jl — the belief-aware exploration budget: compute-budgeted lookahead VOI for
+    threshold refinement (exploration-budget Move 3).
+
+The belief-aware sibling of prior-only `perturbation.jl`. Where `perturb_grammar` prices the COMPRESSION
+class depth-one in prior nats (`net_voc`), `explore_grammar` prices the GENERATIVE-CHANGE class — here,
+threshold refinement — by **lookahead against the belief's predictive residual** (master plan §2): a
+threshold is complexity-invariant (zero prior signal, all fit), so the only honest valuation is to
+*actually* refine the grid, re-enumerate, re-condition the buffer, and measure the realised marginal
+log-loss reduction `Δℓ` (Q3a — predictive nats). The fineness-Occam is carried by that marginal
+likelihood, NOT the prior (SPEC §1.3 margin; Q1(b)≡Q3(a)) — a noise-fitting split does not improve the
+predictive, so refinement self-limits.
+
+Architecture (code-time refinement of the ratified `explore_grammar(belief, g, observations)` signature):
+self-contained in `src/` so the mll accumulation (probability arithmetic feeding the explore decision)
+stays out of `apps/` (Invariant 1, spatial). Belief-awareness flows through the buffer's per-observation
+`residual` (where the belief mispredicts — the screen ORDER, Q2a) and the counterfactual replay (mll under
+each candidate grammar), not a live belief argument — the lookahead reconstructs beliefs per grammar.
+"""
+
+using .Ontology
+
+# ═══════════════════════════════════════
+# The observation buffer — the host's record of evidence under the current alphabet
+# ═══════════════════════════════════════
+
+"""
+    ExploreObservation(features, temporal_state, correct_actions, residual)
+
+One conditioning event in the explore buffer (host-side DATA, not belief — brain/body split, Q2b). Carries
+exactly what the lookahead needs:
+- `features` — the feature dict, for (a) proposing threshold candidates at observed values and (b) replay.
+- `temporal_state` — temporal context, threaded to the compiled kernels during replay.
+- `correct_actions` — the outcome(s) that count as "correct" for this obs (a `Set` generalises the
+  single-outcome hosts — `Set([true_type])` — and email_agent's multi-action step). Defines the
+  Beta-update direction per component during the replay's conditioning.
+- `residual` — `−log predictive` of this obs under the belief at conditioning time (the host's already-
+  computed `surprise`). Used to ORDER candidate evaluation (descending residual mass), not as a gate — the
+  residual ranks where to look first, no cutoff (Q2a).
+
+The buffer is `all-history-since-reset` (Q2b): the full evidence under the current alphabet, cleared by
+`reset_learning_regime!` on every grammar change (Move 2 Q1b).
+"""
+struct ExploreObservation
+    features::Dict{Symbol, Float64}
+    temporal_state::Dict{Symbol, Any}
+    correct_actions::Set{Symbol}
+    residual::Float64
+end
+
+# ═══════════════════════════════════════
+# Candidate generation — the complete, finite candidate set (Q2a)
+# ═══════════════════════════════════════
+
+"""
+    _threshold_candidates(g, observations) → Vector{Tuple{Symbol, Float64}}
+
+The candidate refinements: for each feature, the midpoints between adjacent OBSERVED values of that
+feature that are not already grid points. A threshold cannot matter except where it crosses an
+observation, so the observed values are the COMPLETE, finite candidate set — generation is exhaustive,
+which is exactly why thresholds are EU-max-complete and need no heuristic proposer (master plan §3.1).
+Midpoints (not the observed values themselves) so the split sits strictly between two observations.
+Deterministic: features in sorted order, values sorted.
+"""
+function _threshold_candidates(g::Grammar,
+                               observations::Vector{ExploreObservation})::Vector{Tuple{Symbol, Float64}}
+    candidates = Tuple{Symbol, Float64}[]
+    for feat in sort(collect(g.feature_set))
+        vals = sort(unique(obs.features[feat] for obs in observations if haskey(obs.features, feat)))
+        length(vals) < 2 && continue
+        existing = g.thresholds[feat]
+        for i in 1:(length(vals) - 1)
+            mid = (vals[i] + vals[i + 1]) / 2.0
+            # Exclude midpoints that coincide (within fp tolerance) with an existing grid point — the
+            # existing threshold already provides that split, so the candidate is a wasteful duplicate
+            # (and the VOI gate would reject it as Δℓ ≈ 0 anyway; this just keeps the candidate set tight).
+            any(isapprox(mid, e; atol = 1e-9) for e in existing) && continue
+            push!(candidates, (feat, mid))
+        end
+    end
+    candidates
+end
+
+"""
+    _refine_grammar(g, feature, threshold) → Grammar
+
+The candidate grammar: `g` with `threshold` inserted into `feature`'s grid (sorted, deduplicated), a
+fresh id. Complexity is recomputed identically — threshold-count-invariant (Q1(b)). All other features'
+grids are shared by reference (unchanged); only `feature`'s grid is a fresh sorted vector.
+"""
+function _refine_grammar(g::Grammar, feature::Symbol, threshold::Float64)::Grammar
+    new_grid = sort(unique(vcat(g.thresholds[feature], threshold)))
+    refined = Dict{Symbol, Vector{Float64}}(f => (f == feature ? new_grid : g.thresholds[f])
+                                            for f in keys(g.thresholds))
+    Grammar(g.feature_set, g.rules, refined, next_grammar_id())
+end
+
+# ═══════════════════════════════════════
+# The generic program-space observation kernel (lifted from the hosts; Invariant 1 — replay arithmetic
+# must live in src/, so the kernel the replay conditions through lives here too)
+# ═══════════════════════════════════════
+
+"""
+    program_space_observation_kernel(compiled_kernels, features, temporal_state, correct_actions) → Kernel
+
+The standard program-space BetaBernoulli per-component conditioning kernel: each component (a
+`TaggedBetaPrevision` tagged by program index) evaluates its compiled kernel on `features` → a recommended
+action; the recommendation is "correct" iff it is in `correct_actions`; the per-component Beta updates
+toward correct/incorrect. `correct_actions::Set` generalises the single-outcome hosts (`Set([true_type])`)
+and email_agent's multi-action step (the set of still-needed actions). The `correct_cache` in `params` is
+read by the `BetaBernoulli` condition dispatch for the per-component update direction.
+
+This is the engine-level home of logic the hosts currently duplicate (grid_world/email_agent
+`build_observation_kernel` + email_agent `build_step_kernel` are the same closure); the lookahead replay
+(`_grammar_marginal_log_loss`) conditions through it. NOTE: the host copies can later delegate here (a DRY
+follow-up) — left untouched in Move 3 to keep the live conditioning trajectories bit-stable.
+"""
+function program_space_observation_kernel(
+    compiled_kernels::Vector{CompiledKernel},
+    features::Dict{Symbol, Float64},
+    temporal_state::Dict{Symbol, Any},
+    correct_actions::Set{Symbol}
+)
+    recommendation_cache = Dict{Int, Symbol}()
+    correct_cache = Dict{Int, Bool}()
+    Kernel(Interval(0.0, 1.0), Finite([0.0, 1.0]),
+        _ -> error("generate not used in condition"),
+        (m_or_θ, obs) -> begin
+            if m_or_θ isa TaggedBetaPrevision
+                tag = m_or_θ.tag
+                recommended = get!(recommendation_cache, tag) do
+                    compiled_kernels[tag].evaluate(features, temporal_state)
+                end
+                correct = recommended in correct_actions
+                correct_cache[tag] = correct
+                p = mean(m_or_θ.beta)
+                correct ? log(max(p, 1e-300)) : log(max(1.0 - p, 1e-300))
+            else
+                obs == 1.0 ? log(max(m_or_θ, 1e-300)) : log(max(1.0 - m_or_θ, 1e-300))
+            end
+        end;
+        params = Dict{Symbol, Any}(:correct_cache => correct_cache),
+        likelihood_family = BetaBernoulli())
+end
+
+# ═══════════════════════════════════════
+# The lookahead — counterfactual marginal log-loss of the buffer under a grammar
+# ═══════════════════════════════════════
+
+"""
+    _grammar_marginal_log_loss(g, observations, max_depth, action_space) → Float64
+
+The prequential marginal log-loss of the buffer under grammar `g`: enumerate `g`'s programs at
+`max_depth`, build the fresh complexity-prior belief the host would (Beta(1,1) per program, two-part-MDL
+log-weights), and replay the buffer — accumulating `−log_predictive` and conditioning each step through
+the Tier-1 mixture `condition`. This is `Σ_t −log P(obs_t | obs_<t, g)`, the evidence for `g` on the
+buffer; the marginal likelihood's parameter integration IS the Bayesian Occam that makes leaving the
+prior fineness-blind sound (Q1(b)≡Q3(a)). All arithmetic is canalised through `log_predictive`/`condition`
+(Invariant 1). A grammar that enumerates nothing returns `Inf` (it predicts nothing).
+"""
+function _grammar_marginal_log_loss(g::Grammar, observations::Vector{ExploreObservation},
+                                    max_depth::Int, action_space::Vector{Symbol})::Float64
+    progs = enumerate_programs(g, max_depth; action_space = action_space)
+    isempty(progs) && return Inf
+    cks = CompiledKernel[compile_kernel(p, g, i) for (i, p) in enumerate(progs)]
+    components = TaggedBetaPrevision[TaggedBetaPrevision(i, BetaPrevision(1.0, 1.0))
+                                     for i in eachindex(progs)]
+    logw = Float64[complexity_logprior(g.complexity; λ = log(2)) +
+                   complexity_logprior(p.complexity; λ = log(2)) for p in progs]
+    belief = MixturePrevision(components, logw)
+
+    mll = 0.0
+    for obs in observations
+        k = program_space_observation_kernel(cks, obs.features, obs.temporal_state, obs.correct_actions)
+        mll += -log_predictive(belief, k, 1.0)
+        belief = condition(belief, k, 1.0)
+    end
+    mll
+end
+
+"""
+    _candidate_residual_mass(feat, t, observations) → Float64
+
+The residual screen ORDER (Q2a): the summed predictive residual of the observations bracketing the split
+`t` on feature `feat` (those at the nearest observed value below and above `t`). Higher mass ⇒ the split
+sits where the current belief mispredicts most ⇒ evaluate first. This ORDERS evaluation; it never gates
+(no cutoff). Because `explore_grammar` then evaluates the full finite candidate set and takes the argmax,
+the order is the screen and the argmax is the decision — no positive-VOI candidate is skipped (Q3b,
+one-sided). The order becomes load-bearing only if a future move adds budget-limited early termination.
+"""
+function _candidate_residual_mass(feat::Symbol, t::Float64,
+                                  observations::Vector{ExploreObservation})::Float64
+    below = -Inf
+    above = Inf
+    for obs in observations
+        haskey(obs.features, feat) || continue
+        v = obs.features[feat]
+        v < t && v > below && (below = v)
+        v > t && v < above && (above = v)
+    end
+    mass = 0.0
+    for obs in observations
+        haskey(obs.features, feat) || continue
+        v = obs.features[feat]
+        (v == below || v == above) && (mass += obs.residual)
+    end
+    mass
+end
+
+# ═══════════════════════════════════════
+# explore_grammar — the belief-aware threshold-refinement meta-action (Q2-master: forced separate entry)
+# ═══════════════════════════════════════
+
+"""
+    explore_grammar(g, observations, max_depth; action_space, compute_cost = 0.0) → Grammar
+
+Refine `g`'s threshold grid by the single candidate whose compute-budgeted lookahead VOI is greatest,
+applied iff that VOI clears `compute_cost`; otherwise a structural no-op (the input `g` unchanged). The
+belief-aware sibling of prior-only `perturb_grammar`: the value of a threshold is invisible to depth-one
+prior `net_voc` (complexity-invariant — all fit, no prior signal), so this *actually* refines, re-enumerates,
+re-conditions the buffer, and measures the realised marginal-log-loss reduction.
+
+Mechanism (Q2a/Q3a/Q3b):
+- Candidates = midpoints between adjacent observed values (`_threshold_candidates`) — the complete finite
+  set, no proposer (master plan §3.1).
+- Evaluated in descending residual-mass order (the screen ORDERS; it never gates).
+- VOI of a candidate = `net_value(Δℓ, compute_cost)` where `Δℓ = mll(buffer|g) − mll(buffer|g')` is the
+  predictive-log-loss reduction (the SAME nats the saturation residual is measured in). `compute_cost`
+  prices the lookahead spend; raising it suppresses refinement smoothly (no cliff, no hard cap — Q3b).
+- The full finite candidate set is evaluated and the argmax taken (one-sided: no positive-VOI candidate is
+  skipped — Q3b's provable form, not a heuristic early-stop). Returns `g` unchanged when none clears.
+
+One refinement per call (like `perturb_grammar` adds one rule): the host applies it, resets the residual
+regime (the alphabet changed — Move 2 Q1b), accrues more data, and may explore again.
+"""
+function explore_grammar(g::Grammar, observations::Vector{ExploreObservation}, max_depth::Int;
+                         action_space::Vector{Symbol} = Symbol[:classify],
+                         compute_cost::Float64 = 0.0)::Grammar
+    isempty(observations) && return g
+    candidates = _threshold_candidates(g, observations)
+    isempty(candidates) && return g
+
+    masses = Float64[_candidate_residual_mass(feat, t, observations) for (feat, t) in candidates]
+    order = sortperm(masses, rev = true)   # stable: residual order, deterministic tie-break
+
+    baseline = _grammar_marginal_log_loss(g, observations, max_depth, action_space)
+
+    best_voi = 0.0   # a candidate must clear net VOI > 0 to win; else no-op
+    best = g
+    for idx in order
+        feat, t = candidates[idx]
+        g_cand = _refine_grammar(g, feat, t)
+        mll = _grammar_marginal_log_loss(g_cand, observations, max_depth, action_space)
+        voi = net_value(baseline - mll, compute_cost)   # Δℓ − compute_cost, through the stdlib functional
+        if voi > best_voi
+            best_voi = voi
+            best = g_cand
+        end
+    end
+    best
+end

--- a/src/program_space/perturbation.jl
+++ b/src/program_space/perturbation.jl
@@ -330,10 +330,14 @@ function perturb_grammar(g::Grammar, freq_table::SubprogramFrequencyTable,
     # id ⇒ a no-op truly changes nothing. (Tested by test_perturb_consumption.jl.)
     best = _best_compression_candidate(g, freq_table; compute_cost = compute_cost)
     best === nothing && return g                                # saturation no-op (the Move-2 signal)
+    # Thread `g.thresholds` through (the 4-arg constructor) so a refined grid (exploration-budget Move 3)
+    # survives a later compression on its lineage — the 3-arg form would re-default the grid and silently
+    # discard the refinement. Bit-identical for default grammars (g.thresholds == default_thresholds by
+    # value ⇒ identical enumeration), so the compression tests stay green.
     if best[4] === :add
-        Grammar(g.feature_set, [g.rules; best[5]], next_grammar_id())
+        Grammar(g.feature_set, [g.rules; best[5]], g.thresholds, next_grammar_id())
     else  # :remove — drop the dead rule by name (names are unique under the idempotence guard)
-        Grammar(g.feature_set, [r for r in g.rules if r.name != best[5].name], next_grammar_id())
+        Grammar(g.feature_set, [r for r in g.rules if r.name != best[5].name], g.thresholds, next_grammar_id())
     end
 end
 

--- a/src/program_space/types.jl
+++ b/src/program_space/types.jl
@@ -111,6 +111,13 @@ struct ProductionRule
     body::ProgramExpr
 end
 
+# The default per-feature threshold grid — the seed every grammar starts from. A threshold (`GTExpr`/
+# `LTExpr`) is enumerated at each grid point; `Grammar.thresholds` carries a per-feature grid so the
+# exploration budget (Move 3) can REFINE it against the belief's residual without touching other
+# grammars. Default grammars copy this for every feature, so enumeration is unchanged. Moved here from
+# enumeration.jl in Move 3 because it is now grammar-structural data, not an enumeration-private constant.
+const THRESHOLDS = [0.1, 0.3, 0.5, 0.7, 0.9]
+
 """
     Grammar(feature_set, rules, id) — a carrier of the complexity prior over program ASTs.
 
@@ -127,8 +134,15 @@ Fields:
   enumerated from this grammar.
 - `rules::Vector{ProductionRule}` — nonterminal productions expanding
   into expression subtrees.
+- `thresholds::Dict{Symbol, Vector{Float64}}` — per-feature grid the
+  predicate atoms (`GTExpr`/`LTExpr`) are enumerated at. Defaults to the
+  global `THRESHOLDS` for every feature; the exploration budget (Move 3)
+  refines it per-feature against the belief's residual. NOT charged in
+  `complexity` — the fineness-Occam is carried by the predictive marginal
+  likelihood, not the prior (SPEC §1.3 margin; Move 3 Q1(b)≡Q3(a)).
 - `complexity::Float64` — precomputed grammar complexity `|G|`,
   contributing `-complexity * log(2)` to each program's log-prior.
+  Threshold-count-invariant by the Q1(b) decision.
 - `id::Int` — grammar identifier, used by `add_programs_to_state!` to
   track which grammar produced each mixture component.
 
@@ -141,7 +155,8 @@ the same enumeration logic.
 struct Grammar
     feature_set::Set{Symbol}
     rules::Vector{ProductionRule}
-    complexity::Float64  # precomputed |G|
+    thresholds::Dict{Symbol, Vector{Float64}}  # per-feature grid (Move 3 refinement target)
+    complexity::Float64  # precomputed |G| — threshold-count-invariant (Q1(b)/§1.3 margin)
     id::Int
 end
 
@@ -151,8 +166,28 @@ function compute_grammar_complexity(feature_set::Set{Symbol}, rules::Vector{Prod
     feature_cost + rules_cost
 end
 
+"""
+    default_thresholds(feature_set) → Dict{Symbol, Vector{Float64}}
+
+The seed per-feature grid: a copy of the global `THRESHOLDS` for every feature. Every grammar built by
+the 3-arg `Grammar(feature_set, rules, id)` constructor uses this, so enumeration is unchanged until a
+grammar is explicitly refined (Move 3 `explore_grammar`). A `copy` per feature so a later per-feature
+refinement never mutates a shared vector.
+"""
+default_thresholds(feature_set::Set{Symbol}) =
+    Dict{Symbol, Vector{Float64}}(f => copy(THRESHOLDS) for f in feature_set)
+
+# 3-arg convenience (the existing call sites): default per-feature grid, computed complexity.
 function Grammar(feature_set::Set{Symbol}, rules::Vector{ProductionRule}, id::Int)
-    Grammar(feature_set, rules, compute_grammar_complexity(feature_set, rules), id)
+    Grammar(feature_set, rules, default_thresholds(feature_set),
+            compute_grammar_complexity(feature_set, rules), id)
+end
+
+# 4-arg with an explicit per-feature grid — the refined-grammar constructor (Move 3 `explore_grammar`).
+# Complexity is computed identically (threshold-count-invariant): a denser grid does NOT raise |G|.
+function Grammar(feature_set::Set{Symbol}, rules::Vector{ProductionRule},
+                 thresholds::Dict{Symbol, Vector{Float64}}, id::Int)
+    Grammar(feature_set, rules, thresholds, compute_grammar_complexity(feature_set, rules), id)
 end
 
 # ═══════════════════════════════════════

--- a/test/test_threshold_explore.jl
+++ b/test/test_threshold_explore.jl
@@ -12,7 +12,8 @@ push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
 using Credence: Grammar, ProductionRule, enumerate_programs, show_expr, THRESHOLDS,
                 default_thresholds, explore_grammar, ExploreObservation,
-                next_grammar_id, reset_grammar_counter!
+                next_grammar_id, reset_grammar_counter!,
+                perturb_grammar, SubprogramFrequencyTable, ProgramExpr, AndExpr, GTExpr, LTExpr
 
 function check(name, cond, detail = "")
     cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
@@ -182,6 +183,25 @@ let
     # §3f Empty buffer / no candidates ⇒ no-op (the input grammar, unchanged).
     check("§3f empty buffer ⇒ no-op", explore_grammar(g, ExploreObservation[], 2; action_space = AS) === g,
           "expected no-op on empty buffer")
+end
+
+# ── §4  a refined grid survives compression (perturb_grammar threads g.thresholds — review should-fix) ──
+let
+    reset_grammar_counter!()
+    g = Grammar(Set([:x]), ProductionRule[], next_grammar_id())
+    g_ref = Credence._refine_grammar(g, :x, 0.42)        # grid [0.1,0.3,0.42,0.5,0.7,0.9]
+    refined_grid = g_ref.thresholds[:x]
+
+    # A freq_table whose top subtree compresses: AndExpr (complexity 3) used by 3 programs ⇒
+    # net_payoff = 3·(3−1) − (1+3) = 2 > 0 ⇒ :add_rule fires (referenced=nothing ⇒ no removal candidates).
+    sub = AndExpr(GTExpr(:x, 0.3), LTExpr(:x, 0.7))
+    table = SubprogramFrequencyTable(ProgramExpr[sub], [3.0], [[1, 2, 3]])
+    g_perturbed = perturb_grammar(g_ref, table, g_ref.feature_set)
+
+    check("§4 perturb compressed the refined grammar (a rule was added)",
+          length(g_perturbed.rules) == length(g_ref.rules) + 1, "rules=$(g_perturbed.rules)")
+    check("§4 the refined threshold grid SURVIVES compression (not re-defaulted to the global grid)",
+          g_perturbed.thresholds[:x] == refined_grid, "got $(g_perturbed.thresholds[:x])")
 end
 
 println("="^64)

--- a/test/test_threshold_explore.jl
+++ b/test/test_threshold_explore.jl
@@ -1,0 +1,189 @@
+# test_threshold_explore.jl — exploration-budget Move 3: compute-budgeted lookahead VOI for threshold
+# refinement (the headline move). Sections:
+#   §1  capture-before-refactor: a default grammar enumerates IDENTICALLY after the Grammar.thresholds
+#       field + enumeration rewire (the 42-program canonical signature, pinned PRE-change on master).
+#   §2  candidate generation — midpoints between adjacent observed values (complete finite set).
+#   §3  the lookahead VOI + cap-free sequential stop + completeness guard.
+#   §4  discovery: explore_grammar finds an off-grid optimum Scope A provably cannot reach.
+#
+# Run: julia test/test_threshold_explore.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: Grammar, ProductionRule, enumerate_programs, show_expr, THRESHOLDS,
+                default_thresholds, explore_grammar, ExploreObservation,
+                next_grammar_id, reset_grammar_counter!
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+
+println("="^64)
+println("threshold-explore — Move 3")
+println("="^64)
+
+# ── §1  capture-before-refactor: default-grammar enumeration is bit-identical ──
+#
+# Canonical signature captured on master (pre-Grammar.thresholds) for
+#   Grammar(Set([:red, :speed]), ProductionRule[], 1), enumerate_programs(g, 2; [:food, :enemy])
+# 42 programs: 2 constant actions (c=1), then sorted features (:red < :speed) × THRESHOLDS × {GT,LT}
+# × {(food,enemy),(enemy,food)} (c=4 each). The default per-feature grid MUST equal the old global grid,
+# so this enumeration MUST be unchanged. Asserted `==` (capture-before-refactor; the pin guards the rewire).
+let
+    g = Grammar(Set([:red, :speed]), ProductionRule[], 1)
+
+    # The default grid is exactly the global THRESHOLDS for every feature.
+    check("§1 default_thresholds ≡ global THRESHOLDS per feature",
+          g.thresholds[:red] == THRESHOLDS && g.thresholds[:speed] == THRESHOLDS,
+          "got red=$(g.thresholds[:red]) speed=$(g.thresholds[:speed])")
+    check("§1 complexity is threshold-count-invariant (|G| = #features = 2.0)",
+          g.complexity == 2.0, "got $(g.complexity)")
+
+    progs = enumerate_programs(g, 2; action_space = Symbol[:food, :enemy])
+    sig = [(show_expr(p.expr), p.complexity) for p in progs]
+
+    expected = Tuple{String, Int}[
+        ("food", 1), ("enemy", 1),
+        ("IF((gt :red 0.1),food,enemy)", 4), ("IF((gt :red 0.1),enemy,food)", 4),
+        ("IF((lt :red 0.1),food,enemy)", 4), ("IF((lt :red 0.1),enemy,food)", 4),
+        ("IF((gt :red 0.3),food,enemy)", 4), ("IF((gt :red 0.3),enemy,food)", 4),
+        ("IF((lt :red 0.3),food,enemy)", 4), ("IF((lt :red 0.3),enemy,food)", 4),
+        ("IF((gt :red 0.5),food,enemy)", 4), ("IF((gt :red 0.5),enemy,food)", 4),
+        ("IF((lt :red 0.5),food,enemy)", 4), ("IF((lt :red 0.5),enemy,food)", 4),
+        ("IF((gt :red 0.7),food,enemy)", 4), ("IF((gt :red 0.7),enemy,food)", 4),
+        ("IF((lt :red 0.7),food,enemy)", 4), ("IF((lt :red 0.7),enemy,food)", 4),
+        ("IF((gt :red 0.9),food,enemy)", 4), ("IF((gt :red 0.9),enemy,food)", 4),
+        ("IF((lt :red 0.9),food,enemy)", 4), ("IF((lt :red 0.9),enemy,food)", 4),
+        ("IF((gt :speed 0.1),food,enemy)", 4), ("IF((gt :speed 0.1),enemy,food)", 4),
+        ("IF((lt :speed 0.1),food,enemy)", 4), ("IF((lt :speed 0.1),enemy,food)", 4),
+        ("IF((gt :speed 0.3),food,enemy)", 4), ("IF((gt :speed 0.3),enemy,food)", 4),
+        ("IF((lt :speed 0.3),food,enemy)", 4), ("IF((lt :speed 0.3),enemy,food)", 4),
+        ("IF((gt :speed 0.5),food,enemy)", 4), ("IF((gt :speed 0.5),enemy,food)", 4),
+        ("IF((lt :speed 0.5),food,enemy)", 4), ("IF((lt :speed 0.5),enemy,food)", 4),
+        ("IF((gt :speed 0.7),food,enemy)", 4), ("IF((gt :speed 0.7),enemy,food)", 4),
+        ("IF((lt :speed 0.7),food,enemy)", 4), ("IF((lt :speed 0.7),enemy,food)", 4),
+        ("IF((gt :speed 0.9),food,enemy)", 4), ("IF((gt :speed 0.9),enemy,food)", 4),
+        ("IF((lt :speed 0.9),food,enemy)", 4), ("IF((lt :speed 0.9),enemy,food)", 4),
+    ]
+
+    check("§1 enumeration count unchanged (42)", length(sig) == 42, "got $(length(sig))")
+    check("§1 enumeration bit-identical to pre-refactor canonical (==)",
+          sig == expected, "enumeration drifted after the Grammar.thresholds rewire")
+end
+
+# ── §2  candidate generation: midpoints between adjacent observed values, off-grid only ──
+let
+    _cand = Credence._threshold_candidates
+    reset_grammar_counter!()
+    g = Grammar(Set([:x]), ProductionRule[], next_grammar_id())   # default grid [0.1,0.3,0.5,0.7,0.9]
+    mk(v) = ExploreObservation(Dict(:x => v), Dict{Symbol,Any}(), Set([:a]), 0.0)
+
+    # Observed :x ∈ {0.2, 0.5, 0.62} → midpoints 0.35, 0.56 (neither on the default grid).
+    obs = [mk(0.2), mk(0.5), mk(0.62), mk(0.5)]   # 0.5 repeated → unique handles it
+    cands = _cand(g, obs)
+    check("§2 candidates are the off-grid midpoints {0.35, 0.56}",
+          Set(t for (_, t) in cands) == Set([0.35, 0.56]),
+          "got $(cands)")
+    check("§2 all candidates are on feature :x", all(f == :x for (f, _) in cands), "got $(cands)")
+
+    # A midpoint landing exactly on an existing grid point is excluded (0.2,0.4 → 0.3 ∈ grid).
+    obs2 = [mk(0.2), mk(0.4)]
+    check("§2 midpoint coinciding with a grid point is excluded",
+          isempty(_cand(g, obs2)), "got $(_cand(g, obs2))")
+
+    # Fewer than two distinct observed values ⇒ no candidate (a threshold needs a gap to split).
+    check("§2 <2 distinct values ⇒ no candidates",
+          isempty(_cand(g, [mk(0.3), mk(0.3)])), "got $(_cand(g, [mk(0.3), mk(0.3)]))")
+
+    # _refine_grammar inserts the threshold (sorted), fresh id, complexity unchanged (Q1(b)).
+    g2 = Credence._refine_grammar(g, :x, 0.56)
+    check("§2 refined grid is sorted with the new threshold inserted",
+          g2.thresholds[:x] == [0.1, 0.3, 0.5, 0.56, 0.7, 0.9], "got $(g2.thresholds[:x])")
+    check("§2 refinement is complexity-invariant (Q1(b))", g2.complexity == g.complexity,
+          "got $(g2.complexity) vs $(g.complexity)")
+    check("§2 refined grammar has a fresh id", g2.id != g.id, "got $(g2.id)")
+end
+
+# ── §3  the lookahead VOI + explore_grammar: discovery, no-op, cap-free boundary, completeness guard ──
+#
+# Scenario: feature :x, true class boundary at x ≈ 0.62 (OFF the default grid [0.1,…,0.9]). Observed
+# values {0.55, 0.60} → :b and {0.65, 0.70} → :a. No on-grid threshold separates them; the midpoint
+# candidate 0.625 (between observed 0.60 and 0.65) splits them PERFECTLY. Scope A (compression) can never
+# add a threshold, so it provably cannot reach this grammar.
+let
+    AS = Symbol[:a, :b]
+    mk(x, label; r = 1.0) = ExploreObservation(Dict(:x => x), Dict{Symbol, Any}(), Set([label]), r)
+    # 5 copies of each ⇒ the marginal-likelihood gap is decisive.
+    data = ExploreObservation[]
+    for _ in 1:5
+        push!(data, mk(0.55, :b)); push!(data, mk(0.60, :b))
+        push!(data, mk(0.65, :a)); push!(data, mk(0.70, :a))
+    end
+    reset_grammar_counter!()
+    g = Grammar(Set([:x]), ProductionRule[], next_grammar_id())
+
+    # The lookahead gives the perfect split strictly lower marginal log-loss than the on-grid baseline.
+    baseline = Credence._grammar_marginal_log_loss(g, data, 2, AS)
+    g625 = Credence._refine_grammar(g, :x, 0.625)
+    mll625 = Credence._grammar_marginal_log_loss(g625, data, 2, AS)
+    dl = baseline - mll625
+    check("§3 Δℓ > 0: the off-grid 0.625 split beats the on-grid baseline", dl > 0.0,
+          "baseline=$baseline mll625=$mll625 Δℓ=$dl")
+
+    # §3a Discovery: explore_grammar refines the grid and adds a split at the true boundary.
+    g2 = explore_grammar(g, data, 2; action_space = AS, compute_cost = 0.0)
+    check("§3a discovery: grid refined (off-grid optimum found; Scope A cannot)", g2.id != g.id,
+          "explore returned the input grammar unchanged")
+    check("§3a discovery: the added threshold is the perfect-separation midpoint 0.625",
+          any(isapprox(t, 0.625; atol = 1e-9) for t in g2.thresholds[:x]),
+          "got grid $(g2.thresholds[:x])")
+    check("§3a discovery: exactly one threshold added (one refinement per call)",
+          length(g2.thresholds[:x]) == length(g.thresholds[:x]) + 1, "got $(g2.thresholds[:x])")
+
+    # §3b No-op: a compute_cost above every candidate's Δℓ suppresses refinement — the input is returned.
+    g_noop = explore_grammar(g, data, 2; action_space = AS, compute_cost = 1.0e6)
+    check("§3b no-op when compute_cost exceeds every VOI (same grammar object)", g_noop === g,
+          "expected the input grammar; got id $(g_noop.id)")
+
+    # §3c Cap-free graceful boundary: the explore/no-op decision flips CONTINUOUSLY at compute_cost = Δℓ —
+    # no cliff, no hard cap. Just below Δℓ ⇒ refine; just above ⇒ no-op (Q3b graceful degradation).
+    g_below = explore_grammar(g, data, 2; action_space = AS, compute_cost = dl - 0.1)
+    g_above = explore_grammar(g, data, 2; action_space = AS, compute_cost = dl + 0.1)
+    check("§3c graceful: compute_cost just below Δℓ ⇒ refine", g_below.id != g.id, "got no-op")
+    check("§3c graceful: compute_cost just above Δℓ ⇒ no-op (smooth, no cap)", g_above === g, "got refine")
+
+    # §3d Completeness guard (Q3b one-sidedness): make 0.625 the LOWEST residual-mass candidate (residual
+    # concentrated on the 0.55/0.70 extremes, near-zero on 0.60/0.65) — so a residual-order EARLY-STOP
+    # would evaluate it LAST and might skip it. Full evaluation still selects it (global VOI argmax),
+    # proving no positive-VOI candidate is skipped.
+    data_skew = ExploreObservation[]
+    for _ in 1:5
+        push!(data_skew, mk(0.55, :b; r = 5.0)); push!(data_skew, mk(0.60, :b; r = 0.01))
+        push!(data_skew, mk(0.65, :a; r = 0.01)); push!(data_skew, mk(0.70, :a; r = 5.0))
+    end
+    # 0.625 brackets observed 0.60 & 0.65 (the low-residual pair) ⇒ lowest residual mass of the candidates.
+    m575 = Credence._candidate_residual_mass(:x, 0.575, data_skew)
+    m625 = Credence._candidate_residual_mass(:x, 0.625, data_skew)
+    m675 = Credence._candidate_residual_mass(:x, 0.675, data_skew)
+    check("§3d setup: 0.625 has the lowest residual mass (would be evaluated last)",
+          m625 < m575 && m625 < m675, "masses 575=$m575 625=$m625 675=$m675")
+    g_skew = explore_grammar(g, data_skew, 2; action_space = AS, compute_cost = 0.0)
+    check("§3d completeness: full-eval still selects 0.625 (one-sided; lowest-residual ≠ skipped)",
+          any(isapprox(t, 0.625; atol = 1e-9) for t in g_skew.thresholds[:x]),
+          "got grid $(g_skew.thresholds[:x])")
+
+    # §3e Determinism: two runs on identical inputs produce the same refined grid (no rand, deterministic
+    # argmax — the Invariant-1 breach that Phase 5 closed stays closed).
+    ga = explore_grammar(g, data, 2; action_space = AS, compute_cost = 0.0)
+    gb = explore_grammar(g, data, 2; action_space = AS, compute_cost = 0.0)
+    check("§3e determinism: identical inputs ⇒ identical refined grid", ga.thresholds == gb.thresholds,
+          "a=$(ga.thresholds) b=$(gb.thresholds)")
+
+    # §3f Empty buffer / no candidates ⇒ no-op (the input grammar, unchanged).
+    check("§3f empty buffer ⇒ no-op", explore_grammar(g, ExploreObservation[], 2; action_space = AS) === g,
+          "expected no-op on empty buffer")
+end
+
+println("="^64)
+println("ALL CHECKS PASSED — threshold-explore")
+println("="^64)


### PR DESCRIPTION
## Move 3 code — compute-budgeted lookahead VOI for threshold refinement (the headline)

The arc's first belief-aware generative-change op, and the first consumer of Move 2's saturation signal. Stacked on the merged design (#170). Ratified architecture; see design §8–§9.

A threshold is **complexity-invariant** (zero prior signal, all fit), so prior-only `net_voc` (Move 1) is blind by construction and **lookahead is the only honest valuation** — and thresholds are the op for which EU-max *generative* discovery **fully closes**: a threshold matters only at an observed value, so the observed values **are** the complete finite candidate set (no proposer, no creative floor).

### What landed

**§1 — `Grammar.thresholds`** (per-feature `Dict`, defaulted to the global `THRESHOLDS` grid). Enumeration reads `g.thresholds[feat]`. Behaviour-preserving: the 42-program canonical enumeration is asserted `==` for a default grammar (capture-before-refactor). Complexity stays threshold-count-invariant (Q1(b)).

**§2-3 — `explore_grammar`** (`src/program_space/exploration.jl`): candidate midpoints → counterfactual prequential replay (`_grammar_marginal_log_loss`, Tier-1 `condition`/`log_predictive`) → residual-ordered full-eval argmax over `net_value(Δℓ, compute_cost)`. The fineness-Occam rides the **predictive marginal likelihood**, not the prior (Q1(b)≡Q3(a); SPEC §1.3 margin).

**§4 — host wiring (both hosts):** feed the already-computed `surprise` (= `ℓ = −log predictive`) into `update_learning_regime`, accumulate the `ExploreObservation` buffer, add `:explore` as a saturation-gated meta-action; reset on refinement.

### The discovery result (gate 1, §3a)

On a task whose true boundary (0.62) is **off the grid**, `explore_grammar` finds the perfect-separation split (0.625) — which Scope A (compression) provably cannot reach. The cost-gated boundary flips **continuously** at `Δℓ` (cap-free); the completeness guard proves one-sidedness (0.625 wins even as the *lowest*-residual candidate); determinism holds (no `rand`).

### Code-time refinements (design §9, all ratified)

1. **Self-contained in `src/`** — Invariant 1 forbids `apps/` summing log-probs; the replay (and a generic `program_space_observation_kernel`, lifted from the identical host copies) lives in `src/`.
2. **No live `belief` arg** — belief-awareness via the buffer's residuals + the counterfactual replay.
3. **Full-eval-argmax, not residual-order early-stop** — Q3b's provably one-sided form.
4. **Reset on alphabet expansion (explore) only** — *not* perturb/deepen/enumerate (a precise reading of Q1b: those are within-alphabet; their effects surface in later residuals). Keeps the integration minimal.
5. **email_agent scope** — single-decision `run_agent` path fully wired; episode path safely gated off (`:explore` → `-Inf` when `last_residual === nothing`). Episode-path feed is a follow-up.
6. **Saturation gate** — `compression_exhausted` (prior-side, lazy) ∧ residual-plateau (`plateau_probability` the soft prior). Orthogonal → both required.
7. **Skin: no wire change** — `thresholds` defaulted/not serialised; no new verb; `build_grammar` neutral.

### Verification

Full Julia suite **49/49**; `test_threshold_explore` (discovery, no-op, graceful boundary, completeness guard, determinism, the enumeration pin); `test_grid_world` + `test_email_agent` green (incl. "preserves existing behavior"); Move 1/2 regressions green; lint clean (173 files, 0 violations); skin wire smoke green.

Note (NOT a silent cap): the host meta-EU computes `freq_table` per meta-iteration when the belief-side explore EU is positive — a perf cost, acceptable here; a per-step cache is the follow-up if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)