### PR TITLE
fix(exploration-budget): drop the compression_exhausted veto from both exploration gates (#174 PR 2)

### DIFF
--- a/apps/julia/grid_world/host.jl
+++ b/apps/julia/grid_world/host.jl
@@ -24,7 +24,7 @@ using Credence: density, log_density_at, prune, truncate
 using Credence: AgentState, sync_prune!, sync_truncate!
 using Credence: Grammar, Program, CompiledKernel, ProductionRule
 using Credence: enumerate_programs, compile_kernel
-using Credence: analyse_posterior_subtrees, perturb_grammar, compression_exhausted
+using Credence: analyse_posterior_subtrees, perturb_grammar
 using Credence: aggregate_grammar_weights, top_k_grammar_ids, add_programs_to_state!
 using Credence: next_grammar_id, reset_grammar_counter!
 using Credence: show_expr, GTExpr, LTExpr, AndExpr, OrExpr, NotExpr, NonterminalRef, ActionExpr, IfExpr
@@ -190,46 +190,35 @@ function compute_gw_meta_eu(
     elseif action == :gw_deepen
         return uncertainty_benefit * 0.4 - GW_DEEPEN_COST - meta_cost_this_turn
     elseif action == :gw_explore
-        # Saturation-gated belief-aware exploration (Move 3). Two orthogonal halves, BOTH required
-        # (master plan §3.2): the residual-plateau (belief-side, the SOFT prior — Q3 — it SCALES the EU
-        # continuously, never a hard threshold) AND compression-exhausted (prior-side — perturb would
-        # no-op; orthogonal because compression is a prior effect, the residual a fit effect). The costly
-        # prior-side check is lazy: skipped unless the belief-side EU is already positive (so the
-        # freq_table is built only when exploration is even viable on the residual).
+        # Belief-aware threshold-refinement exploration (Move 3), gated by the residual-plateau SOFT prior
+        # ONLY: plateau SCALES the EU continuously, never a hard threshold. The compression_exhausted hard
+        # rung was DROPPED (#174 PR 2): compression is prior-only and never confounds the fit-side threshold
+        # VOI (Move 2 Q3), so it is a soft cost-ordering preference, not a veto — and that preference is
+        # already carried by the meta-action cost asymmetry (GW_PERTURB_COST < GW_EXPLORE_COST) in the
+        # caller's argmax, exactly as :gw_enumerate_more/:gw_deepen compete with no gate. No discount
+        # constant: the host compares PROXY EUs in a common scale, so there is no cross-currency comparison
+        # to gate here (the Q5 gap is engine-level; the principled end-state is one net-EU argmax once Move 5
+        # closes it). Asserted by test_grid_world_meta.jl §1–§2.
         plateau = plateau_probability(state.learning_regime)
         eu_explore = plateau * GW_EXPLORE_BASE - GW_EXPLORE_COST - meta_cost_this_turn
-        eu_explore <= 0.0 && return eu_explore
-        top = top_k_grammar_ids(state, 1)
-        isempty(top) && return -Inf
-        freq_table = analyse_posterior_subtrees(state.all_programs, weights(state.belief);
-                                                min_frequency=0.01, min_complexity=2)
-        compression_exhausted(state.grammars[top[1]], freq_table) || return -Inf
         return eu_explore
     elseif action == :gw_add_feature
-        # Feature discovery (Move 4): the THIRD rung of the lazy escalation ladder. Admissible only when
-        # plateau ∧ compression_exhausted ∧ threshold_exhausted. The third rung is NOT a fine-before-coarse
-        # ORDERING gate — Q2's two-axis pricing in explore_features (it charges the log2 prior-Occam a
-        # threshold never owes) already orders cheap-before-dear. It is an ATTRIBUTION-FIDELITY guard (§8.4):
-        # a feature's Δℓ measured against a COARSE-grid baseline is confounded — inflated by residual that
-        # threshold refinement would ALSO have captured — so feature evaluation waits until the
-        # threshold-exhausted baseline exists and the feature is scored against what thresholds cannot reach.
-        # A sound deferral (defer a confounded measurement), not a cap on a correctly-measured positive-EU
-        # explore. Lazy & cheapest-first: plateau (cheap) → compression_exhausted (builds the freq_table) →
-        # threshold_exhausted (the full threshold lookahead, last). threshold_exhausted is RECOMPUTED each
-        # call, never carried: the ladder is cyclic (an added feature re-opens its own grid via the next
-        # explore pass), so a cached signal goes stale across the cycle.
+        # Feature discovery (Move 4), gated by plateau (SOFT) ∧ threshold_exhausted (HARD). The
+        # compression_exhausted rung was DROPPED (#174 PR 2): compression is prior-only and never confounds
+        # the fit-side feature Δℓ (Move 2 Q3) — a soft cost-ordering preference (carried by the cost
+        # asymmetry in the caller's argmax), not a veto, and no discount constant is needed at the host's
+        # proxy layer. threshold_exhausted STAYS hard: a feature's Δℓ measured against a COARSE-grid baseline
+        # IS confounded — inflated by residual that threshold refinement would ALSO have captured — so
+        # feature evaluation waits until the threshold-exhausted (un-confounded) baseline exists. A sound
+        # deferral, not a cap (attribution fidelity). It is RECOMPUTED each call, never carried: the ladder
+        # is cyclic (an added feature re-opens its own grid via the next explore pass), so a cached signal
+        # goes stale. Asserted by test_grid_world_meta.jl §3a–§3b.
         plateau = plateau_probability(state.learning_regime)
         eu_feature = plateau * GW_ADD_FEATURE_BASE - GW_ADD_FEATURE_COST - meta_cost_this_turn
         eu_feature <= 0.0 && return eu_feature
         top = top_k_grammar_ids(state, 1)
         isempty(top) && return -Inf
         g_top = state.grammars[top[1]]
-        freq_table = analyse_posterior_subtrees(state.all_programs, weights(state.belief);
-                                                min_frequency=0.01, min_complexity=2)
-        compression_exhausted(g_top, freq_table) || return -Inf
-        # threshold_exhausted ⟺ the threshold lookahead would no-op at the SAME VOI floor the explore
-        # meta-action applies — so features wait until thresholds genuinely stop paying (the un-confounded
-        # baseline). Run last (it is the costliest signal); gated by the two cheaper rungs above.
         explore_grammar(g_top, explore_buffer, state.current_max_depth;
                         action_space=Symbol[:food, :enemy], compute_cost=GW_EXPLORE_VOI_FLOOR) === g_top ||
             return -Inf

--- a/docs/exploration-budget/compression-removal-design.md
+++ b/docs/exploration-budget/compression-removal-design.md
@@ -41,12 +41,12 @@ feature is destructive generative change and is never a candidate (only dead fea
 because compression never confounds exploration VOI).** **PR 1 = the `:remove_rule` transitive crash fix**
 (`_removal_payoff` unions rule-body refs) + capture-before-refactor + a nested-abstraction regression test —
 the isolated soundness fix; lands FIRST regardless (it is a live crash; the rest is suboptimality).
-**PR 2 = soften the compression rung in BOTH exploration gates** (`:gw_explore`, `:gw_add_feature`) — a
+**PR 2 = DROP the compression rung from BOTH exploration gates** (`:gw_explore`, `:gw_add_feature`) — a
 self-contained one-sidedness fix (§5 Q1 (i)/(iii)), standalone because once it spans two move surfaces it is
 no longer a compression-*removal* concern; lands BEFORE PR 3 (hard ordering: a dead feature feeding
-`compression_exhausted` while the gate is still hard would *widen* the soft-cap before it is fixed — soften,
-then couple). **PR 3 = `:remove_feature`** (the new op + the `SubprogramFrequencyTable` field + the argmax
-wiring), riding on the softened gate. #174 (the issue) closes on PR 1 + PR 3 — its two stated concerns,
+`compression_exhausted` while the gate is still hard would *widen* the soft-cap before it is fixed — drop the
+veto, then couple). **PR 3 = `:remove_feature`** (the new op + the `SubprogramFrequencyTable` field + the
+argmax wiring), riding on the un-vetoed gate. #174 (the issue) closes on PR 1 + PR 3 — its two stated concerns,
 removal soundness and removal mechanics; PR 2 is the sibling fix the Q1 analysis spawned, kept tied to this
 doc because all three are downstream of the single fact that compression never confounds exploration VOI.
 
@@ -79,13 +79,15 @@ doc because all three are downstream of the single fact that compression never c
   `collect_feature_refs!` soundness (direct + transitive-via-rule-body), `_feature_removal_payoff`, the
   unified argmax, determinism, and the capture-before-refactor pins (§3).
 
-- **`apps/julia/grid_world/host.jl`** (modification, **PR 2** — §5 Q1's finding, standalone). Soften the
-  `compression_exhausted` hard-gate (`... || return -Inf`) to a soft multiplicative discount on the proxy
-  EU, in BOTH `:gw_add_feature` (`:229`) and `:gw_explore` (`:206`); `threshold_exhausted` (`:233`) stays
-  hard. Adds a const `GW_COMPRESSION_UNSATURATED_DISCOUNT` — **named honestly as a proxy-host tuning knob**
-  (a fixed magic constant, NOT a learned multiplier like `plateau`'s carried posterior — see §5 Q1 (ii));
-  its comment records that it is interim, pinned between Move 2 Q3 and the Move-5 currency gap (Q5). This is
-  its own PR, not part of #174's removal commits.
+- **`apps/julia/grid_world/host.jl`** (modification, **PR 2** — §5 Q1's finding, standalone). DROP the
+  `compression_exhausted` hard-gate (`... || return -Inf`) entirely from BOTH `:gw_explore` (`:206`) and
+  `:gw_add_feature` (`:229`); `threshold_exhausted` (`:233`) stays hard. **No discount, no new constant**
+  (the §5 Q1 (ii) resolution): compression is prior-only and never confounds a fit-side VOI, so the soft
+  cost-ordering preference is already carried by the existing meta-action cost asymmetry (`GW_PERTURB_COST`
+  0.05 < `GW_EXPLORE`/`GW_ADD_FEATURE_COST` 0.10) in the caller's argmax — the host compares PROXY EUs in a
+  common scale, so the Q5 currency gap never arises here. Also removes the now-pointless
+  `analyse_posterior_subtrees`/`top_k` from `:gw_explore` and the now-unused `compression_exhausted` import.
+  New `test/test_grid_world_meta.jl` (the FIRST test of `compute_gw_meta_eu`). Its own PR, not part of #174.
 
 **No new meta-action.** `:remove_feature` rides inside the existing `:perturb_grammar`/`:gw_perturb_grammar`
 meta-action (which already calls `perturb_grammar`); the host re-enumerates the returned grammar exactly as
@@ -108,10 +110,12 @@ identities, grammar feature sets — not floats; no tolerance class applies).
 - **`compression_exhausted` / the Q4 ladder shift ONLY where correctness demands it** (§5 Q1): a grammar with
   a removable dead feature, or a nested-abstraction grammar whose false-dead `:remove_rule` candidate the fix
   removes. Both are *corrections*; the nested case is new behaviour exercised only by the new test.
-- **The PR-2 gate-softening is a deliberate behaviour change, NOT preserved** (§5 Q1 finding, §6 risk
-  4(b)): `:gw_add_feature`/`:gw_explore` selection changes when compression is unexhausted (the hard gate
-  was the bug). Its `test_grid_world.jl` pins are captured PRE-change and updated WITH the fix — the only
-  pins in this follow-up that intentionally move; everything in the bullets above holds `==`.
+- **The PR-2 gate-DROP is a deliberate behaviour change, NOT preserved** (§5 Q1 finding, §6 risk 4(b)):
+  `:gw_add_feature`/`:gw_explore` selection changes when compression is unexhausted (the hard veto was the
+  bug). **Correction (verified during PR 2): no existing test pinned these gates** — `compute_gw_meta_eu`
+  was untested (`test_grid_world.jl`'s only agent run sets `max_meta_per_step=0`). So PR 2 *adds the first*
+  test (`test_grid_world_meta.jl`), a net coverage gain — not a pin migration. There is nothing to capture
+  PRE-change; the new test pins the post-drop contract directly. Everything in the bullets above holds `==`.
 
 ## 4. Worked end-to-end examples
 
@@ -189,21 +193,23 @@ coupling as correct — a reclaimable symbol is genuine residual compression, so
 > *live* shipped soft-cap in the Move-3 path (a pending compression candidate deferring a correctly-measured
 > positive-EU threshold refinement). Soften both.
 >
-> **(ii) Mechanical form — the multiplicative discount, as an explicitly INTERIM device.** Its justification
-> is NOT "it matches how `plateau` enters" — that analogy is false and must not be made. `plateau`'s
-> multiplier is a *learned* quantity (the carried regime posterior, a belief that earns its multiplier);
-> `GW_COMPRESSION_UNSATURATED_DISCOUNT` is a fixed constant with no principled value — **a magic number,
-> named honestly as a proxy-host tuning knob.** In a proxy-EU host that is tolerable (the discount is soft,
-> overridable, and the host's EU is already a proxy), but it is not laundered into a posterior. The
-> discount's actual purpose: it keeps compression (priced in *prior* nats) and exploration (priced in
-> *predictive* nats) as **two separate decisions**, sidestepping the cross-currency comparison the
-> principled end-state would require. That end-state — **(A)** drop the gate entirely and let one net-EU
-> argmax order compression against exploration by their own costs — is correct but **blocked on the Move-5
-> currency gap (Q5)**: (A) presupposes Move 5's single-currency unification is permanent, so it cannot be
-> built now. **(B)** a graded compression-residual signal from `_best_compression_candidate` is the
-> principled upgrade for the day this runs on a *real-utility* host (overkill for a proxy host now). So the
-> discount is **interim by construction**, pinned between Move 2 Q3 (soft, never hard) and Q5 (the currency
-> it refuses to cross); the code comment must say exactly this.
+> **(ii) Mechanical form — DROP the gate, no constant (revised from the discount on review).** A first pass
+> ratified a multiplicative discount as an interim device. On building it the bare constant was rejected —
+> *magic constants are a big no-no* — and, decisively, the discount's stated justification does not hold at
+> the host level. That justification was "keep compression (prior nats) and exploration (predictive nats) as
+> two separate decisions, sidestepping the cross-currency comparison." But the host never makes that
+> comparison: `compute_gw_meta_eu` hands every meta-action a PROXY EU (`plateau · BASE − cost`) in a common
+> hand-tuned scale and the caller argmaxes over proxies; the real `explore_grammar`/`explore_features` VOIs
+> are computed at *execution*, not selection. So there is no cross-currency comparison at the selection point
+> to sidestep — the Q5 currency gap is engine-level, untouched by this host gate. The clean interim is
+> therefore to **drop the `compression_exhausted` veto entirely** (no constant): the bug (hard veto) is gone,
+> and the soft "compression-first" preference survives via the EXISTING cost asymmetry (`GW_PERTURB_COST`
+> 0.05 < `GW_EXPLORE`/`GW_ADD_FEATURE_COST` 0.10), exactly as the un-gated `:gw_enumerate_more`/`:gw_deepen`
+> already compete. No correctness claim rides on compression-first (compression never confounds — the whole
+> basis of the fix), so a *stronger* nudge would be a preference with no principle behind its strength: the
+> magic constant. The principled end-states remain — **(A)** one net-EU argmax over compression and
+> exploration once Move 5 closes Q5; **(B)** a graded compression-residual signal for a *real-utility* host
+> (the proxy host needs neither now).
 >
 > **(iii) Sequencing + home — resolved.** Crash-fix → soften → couple. The `:remove_rule` transitive fix is
 > **PR 1** (a crash; first regardless). The softening is **PR 2, standalone** — once (i) makes it span both
@@ -274,13 +280,14 @@ if single-pass reclamation of dead chains matters.
    the tuple changes `_candidate_better`'s total order (e.g. tie-break drift) → a different perturbation wins
    → benchmark drift. Mitigation: preserve the exact order (voc → is_remove → name); capture-before-refactor
    pins `_best_compression_candidate`'s winner `==` on the existing fixtures.
-4. **`compression_exhausted` regression to the Q4 ladder + the gate-softening behaviour change.** Two parts.
+4. **`compression_exhausted` regression to the Q4 ladder + the gate-DROP behaviour change.** Two parts.
    (a) The `:remove_feature` coupling: pin every test grammar's `compression_exhausted` `==`; the only
-   intended change is the coupling, blessed in Q1. (b) The **PR-2** softening **deliberately** changes BOTH
-   `:gw_add_feature` and `:gw_explore` selection when compression is unexhausted (the bug fix): capture the
-   affected `test_grid_world.jl` EU/selection pins PRE-change and update them WITH the softening as the
-   recorded reason (the Move-4 "behaviour shift is intended" discipline) — never reintroduce the hard gate
-   to keep a stale pin green.
+   intended change is the coupling, blessed in Q1. (b) The **PR-2** gate-DROP **deliberately** changes BOTH
+   `:gw_add_feature` and `:gw_explore` selection when compression is unexhausted (the bug fix). No existing
+   test pinned the gate (`compute_gw_meta_eu` was untested), so there is nothing to migrate: PR 2's new
+   `test_grid_world_meta.jl` pins the post-drop contract directly (`:gw_explore` returns the soft plateau
+   proxy, not −Inf, when compression is available; `:gw_add_feature` likewise, with `threshold_exhausted`
+   still vetoing). Never reintroduce the hard veto to keep a stale expectation green.
 
 ## 7. Verification cadence
 
@@ -291,12 +298,13 @@ julia test/test_saturation.jl            # Move 2 compression_exhausted — pinn
 julia test/test_threshold_explore.jl     # Move 3 untouched (incl. the refined-grid-survives-compression pin)
 julia test/test_feature_discovery.jl     # Move 4 :add_feature untouched
 julia test/test_program_space.jl         # enumeration + removal — pinned ==
-julia test/test_grid_world.jl            # PR 3: host :perturb_grammar now also reclaims dead features (no new meta-action)
+julia test/test_grid_world_meta.jl       # PR 2: the FIRST test of compute_gw_meta_eu — gate-drop contract
+julia test/test_grid_world.jl            # host loads + runs after PR 2; PR 3 dead-feature reclaim (no new meta-action)
 ```
 
 Per-PR split: **PR 1** (crash fix) = the nested-abstraction regression test + the §3 capture pins (`==`).
-**PR 2** (soften both gates) = `test_grid_world.jl` — capture the `:gw_explore`/`:gw_add_feature` selection
-pins PRE-change and update them WITH the softening (the only intentionally-moving pins; §6 risk 4(b)).
+**PR 2** (drop the veto, both gates) = `test_grid_world_meta.jl` (NEW — the first test of
+`compute_gw_meta_eu`); `test_grid_world.jl` stays green (host still loads + runs).
 **PR 3** (`:remove_feature`) = `test_compression_removal.jl` + the remaining `==` pins above. Full
 `test/test_*.jl` green before each merge; lint self-test + `check apps/`. **Skin smoke optional** (no wire
 verb, no serialised-path change — the `SubprogramFrequencyTable` field is in-memory only). Halt-the-line on
@@ -310,10 +318,12 @@ blocks inline (§5 Q1 (i)/(ii)/(iii)). Summary:
 - **Q1.** Coupling blessed; `compression_exhausted` confirmed **soft**, `threshold_exhausted` the hard one.
   Its finding (the shipped hard-gate at `:gw_add_feature:229` + `:gw_explore:206`) is fixed by **PR 2**.
   - **(i) Both gates** — one bug, one argument ("compression never confounds the residual"); reject the split.
-  - **(ii) Multiplicative discount, INTERIM** — a proxy-host tuning knob (a magic constant, *not* a
-    `plateau`-style learned multiplier); its job is to keep prior-nats and predictive-nats as separate
-    decisions, sidestepping the Move-5 currency gap (Q5). End-state (A) = single net-EU argmax, Q5-blocked.
-    Upgrade (B) = graded compression-residual, for a real-utility host. Pinned between Move 2 Q3 and Q5.
+  - **(ii) DROP the gate — no constant** (revised from the discount on review: *magic constants are a big
+    no-no*). The discount's "sidestep Q5" rationale does not bite at the host's PROXY-EU layer — no real
+    cross-currency comparison happens at *selection* (the real VOIs are computed at execution) — so the clean
+    interim is to drop the `compression_exhausted` veto entirely; the soft compression-first preference rides
+    the existing cost asymmetry (`GW_PERTURB_COST` < `GW_EXPLORE`/`GW_ADD_FEATURE_COST`). End-state (A) =
+    single net-EU argmax once Move 5 closes Q5; (B) = graded compression-residual for a real-utility host.
   - **(iii)** Crash-fix (PR 1) → soften (PR 2, standalone) → `:remove_feature` (PR 3).
 - **Q2.** The declared `PerturbationCandidate` struct (the thing Move 5 extends).
 - **Q3.** Union **ALL** rule bodies.

--- a/test/test_grid_world_meta.jl
+++ b/test/test_grid_world_meta.jl
@@ -1,0 +1,129 @@
+# test_grid_world_meta.jl — the grid-world meta-action EU gates (#174 PR 2).
+#
+# PR 2 DROPS the compression_exhausted HARD veto from :gw_explore and :gw_add_feature. compression is
+# prior-only and never confounds a fit-side VOI (Move 2 Q3), so it is a soft cost-ordering preference —
+# already carried by the meta-action cost asymmetry (GW_PERTURB_COST 0.05 < GW_EXPLORE/ADD_FEATURE_COST 0.10)
+# in the caller's argmax, the same way :gw_enumerate_more/:gw_deepen compete — NOT a veto. No discount
+# constant: the host compares PROXY EUs in a common scale, so the Q5 currency gap (engine-level) never arises
+# here; the principled end-state is one net-EU argmax once Move 5 closes Q5. threshold_exhausted STAYS hard in
+# :gw_add_feature (it genuinely confounds feature Δℓ). These are the FIRST tests to exercise compute_gw_meta_eu.
+#
+# Sections:
+#   §1  :gw_explore — compression-not-exhausted no longer vetoes (the dropped rung; RED→GREEN).
+#   §2  :gw_explore — the compression-EXHAUSTED case is unchanged (stable pin, green pre+post).
+#   §3a :gw_add_feature — compression-not-exhausted no longer vetoes (empty buffer ⇒ threshold vacuous).
+#   §3b :gw_add_feature — threshold_exhausted STAYS hard (precondition-guarded: explore_grammar refines ⇒ -Inf).
+#
+# Run: julia test/test_grid_world_meta.jl
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+using Credence
+using Credence: Grammar, ProductionRule, Program, GTExpr, AndExpr, IfExpr, ActionExpr, NonterminalRef,
+                AgentState, MixturePrevision, TaggedBetaPrevision, BetaPrevision, Prevision,
+                compile_kernel, update_learning_regime, plateau_probability,
+                analyse_posterior_subtrees, compression_exhausted, explore_grammar, ExploreObservation
+
+include(joinpath(@__DIR__, "..", "apps", "julia", "grid_world", "host.jl"))
+
+function check(name, cond, detail = "")
+    cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
+end
+
+# Minimal AgentState over a single program with a chosen top grammar (template: test_program_space TEST 14c).
+function mk_state(g::Grammar, prog::Program; gid::Int = g.id)
+    comps = Prevision[TaggedBetaPrevision(1, BetaPrevision(1.0, 1.0))]
+    AgentState(MixturePrevision(comps, [0.0]), [(gid, 1)],
+               [compile_kernel(prog, g, 1)], Program[prog], Dict(gid => g), 2)
+end
+
+# Drive the regime to a PLATEAU (bouncing-flat residuals ⇒ high plateau_probability; cf. test_saturation phaseB).
+function plateau!(state)
+    prev = nothing
+    for ℓ in [0.755, 0.758, 0.752, 0.757, 0.754, 0.756, 0.753, 0.755, 0.754, 0.756]
+        state.learning_regime = update_learning_regime(state.learning_regime, prev, ℓ)
+        prev = ℓ
+    end
+    state
+end
+
+# A grammar whose top has a DEAD rule ⇒ compression NOT exhausted; the program references only :LIVE.
+function compressible_state()
+    g = Grammar(Set([:red, :blue]),
+                [ProductionRule(:LIVE, GTExpr(:red, 0.7)), ProductionRule(:DEAD, GTExpr(:blue, 0.5))], 1)
+    prog = Program(IfExpr(NonterminalRef(:LIVE), ActionExpr(:a), ActionExpr(:b)), 3, 1)
+    plateau!(mk_state(g, prog))
+end
+
+println("="^64)
+println("grid-world meta gates — compression rung dropped (#174 PR 2)")
+println("="^64)
+
+# ── §1  :gw_explore — compression-not-exhausted no longer vetoes (the dropped hard rung) ──
+let
+    state = compressible_state()
+    ft = analyse_posterior_subtrees(state.all_programs, Credence.weights(state.belief);
+                                    min_frequency = 0.01, min_complexity = 2)
+    check("§1 precondition: compression NOT exhausted (dead rule present)",
+          compression_exhausted(state.grammars[1], ft) == false)
+    pl = plateau_probability(state.learning_regime)
+    check("§1 precondition: plateau prior is high (exploration viable)", pl > 0.6, "plateau=$pl")
+
+    eu = compute_gw_meta_eu(state, :gw_explore, 0.0, 10.0, ExploreObservation[]; meta_cost_this_turn = 0.0)
+    expected = pl * GW_EXPLORE_BASE - GW_EXPLORE_COST
+    # POST-drop: the soft plateau proxy, NOT -Inf. (PRE-drop the hard rung returned -Inf here — the RED.)
+    check("§1 :gw_explore NOT vetoed by available compression (hard rung gone)", eu > -Inf, "eu=$eu")
+    check("§1 :gw_explore EU == the soft plateau proxy (no compression term)", eu ≈ expected,
+          "eu=$eu expected=$expected")
+end
+
+# ── §2  :gw_explore — the compression-EXHAUSTED case is unchanged (stable pin, green pre+post) ──
+let
+    g = Grammar(Set([:red]), ProductionRule[], 2)   # no rules ⇒ nothing to compress ⇒ exhausted
+    prog = Program(IfExpr(GTExpr(:red, 0.5), ActionExpr(:a), ActionExpr(:b)), 3, 1)
+    state = plateau!(mk_state(g, prog))
+    ft = analyse_posterior_subtrees(state.all_programs, Credence.weights(state.belief);
+                                    min_frequency = 0.01, min_complexity = 2)
+    check("§2 precondition: compression EXHAUSTED (no rules, no compressible subtree)",
+          compression_exhausted(state.grammars[2], ft) == true)
+    pl = plateau_probability(state.learning_regime)
+    eu = compute_gw_meta_eu(state, :gw_explore, 0.0, 10.0, ExploreObservation[]; meta_cost_this_turn = 0.0)
+    check("§2 exhausted case unchanged: eu == plateau·BASE − COST",
+          eu ≈ pl * GW_EXPLORE_BASE - GW_EXPLORE_COST, "eu=$eu")
+end
+
+# ── §3a  :gw_add_feature — compression-not-exhausted no longer vetoes (empty buffer ⇒ threshold vacuous) ──
+let
+    state = compressible_state()
+    pl = plateau_probability(state.learning_regime)
+    eu = compute_gw_meta_eu(state, :gw_add_feature, 0.0, 10.0, ExploreObservation[]; meta_cost_this_turn = 0.0)
+    expected = pl * GW_ADD_FEATURE_BASE - GW_ADD_FEATURE_COST
+    # POST-drop: not vetoed by compression; empty buffer ⇒ explore_grammar no-ops ⇒ threshold vacuously
+    # exhausted ⇒ the soft proxy. (PRE-drop the compression rung returned -Inf here — the RED.)
+    check("§3a :gw_add_feature NOT vetoed by compression (hard rung gone)", eu ≈ expected,
+          "eu=$eu expected=$expected")
+end
+
+# ── §3b  :gw_add_feature — threshold_exhausted STAYS hard (precondition-guarded behavioural pin) ──
+let
+    g = Grammar(Set([:red]), ProductionRule[], 3)   # exhausted (no rules) — isolates the threshold rung
+    prog = Program(IfExpr(GTExpr(:red, 0.5), ActionExpr(:a), ActionExpr(:b)), 3, 1)
+    state = plateau!(mk_state(g, prog))
+    # A buffer separable only at 0.4 (a midpoint off the default grid {0.1,0.3,0.5,0.7,0.9}): 0.35 vs 0.45
+    # land on the same side of every existing threshold, so explore_grammar MUST add ~0.4 to fit ⇒ refines.
+    buf = ExploreObservation[]
+    for _ in 1:6
+        push!(buf, ExploreObservation(Dict(:red => 0.35), Dict{Symbol, Any}(), Set([:food]), 1.0))
+        push!(buf, ExploreObservation(Dict(:red => 0.45), Dict{Symbol, Any}(), Set([:enemy]), 1.0))
+    end
+    refined = explore_grammar(g, buf, state.current_max_depth;
+                              action_space = Symbol[:food, :enemy], compute_cost = GW_EXPLORE_VOI_FLOOR)
+    check("§3b precondition: thresholds NOT exhausted (explore_grammar refines this buffer)",
+          refined !== g, "explore_grammar no-opped — the buffer needs to force a refinement")
+    eu = compute_gw_meta_eu(state, :gw_add_feature, 0.0, 10.0, buf; meta_cost_this_turn = 0.0)
+    check("§3b :gw_add_feature still vetoed when thresholds NOT exhausted (hard rung survives)",
+          eu == -Inf, "eu=$eu (threshold_exhausted hard gate should veto)")
+end
+
+println("="^64)
+println("ALL CHECKS PASSED — grid-world meta gates (compression rung dropped)")
+println("="^64)


### PR DESCRIPTION
## What

Drops the `compression_exhausted` hard veto from the grid-world exploration gates — **PR 2 of 3** for #174
(design doc #176; the (ii) resolution revised to drop-the-gate).

## The bug

`compute_gw_meta_eu` hard-gated `:gw_explore` and `:gw_add_feature` on `compression_exhausted`
(`... || return -Inf`). But compression is prior-only and **never confounds a fit-side VOI** (Move 2 Q3) —
so it's a soft cost-ordering preference, not a veto. The hard gate is a one-sidedness bug: a pending
compression candidate deferred a correctly-measured, positive-EU exploration.

## The fix — drop the veto, no constant

A first review pass proposed an interim *discount* constant. On building it the bare constant was rejected —
**magic constants are a big no-no** — and, decisively, the discount's "keep the two decisions separate to
sidestep the Q5 currency gap" rationale **does not bite at the host's proxy layer**: `compute_gw_meta_eu`
argmaxes over `plateau·BASE − cost` *proxies* in a common hand-tuned scale; the real
`explore_grammar`/`explore_features` VOIs are computed at *execution*, not selection. There is no
cross-currency comparison at the selection point to sidestep — Q5 is engine-level, untouched here.

So the clean interim is to **drop the veto entirely**: the bug is gone, and the soft compression-first
preference rides the **existing** cost asymmetry (`GW_PERTURB_COST` 0.05 < `GW_EXPLORE`/`GW_ADD_FEATURE_COST`
0.10), exactly as the un-gated `:gw_enumerate_more`/`:gw_deepen` compete. `threshold_exhausted` **stays hard**
in `:gw_add_feature` (it genuinely confounds feature Δℓ). Also removes the now-pointless
`analyse_posterior_subtrees`/`top_k` from `:gw_explore` and the now-unused `compression_exhausted` import.

The principled end-states remain: **(A)** one net-EU argmax over compression and exploration once Move 5
closes Q5; **(B)** a graded compression-residual signal for a real-utility host.

## Tests

No existing test pinned these gates (`compute_gw_meta_eu` was untested — `test_grid_world.jl`'s only agent run
sets `max_meta_per_step=0`). PR 2 adds the **first** test: `test/test_grid_world_meta.jl` — §1 `:gw_explore`
not vetoed by available compression (the dropped rung); §2 the exhausted case unchanged; §3a
`:gw_add_feature` likewise; §3b `threshold_exhausted` still vetoes (precondition-guarded). `test_grid_world.jl`
stays green (host loads + runs). Lint: `check apps/` 0 violations, corpus intact. Full local suite run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
