### PR TITLE
feat: explore_features — feature-discovery lookahead VOI (exploration-budget Move 4)

### DIFF
--- a/apps/julia/email_agent/host.jl
+++ b/apps/julia/email_agent/host.jl
@@ -265,6 +265,14 @@ function compute_meta_eu(
         compression_exhausted(state.grammars[top[1]], freq_table) || return -Inf
         return eu_explore
     end
+    # TODO (email :add_feature parity — Move 4 deferred, scope B): feature discovery (:add_feature /
+    # explore_features) is wired in grid_world but not here. Pure plumbing, no new capability — the
+    # mechanism is engine-level and grid_world proves the thesis end-to-end. Wiring it needs the Q4
+    # threshold_exhausted rung, which runs explore_grammar over the residual buffer; this fn's TWO callers
+    # (the single-decision + episode compute_eu EU-functions) don't have explore_buffer in scope, so it
+    # must be threaded through them. Carrying a threshold_exhausted flag on `state` is forbidden (§8.4 —
+    # the ladder is cyclic, a cached signal goes stale). Fold in whenever this host's meta-actions are next
+    # touched; no design doc required (docs/exploration-budget/move-4-design.md §9).
     -Inf
 end
 

--- a/apps/julia/grid_world/host.jl
+++ b/apps/julia/grid_world/host.jl
@@ -30,7 +30,7 @@ using Credence: next_grammar_id, reset_grammar_counter!
 using Credence: show_expr, GTExpr, LTExpr, AndExpr, OrExpr, NotExpr, NonterminalRef, ActionExpr, IfExpr
 using Credence: SubprogramFrequencyTable
 # Move 3 — the belief-aware exploration budget (threshold refinement) + the Move-2 saturation signal.
-using Credence: explore_grammar, ExploreObservation
+using Credence: explore_grammar, explore_features, ExploreObservation
 using Credence: update_learning_regime, plateau_probability, reset_learning_regime!
 
 include("simulation.jl")
@@ -43,7 +43,8 @@ using Random
 # Meta-action constants
 # ═══════════════════════════════════════
 
-const GW_META_ACTIONS = [:gw_enumerate_more, :gw_perturb_grammar, :gw_deepen, :gw_explore, :gw_do_nothing]
+const GW_META_ACTIONS = [:gw_enumerate_more, :gw_perturb_grammar, :gw_deepen, :gw_explore,
+                         :gw_add_feature, :gw_do_nothing]
 const GW_ENUMERATE_COST = 0.05
 const GW_PERTURB_COST = 0.05
 const GW_DEEPEN_COST = 0.10
@@ -52,6 +53,10 @@ const GW_EXPLORE_BASE = 0.6        # the saturation-scaled value the residual-pl
 const GW_EXPLORE_VOI_FLOOR = 0.10  # min predictive-log-loss gain (nats) a refinement must clear — a
                                    # DISTINCT currency from GW_EXPLORE_COST (meta-time), passed as the
                                    # explore_grammar compute_cost (cf. email host's expected_cost vs 0.1)
+const GW_ADD_FEATURE_COST = 0.10       # meta-time cost of the feature-discovery meta-action (Move 4)
+const GW_ADD_FEATURE_BASE = 0.6        # the residual-plateau-scaled value (the soft prior, as for explore)
+const GW_ADD_FEATURE_VOI_FLOOR = 0.10  # min net VOI (nats, ON TOP of the log2 prior-Occam bar that
+                                       # explore_features charges internally) a feature must clear
 
 # ═══════════════════════════════════════
 # Build the observation kernel
@@ -168,7 +173,8 @@ function compute_gw_meta_eu(
     state::AgentState,
     action::Symbol,
     eu_interact::Float64,
-    n_obs::Float64;
+    n_obs::Float64,
+    explore_buffer::Vector{ExploreObservation};
     meta_cost_this_turn::Float64=0.0
 )::Float64
     action == :gw_do_nothing && return -Inf
@@ -199,6 +205,35 @@ function compute_gw_meta_eu(
                                                 min_frequency=0.01, min_complexity=2)
         compression_exhausted(state.grammars[top[1]], freq_table) || return -Inf
         return eu_explore
+    elseif action == :gw_add_feature
+        # Feature discovery (Move 4): the THIRD rung of the lazy escalation ladder. Admissible only when
+        # plateau ∧ compression_exhausted ∧ threshold_exhausted. The third rung is NOT a fine-before-coarse
+        # ORDERING gate — Q2's two-axis pricing in explore_features (it charges the log2 prior-Occam a
+        # threshold never owes) already orders cheap-before-dear. It is an ATTRIBUTION-FIDELITY guard (§8.4):
+        # a feature's Δℓ measured against a COARSE-grid baseline is confounded — inflated by residual that
+        # threshold refinement would ALSO have captured — so feature evaluation waits until the
+        # threshold-exhausted baseline exists and the feature is scored against what thresholds cannot reach.
+        # A sound deferral (defer a confounded measurement), not a cap on a correctly-measured positive-EU
+        # explore. Lazy & cheapest-first: plateau (cheap) → compression_exhausted (builds the freq_table) →
+        # threshold_exhausted (the full threshold lookahead, last). threshold_exhausted is RECOMPUTED each
+        # call, never carried: the ladder is cyclic (an added feature re-opens its own grid via the next
+        # explore pass), so a cached signal goes stale across the cycle.
+        plateau = plateau_probability(state.learning_regime)
+        eu_feature = plateau * GW_ADD_FEATURE_BASE - GW_ADD_FEATURE_COST - meta_cost_this_turn
+        eu_feature <= 0.0 && return eu_feature
+        top = top_k_grammar_ids(state, 1)
+        isempty(top) && return -Inf
+        g_top = state.grammars[top[1]]
+        freq_table = analyse_posterior_subtrees(state.all_programs, weights(state.belief);
+                                                min_frequency=0.01, min_complexity=2)
+        compression_exhausted(g_top, freq_table) || return -Inf
+        # threshold_exhausted ⟺ the threshold lookahead would no-op at the SAME VOI floor the explore
+        # meta-action applies — so features wait until thresholds genuinely stop paying (the un-confounded
+        # baseline). Run last (it is the costliest signal); gated by the two cheaper rungs above.
+        explore_grammar(g_top, explore_buffer, state.current_max_depth;
+                        action_space=Symbol[:food, :enemy], compute_cost=GW_EXPLORE_VOI_FLOOR) === g_top ||
+            return -Inf
+        return eu_feature
     end
     -Inf
 end
@@ -276,6 +311,28 @@ function execute_gw_meta_action!(
         reset_learning_regime!(state)
         empty!(explore_buffer)
         verbose && println("  [Meta: explore → grammar $gid→$(new_g.id) (threshold refined), +$n_added components]")
+        return n_added
+
+    elseif action == :gw_add_feature
+        # Feature discovery (Move 4): add the host-furnished feature whose lookahead VOI (two-axis: fit Δℓ
+        # MINUS the log2 prior-Occam explore_features charges internally) is greatest; no-op if none clears.
+        # Like explore, an ALPHABET EXPANSION ⇒ resets the residual regime + clears the buffer (Q1b). The
+        # candidate source is ALL_GW_FEATURES — the full superset the host already extracts every step, so a
+        # selected feature's value is already in each observation's features Dict (base-feature SELECTION,
+        # not construction). The reset re-opens the next explore pass on the NEW feature's grid (the cycle).
+        top = top_k_grammar_ids(state, 1)
+        isempty(top) && return 0
+        gid = top[1]
+        new_g = explore_features(state.grammars[gid], explore_buffer, ALL_GW_FEATURES,
+                                 state.current_max_depth;
+                                 action_space=gw_action_space, compute_cost=GW_ADD_FEATURE_VOI_FLOOR)
+        new_g.id == gid && return 0   # no positive-VOI feature → no-op
+        state.grammars[new_g.id] = new_g
+        n_added = add_programs_to_state!(state, new_g, state.current_max_depth;
+            action_space=gw_action_space, include_temporal=include_temporal)
+        reset_learning_regime!(state)
+        empty!(explore_buffer)
+        verbose && println("  [Meta: add_feature → grammar $gid→$(new_g.id) (feature acquired), +$n_added components]")
         return n_added
     end
     0
@@ -393,7 +450,7 @@ function run_agent(;
                 best_meta_eu = -Inf
                 best_meta = :gw_do_nothing
                 for ma in GW_META_ACTIONS
-                    meu = compute_gw_meta_eu(state, ma, eu, n_obs;
+                    meu = compute_gw_meta_eu(state, ma, eu, n_obs, explore_buffer;
                                               meta_cost_this_turn=meta_cost_this_turn)
                     if meu > best_meta_eu
                         best_meta_eu = meu
@@ -409,6 +466,7 @@ function run_agent(;
                 meta_cost_this_turn += (best_meta == :gw_deepen ? GW_DEEPEN_COST :
                                         best_meta == :gw_perturb_grammar ? GW_PERTURB_COST :
                                         best_meta == :gw_explore ? GW_EXPLORE_COST :
+                                        best_meta == :gw_add_feature ? GW_ADD_FEATURE_COST :
                                         GW_ENUMERATE_COST)
 
                 sync_prune!(state; threshold=-30.0)

--- a/docs/exploration-budget/move-4-design.md
+++ b/docs/exploration-budget/move-4-design.md
@@ -321,3 +321,47 @@ Base-feature only, with "combinations" clarified as the compositions the grammar
 feature prior-Occam (fine-before-coarse is now endogenous); the three-level ladder banked as *attribution
 fidelity*, not ordering; siblings until Move 5. Move 4 claims **EU-max selection over host-furnished
 features** and stops, correctly, one rung short of proposing the features that aren't there yet.
+
+## 9. Code-time refinements (build, 2026-06-29)
+
+Building surfaced three things the design under-specified. One grounds the headline mechanism (built); two
+move `:remove_feature` out of this move. As-shipped scope: **`:add_feature`, engine + grid_world**.
+
+**9.1 — Q2's prior-Occam is charged EXPLICITLY at the argmax (the design's "reuse the mll" was the wrong
+half).** The grammar-complexity prior is a per-grammar CONSTANT on every component's log-weight, so it
+**cancels inside the normalized marginal log-loss** (`condition`/`log_predictive` normalize — a uniform shift
+to all weights cancels in numerator and denominator at every step). `mll(g')` is therefore blind to
+`g'.complexity`; reusing the mll verbatim would price a feature on the FIT axis alone — violating Q2. So
+`explore_features` charges the prior penalty explicitly:
+
+    voi = net_value( Δℓ + complexity_logprior(Δcomplexity; λ = log2), compute_cost )   [= Δℓ − log2·Δcomplexity − compute_cost]
+
+This *grounds* ratified Q2 rather than disturbing it (the conclusion "priced on both axes" stands; the
+design's assumption that the second axis rode inside the mll did not). It is the literal mechanical content
+of Q1(b)≡Q2: thresholds carry `Δcomplexity = 0` (term vanishes, Occam on the likelihood); features carry
+`+1` (Occam on the prior). Proven by `test_feature_discovery.jl §4`: the explore/no-op boundary sits at
+**Δℓ − log2, not Δℓ** — a fit-only valuation would have added where this no-ops.
+
+**9.2 — `:remove_feature` split to the compression class (issue #174).** `:remove_feature` of a *dead*
+feature is prior-only MDL reclamation — the symmetric partner of `:remove_rule`, priced by `net_voc`, NOT
+the lookahead. Its home is `_best_compression_candidate`, and wiring it there changes `compression_exhausted`
+— the middle rung of this move's Q4 ladder — a behaviour change to shipped Move-1/Move-2 machinery needing
+capture-before-refactor. So the `_remove_feature`/`collect_feature_refs!`/`SubprogramFrequencyTable.
+referenced_features` items from §2 are **deferred to a focused compression-class follow-up** (#174), not built
+here. `:add_feature` needs none of them (enlarging the alphabet is always sound).
+
+**9.3 — that follow-up also closes a shipped `:remove_rule` soundness hole (#174).** Enumerated programs hold
+`NonterminalRef`s unexpanded, so a rule referenced only inside another rule's body is invisible to
+`collect_nonterminal_refs!`'s program-AST walk — `_removal_payoff` flags it dead and removing it crashes
+compilation ("Undefined nonterminal"). Reachable under ordinary nested abstraction; the fail-closed default
+does NOT catch it (it guards the *un-analysed* case, this is *analysed-but-incomplete*). Verified reproduced
+during the build. Shares its fix (union rule-body refs at the consumer) and home (compression class) with
+`:remove_feature`, so #174 closes both — landing **sooner**, since it is a live hole in shipped code.
+
+**9.4 — email_agent `:add_feature` parity deferred (scope B).** The mechanism is engine-level and grid_world
+proves the thesis end-to-end, so a second host adds parity, not capability. email's `compute_meta_eu` has two
+callers without `explore_buffer` in scope, so the `threshold_exhausted` rung needs the buffer threaded
+through both EU-functions (carrying a flag is §8.4-forbidden). Left as an in-code TODO at the email
+`:explore` gate — pure plumbing, fold in when that host is next touched, no design doc required. The one
+condition that would flip this to "do it now" is a near-term need to *report* a two-host result (paper claim
+/ product demo); absent that, deferred.

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -83,7 +83,7 @@ export enumerate_programs, enumerate_programs_as_measure
 export compile_kernel, compile_expr, evaluate_predicate
 export analyse_posterior_subtrees, extract_subtrees
 export propose_nonterminal, perturb_grammar, net_voc, compression_exhausted
-export ExploreObservation, explore_grammar, program_space_observation_kernel, default_thresholds
+export ExploreObservation, explore_grammar, explore_features, program_space_observation_kernel, default_thresholds
 export expr_equal
 export AgentState, sync_prune!, sync_truncate!, reset_learning_regime!
 export aggregate_grammar_weights, top_k_grammar_ids

--- a/src/program_space/exploration.jl
+++ b/src/program_space/exploration.jl
@@ -95,6 +95,39 @@ function _refine_grammar(g::Grammar, feature::Symbol, threshold::Float64)::Gramm
     Grammar(g.feature_set, g.rules, refined, next_grammar_id())
 end
 
+"""
+    _feature_candidates(g, available_features) → Vector{Symbol}
+
+The feature-discovery candidate set: the host-furnished features `g` does NOT yet use,
+`available_features \\ g.feature_set`, in sorted (deterministic) order. Move 4's headline realisation —
+base-feature discovery is pure EU-max **selection**, NOT construction: the host already extracts the full
+feature superset every step (its value is in every observation's `features` Dict), so a candidate feature's
+predicates work immediately on adding it. The host *provides* the candidates (`available_features`); the
+lookahead *ranks* them. The fully-closed selection half of the master plan's §3.1 selection/generation seam
+— no proposer, no AST extension (those are the deferred construction frontier: arithmetic feature products).
+"""
+function _feature_candidates(g::Grammar, available_features::Set{Symbol})::Vector{Symbol}
+    sort(collect(setdiff(available_features, g.feature_set)))
+end
+
+"""
+    _add_feature(g, feature) → Grammar
+
+The candidate grammar: `g` with `feature` added to `feature_set` and seeded with the default threshold
+grid, a fresh id. **Complexity RISES by 1** — unlike a threshold refinement (`_refine_grammar`, which is
+complexity-invariant per Q1(b)), a feature is a genuine description-length unit: `compute_grammar_complexity`
+counts `length(feature_set)`, so the new symbol costs one bit of prior. This is Q2, and the exact converse
+of Move 3's Q1(b): a finer grid adds no symbol (fineness-Occam rides the marginal likelihood), a new feature
+adds a symbol (the Occam rides the prior). All existing features' grids are preserved by reference (a refined
+grid SURVIVES the add — the Move-3 review lesson); only `feature` gets a fresh default grid.
+"""
+function _add_feature(g::Grammar, feature::Symbol)::Grammar
+    new_features = union(g.feature_set, Set([feature]))
+    grids = Dict{Symbol, Vector{Float64}}(f => g.thresholds[f] for f in keys(g.thresholds))
+    grids[feature] = copy(THRESHOLDS)
+    Grammar(new_features, g.rules, grids, next_grammar_id())
+end
+
 # ═══════════════════════════════════════
 # The generic program-space observation kernel (lifted from the hosts; Invariant 1 — replay arithmetic
 # must live in src/, so the kernel the replay conditions through lives here too)
@@ -256,6 +289,75 @@ function explore_grammar(g::Grammar, observations::Vector{ExploreObservation}, m
         g_cand = _refine_grammar(g, feat, t)
         mll = _grammar_marginal_log_loss(g_cand, observations, max_depth, action_space)
         voi = net_value(baseline - mll, compute_cost)   # Δℓ − compute_cost, through the stdlib functional
+        if voi > best_voi
+            best_voi = voi
+            best = g_cand
+        end
+    end
+    best
+end
+
+# ═══════════════════════════════════════
+# explore_features — the belief-aware feature-discovery meta-action (Move 4; sibling of explore_grammar)
+# ═══════════════════════════════════════
+
+"""
+    explore_features(g, observations, available_features, max_depth; action_space, compute_cost = 0.0) → Grammar
+
+Grow `g`'s FEATURE alphabet by the single host-furnished candidate whose compute-budgeted lookahead VOI is
+greatest, applied iff that VOI clears the bar; otherwise a structural no-op (the input `g` unchanged). The
+one-rung-up sibling of `explore_grammar`: where threshold refinement sharpens an existing feature's grid,
+feature discovery admits a feature the grammar did not use. Base-feature discovery is pure EU-max
+**selection** — the host already extracts the full feature superset (`_feature_candidates` =
+`available_features \\ g.feature_set`), so a candidate's value is already in every observation's `features`
+Dict; the lookahead ranks the host-provided candidates. (Composed/arithmetic features — *construction* — are
+the deferred §3.1 frontier.)
+
+**The two-axis valuation (Q2 — the keystone, and the converse of Move 3's Q1(b)).** A feature is valued on
+BOTH axes:
+
+    voi = net_value( Δℓ + complexity_logprior(Δcomplexity; λ = log 2), compute_cost )
+        = (mll(buffer|g) − mll(buffer|g')) − log2·Δcomplexity − compute_cost            [nats]
+
+where `g'` = `g` with the candidate feature added and `Δcomplexity = g'.complexity − g.complexity = +1`. The
+fit term `Δℓ` is the SAME marginal-log-loss reduction Move 3 measures (`_grammar_marginal_log_loss`, reused
+verbatim). The prior term is the subtle part: the grammar-complexity prior is a per-grammar CONSTANT added
+to every component's log-weight, so it **cancels inside the normalized marginal log-loss** (`log_predictive`
+/`condition` normalize the mixture — a uniform shift to all weights cancels). Reusing the mll alone would
+therefore price a feature on the fit axis only — exactly what Move 3 does for thresholds, and exactly what
+Q2 says is WRONG for features. So the `−log2·Δcomplexity` prior-Occam penalty is charged **explicitly here,
+at the argmax**. This is the literal mechanical content of the Q1(b)≡Q2 duality: a finer threshold adds no
+symbol (Δcomplexity = 0 ⇒ the term vanishes ⇒ Move 3's `explore_grammar` is the Δcomplexity = 0 special
+case); a new feature adds a symbol (Δcomplexity = +1 ⇒ the feature must repay `log2` nats of prior the
+threshold never owed). fine-before-coarse, made endogenous: the cheap rung clears while it pays; the dear
+rung waits until it doesn't. Asserted by test_feature_discovery.jl §4 (the boundary sits at Δℓ − log2, not Δℓ).
+
+Soundness is trivial for `:add_feature` — enlarging the alphabet can only ADD representable programs, never
+break an existing one — so no reference count is needed (contrast `:remove_feature`, the MDL-compression
+partner). Full-eval argmax over the (small, host-furnished) candidate set in sorted order: deterministic, no
+rand, one feature per call (the host applies it, resets the residual regime — an alphabet expansion, Move 2
+Q1b — and may explore again, including re-opening threshold refinement on the new feature's grid — the cyclic
+ladder of §8.4).
+"""
+function explore_features(g::Grammar, observations::Vector{ExploreObservation},
+                          available_features::Set{Symbol}, max_depth::Int;
+                          action_space::Vector{Symbol} = Symbol[:classify],
+                          compute_cost::Float64 = 0.0)::Grammar
+    isempty(observations) && return g
+    candidates = _feature_candidates(g, available_features)
+    isempty(candidates) && return g
+
+    baseline = _grammar_marginal_log_loss(g, observations, max_depth, action_space)
+
+    best_voi = 0.0   # a candidate must clear net VOI > 0 to win; else no-op
+    best = g
+    for feat in candidates                              # sorted ⇒ deterministic argmax
+        g_cand = _add_feature(g, feat)
+        mll = _grammar_marginal_log_loss(g_cand, observations, max_depth, action_space)
+        # Two-axis valuation: fit Δℓ PLUS the explicit prior-Occam penalty (the grammar-complexity prior
+        # cancels inside the normalized mll, so it is charged here). Δcomplexity = +1 ⇒ −log2 nats.
+        dcomplexity = g_cand.complexity - g.complexity
+        voi = net_value((baseline - mll) + complexity_logprior(dcomplexity; λ = log(2)), compute_cost)
         if voi > best_voi
             best_voi = voi
             best = g_cand

--- a/test/test_feature_discovery.jl
+++ b/test/test_feature_discovery.jl
@@ -1,0 +1,176 @@
+# test_feature_discovery.jl — exploration-budget Move 4: feature-discovery lookahead VOI (`:add_feature`).
+# The belief-aware sibling of Move 3's threshold refinement, one rung up the fine-before-coarse ladder:
+# grow the agent's FEATURE alphabet by EU-max SELECTION over a host-furnished candidate set
+# (`available_features \ feature_set`), valued by the same compute-budgeted lookahead.
+#
+# Sections:
+#   §1  candidate generation — the host-furnished set `available_features \ feature_set` (sorted).
+#   §2  _add_feature — surgery: feature added, default grid for it, OTHER features' grids preserved,
+#       fresh id, complexity +1 (a feature IS a description-length unit — Q2, unlike a threshold).
+#   §3  discovery: a grammar missing the predictive feature acquires it; no-op when nothing helps;
+#       cap-free graceful boundary; determinism; empty.
+#   §4  Q2 — the two-axis pricing is MECHANIZED. The grammar-complexity prior CANCELS inside the
+#       normalized marginal log-loss (a per-grammar constant), so the prior-Occam penalty is charged
+#       EXPLICITLY at the argmax (`+ complexity_logprior(Δcomplexity; λ=log2)`). The boundary sits at
+#       Δℓ − log2, NOT at Δℓ — the signature distinguishing Move 4 (features, dearer) from Move 3
+#       (thresholds, complexity-invariant). This is the literal mechanical content of Q1(b)≡Q2's converse.
+#
+# Run: julia test/test_feature_discovery.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: Grammar, ProductionRule, ExploreObservation, THRESHOLDS,
+                next_grammar_id, reset_grammar_counter!, explore_grammar
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+
+println("="^64)
+println("feature-discovery — Move 4")
+println("="^64)
+
+# ── §1  candidate generation: the host-furnished set `available_features \ feature_set` (sorted) ──
+let
+    reset_grammar_counter!()
+    g = Grammar(Set([:colour]), ProductionRule[], next_grammar_id())
+    available = Set([:colour, :wall_dist, :agent_dist, :speed])
+
+    cands = Credence._feature_candidates(g, available)
+    check("§1 candidates are available \\ feature_set",
+          Set(cands) == Set([:wall_dist, :agent_dist, :speed]), "got $(cands)")
+    check("§1 candidates are sorted (deterministic)",
+          cands == sort(cands), "got $(cands)")
+
+    # A grammar already using every available feature ⇒ no candidates.
+    g_full = Grammar(Set([:colour, :wall_dist]), ProductionRule[], next_grammar_id())
+    check("§1 no candidates when feature_set ⊇ available",
+          isempty(Credence._feature_candidates(g_full, Set([:colour, :wall_dist]))),
+          "got $(Credence._feature_candidates(g_full, Set([:colour, :wall_dist])))")
+end
+
+# ── §2  _add_feature — surgery: a feature is a real description-length unit (Q2), grids preserved ──
+let
+    reset_grammar_counter!()
+    g = Grammar(Set([:colour]), ProductionRule[], next_grammar_id())
+    # Refine :colour's grid first, to prove the existing grid SURVIVES the add (Move-3 review lesson).
+    g_ref = Credence._refine_grammar(g, :colour, 0.42)        # :colour grid gains 0.42
+    refined_grid = g_ref.thresholds[:colour]
+
+    g2 = Credence._add_feature(g_ref, :wall_dist)
+    check("§2 the feature is added to feature_set",
+          :wall_dist in g2.feature_set && g2.feature_set == Set([:colour, :wall_dist]),
+          "got $(g2.feature_set)")
+    check("§2 the new feature gets the default grid",
+          g2.thresholds[:wall_dist] == THRESHOLDS, "got $(g2.thresholds[:wall_dist])")
+    check("§2 the existing (refined) grid SURVIVES the add (not re-defaulted)",
+          g2.thresholds[:colour] == refined_grid, "got $(g2.thresholds[:colour])")
+    check("§2 complexity rises by exactly 1 (a feature IS a prior-Occam unit — Q2)",
+          g2.complexity == g_ref.complexity + 1.0, "got $(g2.complexity) vs $(g_ref.complexity)")
+    check("§2 the grammar gets a fresh id", g2.id != g_ref.id, "got $(g2.id)")
+end
+
+# ── §3  discovery: a grammar missing the predictive feature acquires it via EU-max selection ──
+#
+# Scenario: the label depends ONLY on :wall_dist (< 0.5 ⇒ :a, ≥ 0.5 ⇒ :b); :colour is uncorrelated noise.
+# The colour-only grammar provably cannot separate the classes (no colour program beats chance). Adding
+# :wall_dist admits `IF (lt :wall_dist 0.5) :a :b` — a PERFECT separator the colour grammar could not reach.
+let
+    AS = Symbol[:a, :b]
+    mk(wall, col, label) = ExploreObservation(
+        Dict(:wall_dist => wall, :colour => col), Dict{Symbol, Any}(), Set([label]), 1.0)
+    data = ExploreObservation[]
+    for _ in 1:5
+        push!(data, mk(0.2, 0.1, :a)); push!(data, mk(0.2, 0.9, :a))   # near wall ⇒ :a, colour varies
+        push!(data, mk(0.8, 0.1, :b)); push!(data, mk(0.8, 0.9, :b))   # far  wall ⇒ :b, colour varies
+    end
+    reset_grammar_counter!()
+    g = Grammar(Set([:colour]), ProductionRule[], next_grammar_id())
+    available = Set([:colour, :wall_dist])
+
+    # The lookahead: adding :wall_dist gives strictly lower marginal log-loss than the colour-only baseline.
+    baseline = Credence._grammar_marginal_log_loss(g, data, 2, AS)
+    g_wall = Credence._add_feature(g, :wall_dist)
+    mll_wall = Credence._grammar_marginal_log_loss(g_wall, data, 2, AS)
+    dl = baseline - mll_wall
+    check("§3 Δℓ > 0: adding :wall_dist beats the colour-only baseline", dl > 0.0,
+          "baseline=$baseline mll_wall=$mll_wall Δℓ=$dl")
+    check("§3 Δℓ clears the prior-Occam bar (Δℓ > log2 — a strong feature is worth a symbol)",
+          dl > log(2), "Δℓ=$dl log2=$(log(2))")
+
+    # §3a Discovery: explore_features selects :wall_dist (the EU-max selection over host-furnished features).
+    g2 = Credence.explore_features(g, data, available, 2; action_space = AS, compute_cost = 0.0)
+    check("§3a discovery: the predictive feature is acquired (colour grammar could not reach this)",
+          :wall_dist in g2.feature_set, "feature_set=$(g2.feature_set)")
+    check("§3a discovery: returns a fresh grammar (not the input)", g2.id != g.id, "got input unchanged")
+    check("§3a discovery: exactly the one feature added (selection, not construction)",
+          g2.feature_set == Set([:colour, :wall_dist]), "got $(g2.feature_set)")
+
+    # §3b No-op when no candidate feature helps: constant-label data is already fit by the constant
+    # program, so no feature improves the marginal likelihood ⇒ Δℓ ≈ 0 < log2 ⇒ rejected (the prior bar).
+    flat = ExploreObservation[mk(0.2, 0.1, :a), mk(0.8, 0.9, :a), mk(0.5, 0.5, :a), mk(0.3, 0.7, :a)]
+    g_flat = Credence.explore_features(g, flat, available, 2; action_space = AS, compute_cost = 0.0)
+    check("§3b no-op when no feature helps (constant label ⇒ Δℓ < log2 ⇒ prior bar rejects)",
+          g_flat === g, "expected the input grammar; got id $(g_flat.id)")
+
+    # §3c Empty candidate set ⇒ no-op (every available feature already in the grammar).
+    check("§3c empty candidate set ⇒ no-op",
+          Credence.explore_features(g_wall, data, Set([:colour, :wall_dist]), 2;
+                                    action_space = AS, compute_cost = 0.0) === g_wall,
+          "expected no-op when feature_set ⊇ available")
+
+    # §3d Empty buffer ⇒ no-op.
+    check("§3d empty buffer ⇒ no-op",
+          Credence.explore_features(g, ExploreObservation[], available, 2; action_space = AS) === g,
+          "expected no-op on empty buffer")
+
+    # §3e Determinism: identical inputs ⇒ identical result (no rand; deterministic argmax).
+    ga = Credence.explore_features(g, data, available, 2; action_space = AS, compute_cost = 0.0)
+    gb = Credence.explore_features(g, data, available, 2; action_space = AS, compute_cost = 0.0)
+    check("§3e determinism: identical inputs ⇒ identical feature_set",
+          ga.feature_set == gb.feature_set, "a=$(ga.feature_set) b=$(gb.feature_set)")
+end
+
+# ── §4  Q2 MECHANIZED: the prior-Occam term is charged EXPLICITLY (boundary at Δℓ − log2, not Δℓ) ──
+#
+# The grammar-complexity prior is a per-grammar CONSTANT added to every component's log-weight, so it
+# CANCELS inside the normalized marginal log-loss (`log_predictive`/`condition` normalize). Reusing
+# `_grammar_marginal_log_loss` verbatim would therefore price a feature on the FIT axis alone — violating
+# Q2. `explore_features` charges the prior penalty `complexity_logprior(Δcomplexity; λ=log2) = −log2`
+# explicitly at the argmax. The decisive test: a compute_cost just ABOVE `Δℓ − log2` must no-op. Were the
+# log2 term absent (Move-3 thresholds, complexity-invariant), the boundary would sit at Δℓ and that same
+# compute_cost would still ADD. The no-op proves the prior axis is priced.
+let
+    AS = Symbol[:a, :b]
+    mk(wall, col, label) = ExploreObservation(
+        Dict(:wall_dist => wall, :colour => col), Dict{Symbol, Any}(), Set([label]), 1.0)
+    data = ExploreObservation[]
+    for _ in 1:5
+        push!(data, mk(0.2, 0.1, :a)); push!(data, mk(0.2, 0.9, :a))
+        push!(data, mk(0.8, 0.1, :b)); push!(data, mk(0.8, 0.9, :b))
+    end
+    reset_grammar_counter!()
+    g = Grammar(Set([:colour]), ProductionRule[], next_grammar_id())
+    available = Set([:colour, :wall_dist])
+
+    baseline = Credence._grammar_marginal_log_loss(g, data, 2, AS)
+    g_wall = Credence._add_feature(g, :wall_dist)
+    dl = baseline - Credence._grammar_marginal_log_loss(g_wall, data, 2, AS)
+
+    # Boundary at compute_cost = Δℓ − log2: just below ⇒ add; just above ⇒ no-op.
+    below = Credence.explore_features(g, data, available, 2; action_space = AS, compute_cost = dl - log(2) - 0.1)
+    above = Credence.explore_features(g, data, available, 2; action_space = AS, compute_cost = dl - log(2) + 0.1)
+    check("§4 compute_cost just below Δℓ−log2 ⇒ feature added", :wall_dist in below.feature_set,
+          "expected add at cost $(dl - log(2) - 0.1)")
+    check("§4 compute_cost just above Δℓ−log2 ⇒ NO-OP (the log2 prior term is charged; boundary ≠ Δℓ)",
+          above === g, "expected no-op at cost $(dl - log(2) + 0.1); got id $(above.id)")
+
+    # The contrast that makes §4 decisive: cost just above Δℓ−log2 is still WELL below Δℓ, so a
+    # fit-axis-only valuation (no log2) would have ADDED here. The no-op above is the proof.
+    check("§4 the no-op cost is strictly below Δℓ (a fit-only rule would have added — it didn't)",
+          dl - log(2) + 0.1 < dl, "cost=$(dl - log(2) + 0.1) Δℓ=$dl")
+end
+
+println("="^64)
+println("ALL CHECKS PASSED — feature-discovery")
+println("="^64)


### PR DESCRIPTION
Exploration-budget arc, **Move 4 code** (design ratified in #172). Grows the agent's **feature** alphabet by EU-max **selection** over a host-furnished candidate set, one rung above Move 3's threshold refinement. TDD throughout (RED watched before GREEN).

## What ships: `:add_feature`, engine + grid_world

Base-feature discovery needs **zero host-extraction changes** — the host already extracts the full feature superset every step, so a selected feature's value is already in each observation's Dict. The lookahead ranks host-provided candidates; no proposer (composed/product features are the deferred construction frontier).

**Engine** (`src/program_space/exploration.jl`): `_feature_candidates` (sorted `available \ feature_set`), `_add_feature` (complexity rises by 1 — a feature is a real description-length unit; existing grids preserved), `explore_features` (full-eval argmax of the two-axis valuation).

**Host** (grid_world): `:gw_add_feature` gated by the Q4 three-rung lazy ladder `plateau ∧ compression_exhausted ∧ threshold_exhausted` — the third rung an *attribution-fidelity* guard, not ordering (§8.4); `threshold_exhausted` recomputed lazily (the ladder is cyclic).

## The headline finding: Q2's prior-Occam is charged explicitly (design §9.1)

The grammar-complexity prior is a per-grammar **constant** on every component's log-weight, so it **cancels inside the normalized marginal log-loss** — `mll(g')` is blind to `g'.complexity`. Reusing the mll verbatim would price a feature on the **fit axis alone**, violating ratified Q2. So `explore_features` charges the prior penalty explicitly at the argmax:

```
voi = net_value( Δℓ + complexity_logprior(Δcomplexity; λ=log2), compute_cost )   [= Δℓ − log2·Δcomplexity − compute_cost]
```

This *grounds* Q2 (the "priced on both axes" conclusion stands; the design's "reuse the mll" assumption was the wrong half). The literal mechanical content of Q1(b)≡Q2: thresholds carry `Δcomplexity=0` (Occam on the likelihood), features carry `+1` (Occam on the prior). **Proven by `test_feature_discovery.jl §4`: the explore/no-op boundary sits at Δℓ−log2, not Δℓ** — a fit-only valuation would have added where this no-ops.

## Scope decisions (design §9, ratified)

- **`:remove_feature` split to a compression-class follow-up (#174).** It's prior-only MDL reclamation (`net_voc`, `:remove_rule`'s partner), *not* discovery, and it perturbs `compression_exhausted` = the Q4 ladder's middle rung. `:add_feature` needs none of its machinery (enlarging the alphabet is always sound), so the `SubprogramFrequencyTable` field is untouched here.
- **#174 also closes a shipped `:remove_rule` soundness hole found during the build** — a rule referenced only inside another rule's body is flagged dead and removed → compile crash. Verified reproduced. Shares fix + home with `:remove_feature`; landing sooner since it's live in shipped code.
- **email_agent `:add_feature` parity deferred (scope B)** — an in-code TODO; pure plumbing, no new capability (grid_world proves the thesis end-to-end).

## Verification

- `test/test_feature_discovery.jl` — 20 checks: candidates, surgery (grid preservation), discovery (colour grammar acquires `:wall_dist`), the two-axis prior bar, no-op, determinism.
- Full Julia suite **50/50**; lint clean (corpus 16/11/8 intact, apps 0 violations). No wire/serialization change (skin unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)