### PR TITLE
feat(exploration-budget): :remove_feature + PerturbationCandidate struct (#174 PR 3, closes #174)

### DIFF
--- a/docs/exploration-budget/compression-removal-design.md
+++ b/docs/exploration-budget/compression-removal-design.md
@@ -74,7 +74,9 @@ doc because all three are downstream of the single fact that compression never c
     alongside add/remove-rule. The candidate representation generalises (§5 Q2). ~5 lines.
   - `perturb_grammar` (`:324`) — apply a `:remove_feature` winner: drop the feature from `feature_set` and
     its grid from `thresholds`, fresh id (the 4-arg constructor, threading the surviving grids). ~6 lines.
-- **`src/Credence.jl`** — export `collect_feature_refs!` (mirrors `collect_nonterminal_refs!`).
+- **`src/Credence.jl`** — *no change* (corrected at code time). `collect_feature_refs!` stays **internal**:
+  the truer mirror of `collect_nonterminal_refs!`, which is itself unexported. Tests reach it via
+  `Credence.collect_feature_refs!`.
 - **`test/test_compression_removal.jl`** (new) — the `:remove_rule` nested-abstraction soundness fix,
   `collect_feature_refs!` soundness (direct + transitive-via-rule-body), `_feature_removal_payoff`, the
   unified argmax, determinism, and the capture-before-refactor pins (§3).

--- a/src/program_space/perturbation.jl
+++ b/src/program_space/perturbation.jl
@@ -260,18 +260,28 @@ net_voc(net_payoff_symbols::Real, compute_cost::Real) =
 # Grammar perturbation — deterministic argmax over net_voc (no rand; Invariant 1 canalised)
 # ═══════════════════════════════════════
 
-# Total order on perturbation candidates, for the deterministic argmax. A candidate is the 5-tuple
-# `(voc::Float64, is_remove::Bool, name::String, kind::Symbol, rule::ProductionRule)`. Order:
-# (1) higher `net_voc`; (2) on a tie, prefer `:remove` (hygiene — shrink the dictionary before growing
-# it); (3) on a further tie, lexicographically smaller rule name. No `rand`, no `hash` (Julia's `hash`
-# is not stable across versions — and cross-version-reproducible determinism is the whole point; a name
-# string-compare is stable). A tie is between candidates of EXACTLY-EQUAL computed prior value, so a
-# stable order is honest disambiguation among genuine argmax-optima, not a tiebreak of UNKNOWN values
-# (which Invariant 1 forbids). Asserted by test_voc_gate.jl §5c.
-function _candidate_better(a, b)
-    a[1] != b[1] && return a[1] > b[1]
-    a[2] != b[2] && return a[2]
-    return a[3] < b[3]
+# A perturbation candidate — a kind-tagged, net_voc-ranked grammar edit. Replaces the former 5-tuple so the
+# candidate is a FIRST-CLASS DECLARED type (Invariant 2/3): the structure Move 5's combined single-currency
+# argmax extends by adding `kind`s (the enum), not by widening a positional tuple whose conventions live in
+# slot order. `payload` is the typed edit target — a `ProductionRule` for `:add`/`:remove`, the feature
+# `Symbol` for `:remove_feature`.
+struct PerturbationCandidate
+    voc::Float64                              # net_voc — the argmax key (primary order)
+    is_remove::Bool                           # tie: prefer a removal (shrink) over an addition (grow)
+    name::String                              # tie: lexicographically smaller (version-stable, not `hash`)
+    kind::Symbol                              # :add | :remove | :remove_feature
+    payload::Union{ProductionRule, Symbol}    # rule (:add/:remove) | feature (:remove_feature)
+end
+
+# Total order for the deterministic argmax: (1) higher `net_voc`; (2) on a tie, prefer a removal (hygiene —
+# shrink before grow); (3) on a further tie, lexicographically smaller name. No `rand`, no `hash` (Julia's
+# `hash` is not stable across versions — version-reproducible determinism is the point; a name string-compare
+# is stable). A tie is between candidates of EXACTLY-EQUAL computed prior value, so a stable order is honest
+# disambiguation among genuine argmax-optima, not a tiebreak of UNKNOWN values (Invariant 1). test_voc_gate.jl §5c.
+function _candidate_better(a::PerturbationCandidate, b::PerturbationCandidate)
+    a.voc != b.voc && return a.voc > b.voc
+    a.is_remove != b.is_remove && return a.is_remove
+    return a.name < b.name
 end
 _pick_better(best, cand) = (best === nothing || _candidate_better(cand, best)) ? cand : best
 
@@ -279,26 +289,26 @@ _pick_better(best, cand) = (best === nothing || _candidate_better(cand, best)) ?
     _best_compression_candidate(g, freq_table; compute_cost = 0.0) → Union{Nothing, Tuple}
 
 The compression-class `net_voc` argmax over the MDL pair `{:add_rule} ∪ {:remove_rule candidates}`, or
-`nothing` if no candidate clears `net_voc > 0` (the saturation no-op). Returns the winning candidate
-`(voc, is_remove, name, kind, rule)` (see `_candidate_better` for the total order). The single home of
-the candidate logic — `perturb_grammar` applies it, `compression_exhausted` (Move 2) tests it for
-`nothing` — so the two can never disagree (DRY).
+`nothing` if no candidate clears `net_voc > 0` (the saturation no-op). Returns the winning
+`PerturbationCandidate` (see `_candidate_better` for the total order). The single home of the candidate
+logic — `perturb_grammar` applies it, `compression_exhausted` (Move 2) tests it for `nothing` — so the
+two can never disagree (DRY).
 """
 function _best_compression_candidate(g::Grammar, freq_table::SubprogramFrequencyTable;
-                                     compute_cost::Float64 = 0.0)
-    best = nothing  # (voc, is_remove, name, kind, rule) — the running argmax; see _candidate_better
+                                     compute_cost::Float64 = 0.0)::Union{Nothing, PerturbationCandidate}
+    best = nothing  # the running argmax (a PerturbationCandidate); see _candidate_better
 
     add = _compression_payoff(freq_table)
     if !isnothing(add)
         rule, net_payoff = add
         if !(rule.name in Set(r.name for r in g.rules))         # idempotence guard (already-present name)
             v = net_voc(net_payoff, compute_cost)               # VOC gate (forward compute priced in)
-            v > 0 && (best = _pick_better(best, (v, false, string(rule.name), :add, rule)))
+            v > 0 && (best = _pick_better(best, PerturbationCandidate(v, false, string(rule.name), :add, rule)))
         end
     end
     for (rule, net_payoff) in _removal_payoff(g, freq_table)
         v = net_voc(net_payoff, compute_cost)
-        v > 0 && (best = _pick_better(best, (v, true, string(rule.name), :remove, rule)))
+        v > 0 && (best = _pick_better(best, PerturbationCandidate(v, true, string(rule.name), :remove, rule)))
     end
     best
 end
@@ -348,10 +358,11 @@ function perturb_grammar(g::Grammar, freq_table::SubprogramFrequencyTable,
     # survives a later compression on its lineage — the 3-arg form would re-default the grid and silently
     # discard the refinement. Bit-identical for default grammars (g.thresholds == default_thresholds by
     # value ⇒ identical enumeration), so the compression tests stay green.
-    if best[4] === :add
-        Grammar(g.feature_set, [g.rules; best[5]], g.thresholds, next_grammar_id())
+    if best.kind === :add
+        Grammar(g.feature_set, [g.rules; best.payload::ProductionRule], g.thresholds, next_grammar_id())
     else  # :remove — drop the dead rule by name (names are unique under the idempotence guard)
-        Grammar(g.feature_set, [r for r in g.rules if r.name != best[5].name], g.thresholds, next_grammar_id())
+        Grammar(g.feature_set, [r for r in g.rules if r.name != (best.payload::ProductionRule).name],
+                g.thresholds, next_grammar_id())
     end
 end
 

--- a/src/program_space/perturbation.jl
+++ b/src/program_space/perturbation.jl
@@ -22,15 +22,18 @@ function analyse_posterior_subtrees(
     min_complexity::Int=2
 )::SubprogramFrequencyTable
     subtree_map = Dict{String, Tuple{ProgramExpr, Float64, Vector{Int}}}()
-    # The sound nonterminal reference count (exploration-budget Move 1): full-depth walk over the SAME
-    # support set (w > 1e-15) the subtree loop uses, independent of extract_subtrees' min_complexity
-    # filter. A concrete (possibly empty) Set ⇒ analysed; consumed by `_removal_payoff` / `:remove_rule`.
+    # The sound reference counts (exploration-budget Move 1 + #174): full-depth walks over the SAME support
+    # set (w > 1e-15) the subtree loop uses, independent of extract_subtrees' min_complexity filter. Concrete
+    # (possibly empty) Sets ⇒ analysed; consumed by `_removal_payoff`/`:remove_rule` (nonterminals) and
+    # `_feature_removal_payoff`/`:remove_feature` (features).
     referenced = Set{Symbol}()
+    referenced_feats = Set{Symbol}()
 
     for (i, prog) in enumerate(programs)
         w = prog_weights[i]
         w > 1e-15 || continue
         collect_nonterminal_refs!(referenced, prog.expr)
+        collect_feature_refs!(referenced_feats, prog.expr)
         subtrees = extract_subtrees(prog.expr, min_complexity)
         for st in subtrees
             key = show_expr(st)
@@ -55,7 +58,7 @@ function analyse_posterior_subtrees(
     end
 
     perm = sortperm(freqs, rev=true)
-    SubprogramFrequencyTable(subtrees[perm], freqs[perm], sources[perm], referenced)
+    SubprogramFrequencyTable(subtrees[perm], freqs[perm], sources[perm], referenced, referenced_feats)
 end
 
 """Extract all subtrees of an expression with complexity ≥ min_c."""
@@ -147,6 +150,37 @@ collect_nonterminal_refs!(acc::Set{Symbol}, e::IfExpr) =
      collect_nonterminal_refs!(acc, e.then_branch);
      collect_nonterminal_refs!(acc, e.else_branch))
 
+"""
+    collect_feature_refs!(acc::Set{Symbol}, e::ProgramExpr) → acc
+
+Collect the names of EVERY feature a predicate in `e` tests (the `.feature` of each `GTExpr`/`LTExpr`),
+recursing to all depths and into all branches. The feature-side mirror of `collect_nonterminal_refs!` and
+the soundness keystone of `:remove_feature` (#174): a feature is "referenced" iff some posterior-support
+program tests it ANYWHERE, so a missed reference would wrongly mark a live feature dead and remove it
+(deleting the support programs that use it). `NonterminalRef` contributes nothing DIRECTLY — a rule body's
+features are caught by `_feature_removal_payoff`'s rule-body union (the transitive case), exactly as the
+nonterminal walk handles its own transitivity. One method per `ProgramExpr` subtype, NO generic fallback —
+a future node type fails loud (a silently-unwalked node is a silent unsoundness). Asserted by
+test_compression_removal.jl §5–§6.
+"""
+collect_feature_refs!(acc::Set{Symbol}, e::GTExpr) = (push!(acc, e.feature); acc)
+collect_feature_refs!(acc::Set{Symbol}, e::LTExpr) = (push!(acc, e.feature); acc)
+collect_feature_refs!(acc::Set{Symbol}, ::NonterminalRef) = acc
+collect_feature_refs!(acc::Set{Symbol}, ::ActionExpr) = acc
+collect_feature_refs!(acc::Set{Symbol}, e::AndExpr) =
+    (collect_feature_refs!(acc, e.left); collect_feature_refs!(acc, e.right))
+collect_feature_refs!(acc::Set{Symbol}, e::OrExpr) =
+    (collect_feature_refs!(acc, e.left); collect_feature_refs!(acc, e.right))
+collect_feature_refs!(acc::Set{Symbol}, e::NotExpr) = collect_feature_refs!(acc, e.child)
+collect_feature_refs!(acc::Set{Symbol}, e::PersistsExpr) = collect_feature_refs!(acc, e.child)
+collect_feature_refs!(acc::Set{Symbol}, e::ChangedExpr) = collect_feature_refs!(acc, e.child)
+collect_feature_refs!(acc::Set{Symbol}, e::SinceExpr) =
+    (collect_feature_refs!(acc, e.p); collect_feature_refs!(acc, e.q))
+collect_feature_refs!(acc::Set{Symbol}, e::IfExpr) =
+    (collect_feature_refs!(acc, e.predicate);
+     collect_feature_refs!(acc, e.then_branch);
+     collect_feature_refs!(acc, e.else_branch))
+
 # ═══════════════════════════════════════
 # Compression payoff — the shared description-length arithmetic
 # ═══════════════════════════════════════
@@ -229,6 +263,29 @@ function _removal_payoff(g::Grammar, table::SubprogramFrequencyTable)::Vector{Tu
     [(r, 1 + expr_complexity(r.body)) for r in g.rules if !(r.name in all_refs)]
 end
 
+"""
+    _feature_removal_payoff(g, table) → Vector{Symbol}
+
+The `:remove_feature` candidates: each feature in `g.feature_set` referenced by NEITHER a posterior-support
+program NOR any rule body (`f ∉ referenced_features ∪ ⋃_r collect_feature_refs!(r.body)`). Removing such a
+dead feature reclaims exactly **1 symbol** (`length(g.feature_set)` drops by one; thresholds are NOT charged
+— `compute_grammar_complexity` is grid-count-invariant) at ZERO fit cost — no support program tests it, so
+the belief is untouched (prior-only). The feature-side mirror of `_removal_payoff`; the rule-body union is
+the same transitive-soundness device (#174). `table.referenced_features === nothing` (un-analysed) ⇒ no
+candidates (fail-closed). Removing a *live* feature is destructive generative change — never a candidate.
+Sorted for a deterministic candidate vector (the winner is already determinate via `_candidate_better`'s
+name tiebreak; sorting removes any doubt about `Set` iteration order). Asserted by test_compression_removal.jl §6.
+"""
+function _feature_removal_payoff(g::Grammar, table::SubprogramFrequencyTable)::Vector{Symbol}
+    refs = table.referenced_features
+    refs === nothing && return Symbol[]
+    all_refs = copy(refs)
+    for r in g.rules
+        collect_feature_refs!(all_refs, r.body)
+    end
+    sort([f for f in g.feature_set if !(f in all_refs)])
+end
+
 # ═══════════════════════════════════════
 # net_voc — Value-of-Computation of a grammar perturbation (collapse-towers Phase 5)
 # ═══════════════════════════════════════
@@ -247,11 +304,12 @@ prior (CLAUDE.md §1.3). A compression saving `net_payoff_symbols` raises the lo
 (the program-axis λ is pinned to `log(2)` by §1.3). The structural twin of `net_voi` (`stdlib.jl`):
 the same `net_value` form, in the prior's currency rather than utility — the third representation,
 after scalar `net_voi` and Functional-offset routing EU. At `compute_cost = 0` the gate `net_voc > 0`
-is exactly `propose_nonterminal`'s `net_payoff > 0`. Governs the COMPRESSION class — both `:add_rule`
-(payoff = compression saving) and `:remove_rule` (payoff = the dead rule's reclaimed cost,
-`1 + expr_complexity(body)`); generative-change ops (`:modify_threshold`, `:add_feature`,
-`:remove_feature`) change the likelihood over un-entertained programs (the escape-mass frontier),
-invisible here by construction, and are deferred to an EU-priced exploration mechanism (master plan).
+is exactly `propose_nonterminal`'s `net_payoff > 0`. Governs the COMPRESSION class — `:add_rule`
+(payoff = compression saving), `:remove_rule` (payoff = the dead rule's reclaimed cost,
+`1 + expr_complexity(body)`), AND `:remove_feature` (#174; payoff = 1, a dead feature's reclaimed symbol).
+The remaining generative-change ops (`:modify_threshold`, `:add_feature`) change the likelihood over
+un-entertained programs (the escape-mass frontier), invisible here by construction, and are deferred to an
+EU-priced exploration mechanism (master plan).
 """
 net_voc(net_payoff_symbols::Real, compute_cost::Real) =
     net_value(complexity_logprior(-net_payoff_symbols; λ = log(2)), compute_cost)
@@ -286,9 +344,9 @@ end
 _pick_better(best, cand) = (best === nothing || _candidate_better(cand, best)) ? cand : best
 
 """
-    _best_compression_candidate(g, freq_table; compute_cost = 0.0) → Union{Nothing, Tuple}
+    _best_compression_candidate(g, freq_table; compute_cost = 0.0) → Union{Nothing, PerturbationCandidate}
 
-The compression-class `net_voc` argmax over the MDL pair `{:add_rule} ∪ {:remove_rule candidates}`, or
+The compression-class `net_voc` argmax over `{:add_rule} ∪ {:remove_rule} ∪ {:remove_feature}` candidates, or
 `nothing` if no candidate clears `net_voc > 0` (the saturation no-op). Returns the winning
 `PerturbationCandidate` (see `_candidate_better` for the total order). The single home of the candidate
 logic — `perturb_grammar` applies it, `compression_exhausted` (Move 2) tests it for `nothing` — so the
@@ -309,6 +367,10 @@ function _best_compression_candidate(g::Grammar, freq_table::SubprogramFrequency
     for (rule, net_payoff) in _removal_payoff(g, freq_table)
         v = net_voc(net_payoff, compute_cost)
         v > 0 && (best = _pick_better(best, PerturbationCandidate(v, true, string(rule.name), :remove, rule)))
+    end
+    for feat in _feature_removal_payoff(g, freq_table)       # the symmetric MDL partner (#174): a dead
+        v = net_voc(1, compute_cost)                         # feature reclaims exactly 1 symbol
+        v > 0 && (best = _pick_better(best, PerturbationCandidate(v, true, string(feat), :remove_feature, feat)))
     end
     best
 end
@@ -336,14 +398,15 @@ is REQUIRED (the type system enforces posterior analysis before nonterminal prop
 `available_features` is retained for signature stability (the deferred feature-discovery mechanism will
 consume it); it is not read here.
 
-The compression class is the **MDL pair** `{:add_rule} ∪ {:remove_rule candidates}` (exploration-budget
-Move 1): `:add_rule` is `_compression_payoff`'s proposed rule (gated by the idempotence guard);
-`:remove_rule` candidates are `_removal_payoff`'s dead rules (referenced by no posterior-support
-program — prior-only, the symmetric MDL partner). The applied meta-action is the `net_voc` argmax over
-the pair, tiebroken by `_candidate_better`. When neither improves the prior, the no-op **is** the
-prior-saturation signal the exploration budget's saturation gate reads (Move 2). The generative-change
-ops (`:modify_threshold`, `:add_feature`, `:remove_feature`) remain deferred — their value is invisible
-to depth-one prior-only `net_voc` (the escape-mass frontier; `docs/exploration-budget/master-plan.md`).
+The compression class is the **MDL set** `{:add_rule} ∪ {:remove_rule} ∪ {:remove_feature}` candidates
+(exploration-budget Move 1 + #174): `:add_rule` is `_compression_payoff`'s proposed rule (gated by the
+idempotence guard); `:remove_rule` candidates are `_removal_payoff`'s dead rules; `:remove_feature`
+candidates are `_feature_removal_payoff`'s dead features (each reclaiming 1 symbol) — all referenced by no
+posterior-support program, prior-only, the symmetric MDL partners. The applied meta-action is the `net_voc`
+argmax over the set, tiebroken by `_candidate_better`. When none improves the prior, the no-op **is** the
+prior-saturation signal the exploration budget's saturation gate reads (Move 2). The remaining
+generative-change ops (`:modify_threshold`, `:add_feature`) remain deferred — their value is invisible to
+depth-one prior-only `net_voc` (the escape-mass frontier; `docs/exploration-budget/master-plan.md`).
 """
 function perturb_grammar(g::Grammar, freq_table::SubprogramFrequencyTable,
                           available_features::Set{Symbol};
@@ -360,9 +423,15 @@ function perturb_grammar(g::Grammar, freq_table::SubprogramFrequencyTable,
     # value ⇒ identical enumeration), so the compression tests stay green.
     if best.kind === :add
         Grammar(g.feature_set, [g.rules; best.payload::ProductionRule], g.thresholds, next_grammar_id())
-    else  # :remove — drop the dead rule by name (names are unique under the idempotence guard)
+    elseif best.kind === :remove  # drop the dead rule by name (names are unique under the idempotence guard)
         Grammar(g.feature_set, [r for r in g.rules if r.name != (best.payload::ProductionRule).name],
                 g.thresholds, next_grammar_id())
+    else  # :remove_feature — reclaim a dead feature: drop it from feature_set AND its grid from thresholds.
+        # The 4-arg Grammar recomputes complexity (grid-count-invariant), so |G| drops by exactly 1.
+        feat = best.payload::Symbol
+        new_features = Set(f for f in g.feature_set if f != feat)
+        new_thresholds = Dict{Symbol, Vector{Float64}}(f => grid for (f, grid) in g.thresholds if f != feat)
+        Grammar(new_features, g.rules, new_thresholds, next_grammar_id())
     end
 end
 

--- a/src/program_space/types.jl
+++ b/src/program_space/types.jl
@@ -251,11 +251,17 @@ struct SubprogramFrequencyTable
     # load-bearing: a concrete empty Set means "analysed, every rule dead" — the OPPOSITE of unknown —
     # because the removal predicate `name ∉ referenced` is vacuously true on the empty set.
     referenced_nonterminals::Union{Nothing, Set{Symbol}}
+    # FEATURE names referenced by ≥1 posterior-support program — the symmetric partner consumed by
+    # `:remove_feature` (#174). Same support set, same `nothing` sentinel (un-analysed ⇒ no feature
+    # removable): a feature in `g.feature_set` absent from a *concrete* set AND from every rule body is
+    # dead → reclaimable (prior-only MDL, 1 symbol).
+    referenced_features::Union{Nothing, Set{Symbol}}
 end
 
-# 3-arg convenience constructor: `nothing` references (un-analysed). Hand-built tables (tests) get the
-# Scope-A-preserving default — `_removal_payoff` yields no candidates, so `:remove_rule` never fires.
-# `analyse_posterior_subtrees` is the only site that populates a concrete (possibly empty) Set.
+# 3-arg convenience constructor: `nothing` references (un-analysed) for BOTH analysis fields. Hand-built
+# tables (tests) get the Scope-A-preserving default — `_removal_payoff`/`_feature_removal_payoff` yield no
+# candidates, so `:remove_rule`/`:remove_feature` never fire. `analyse_posterior_subtrees` is the only site
+# that populates concrete (possibly empty) Sets.
 SubprogramFrequencyTable(subtrees::Vector{ProgramExpr}, weighted_frequency::Vector{Float64},
                          source_programs::Vector{Vector{Int}}) =
-    SubprogramFrequencyTable(subtrees, weighted_frequency, source_programs, nothing)
+    SubprogramFrequencyTable(subtrees, weighted_frequency, source_programs, nothing, nothing)

--- a/test/test_compression_removal.jl
+++ b/test/test_compression_removal.jl
@@ -15,16 +15,17 @@
 #   §2  no over-protection: a rule dead AND unreferenced by any live body is still removable.
 #   §3  dead-chain reclaim cadence (Q3 union-ALL ⇒ one link per pass).
 #   §4  leaf-body sentinel: the fix is a no-op for non-nested grammars (the §3-of-doc capture claim).
-#
-# PR 3 will extend this file with :remove_feature (collect_feature_refs!, _feature_removal_payoff, the
-# unified PerturbationCandidate argmax).
+#   §5  collect_feature_refs! — the feature-side mirror of collect_nonterminal_refs! (PR 3).
+#   §6  _feature_removal_payoff — a DEAD feature is a candidate; a rule-body-only feature is protected (transitive).
+#   §7  :remove_feature via perturb_grammar — apply (drop feature + grid, complexity −1); the unified argmax.
+#   §8  PerturbationCandidate struct contract — :remove_feature carries the feature Symbol; :remove the rule.
 #
 # Run: julia test/test_compression_removal.jl
 
 push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
 using Credence
 using Credence: Grammar, ProductionRule, Program,
-                GTExpr, AndExpr, IfExpr, ActionExpr, NonterminalRef,
+                GTExpr, LTExpr, AndExpr, IfExpr, ActionExpr, NonterminalRef, SubprogramFrequencyTable, ProgramExpr,
                 perturb_grammar, analyse_posterior_subtrees, compile_kernel, CompiledKernel
 
 function check(name, cond, detail = "")
@@ -131,6 +132,90 @@ let
           removal_names(g, ft) == Set([:DEAD]), "got $(removal_names(g, ft))")
 end
 
+# ── §5  collect_feature_refs! — the feature-side mirror of collect_nonterminal_refs! ──
+let
+    refs(e) = (acc = Set{Symbol}(); Credence.collect_feature_refs!(acc, e); acc)
+    check("§5 GTExpr contributes its feature", refs(GTExpr(:red, 0.5)) == Set([:red]))
+    check("§5 LTExpr contributes its feature", refs(LTExpr(:blue, 0.3)) == Set([:blue]))
+    check("§5 And/If recurse into all branches; ActionExpr contributes nothing",
+          refs(IfExpr(AndExpr(GTExpr(:red, 0.5), LTExpr(:blue, 0.3)), ActionExpr(:a), ActionExpr(:b))) ==
+          Set([:red, :blue]))
+    check("§5 NonterminalRef contributes nothing DIRECTLY (the rule-body union handles transitivity)",
+          refs(NonterminalRef(:NT)) == Set{Symbol}())
+end
+
+# ── §6  _feature_removal_payoff — dead feature is a candidate; rule-body-only feature is protected ──
+let
+    # §6a a feature used by NO support program and NO rule body is dead → a candidate.
+    g = Grammar(Set([:red, :wall_dist]), ProductionRule[], 1)
+    prog = Program(IfExpr(GTExpr(:wall_dist, 0.5), ActionExpr(:a), ActionExpr(:b)), 3, 1)   # uses :wall_dist only
+    ft = analyse_posterior_subtrees([prog], [1.0]; min_frequency = 0.0, min_complexity = 2)
+    check("§6a analyse populates referenced_features == {:wall_dist}",
+          ft.referenced_features == Set([:wall_dist]), "got $(ft.referenced_features)")
+    check("§6a dead feature :red is the removal candidate",
+          Credence._feature_removal_payoff(g, ft) == [:red], "got $(Credence._feature_removal_payoff(g, ft))")
+
+    # §6b a feature used ONLY inside a rule body is protected by the rule-body union (transitive).
+    g2 = Grammar(Set([:red]), [ProductionRule(:NT, GTExpr(:red, 0.4))], 2)
+    prog2 = Program(IfExpr(NonterminalRef(:NT), ActionExpr(:a), ActionExpr(:b)), 3, 1)       # :red only via NT's body
+    ft2 = analyse_posterior_subtrees([prog2], [1.0]; min_frequency = 0.0, min_complexity = 2)
+    check("§6b referenced_features (program-direct) == {} (:red invisible to the program walk)",
+          ft2.referenced_features == Set{Symbol}(), "got $(ft2.referenced_features)")
+    check("§6b :red protected by NT's rule body ⇒ NOT a candidate (transitive)",
+          isempty(Credence._feature_removal_payoff(g2, ft2)), "got $(Credence._feature_removal_payoff(g2, ft2))")
+
+    # §6c the `nothing` sentinel (hand-built table) ⇒ no candidates (fail-closed).
+    ft3 = SubprogramFrequencyTable(ProgramExpr[], Float64[], Vector{Int}[])
+    check("§6c nothing referenced_features ⇒ no candidates (fail-closed)",
+          isempty(Credence._feature_removal_payoff(g, ft3)))
+end
+
+# ── §7  :remove_feature via perturb_grammar — apply surgery + the unified argmax ──
+let
+    # §7a a dead feature is reclaimed: feature_set shrinks, its grid drops, complexity −1, fresh id.
+    g = Grammar(Set([:red, :wall_dist]), ProductionRule[], 1)
+    prog = Program(IfExpr(GTExpr(:wall_dist, 0.5), ActionExpr(:a), ActionExpr(:b)), 3, 1)
+    ft = analyse_posterior_subtrees([prog], [1.0]; min_frequency = 0.0, min_complexity = 2)
+    got = perturb_grammar(g, ft; compute_cost = 0.0)
+    check("§7a perturb_grammar removes the dead feature :red",
+          got.feature_set == Set([:wall_dist]), "got $(got.feature_set)")
+    check("§7a :red's grid dropped; :wall_dist's grid kept",
+          !haskey(got.thresholds, :red) && haskey(got.thresholds, :wall_dist), "got $(keys(got.thresholds))")
+    check("§7a complexity drops by exactly 1 (one symbol reclaimed)",
+          got.complexity == g.complexity - 1.0, "got $(got.complexity) vs $(g.complexity)")
+    check("§7a fresh grammar id", got.id != g.id)
+
+    # §7b the unified argmax: a dead RULE (payoff 1+complexity = 2) beats a dead FEATURE (payoff 1) — removed first.
+    g2 = Grammar(Set([:red, :wall_dist]), [ProductionRule(:DEAD, GTExpr(:wall_dist, 0.5))], 1)
+    prog2 = Program(IfExpr(GTExpr(:wall_dist, 0.5), ActionExpr(:a), ActionExpr(:b)), 3, 1)   # :wall_dist alive; :red + :DEAD dead
+    ft2 = analyse_posterior_subtrees([prog2], [1.0]; min_frequency = 0.0, min_complexity = 2)
+    got2 = perturb_grammar(g2, ft2; compute_cost = 0.0)
+    check("§7b unified argmax: dead rule (voc 2log2) beats dead feature (voc log2) — :DEAD removed",
+          :DEAD ∉ Set(r.name for r in got2.rules), "rules=$(sort(string.(r.name for r in got2.rules)))")
+    check("§7b the feature_set is untouched this pass (rule won; :red reclaimed a later pass)",
+          got2.feature_set == Set([:red, :wall_dist]), "got $(got2.feature_set)")
+end
+
+# ── §8  PerturbationCandidate struct contract — typed payload per kind ──
+let
+    g = Grammar(Set([:red, :wall_dist]), ProductionRule[], 1)
+    prog = Program(IfExpr(GTExpr(:wall_dist, 0.5), ActionExpr(:a), ActionExpr(:b)), 3, 1)
+    ft = analyse_posterior_subtrees([prog], [1.0]; min_frequency = 0.0, min_complexity = 2)
+    cand = Credence._best_compression_candidate(g, ft)
+    check("§8 :remove_feature candidate carries the feature Symbol as payload",
+          cand.kind == :remove_feature && cand.payload == :red, "kind=$(cand.kind) payload=$(cand.payload)")
+    check("§8 :remove_feature is a removal (is_remove) with voc == log2 (1 symbol)",
+          cand.is_remove == true && cand.voc ≈ log(2), "is_remove=$(cand.is_remove) voc=$(cand.voc)")
+
+    g2 = Grammar(Set([:red, :blue]), [ProductionRule(:DEAD2, GTExpr(:blue, 0.5))], 2)
+    prog2 = Program(IfExpr(GTExpr(:red, 0.5), ActionExpr(:a), ActionExpr(:b)), 3, 1)          # :red alive; :DEAD2 dead
+    ft2 = analyse_posterior_subtrees([prog2], [1.0]; min_frequency = 0.0, min_complexity = 2)
+    cand2 = Credence._best_compression_candidate(g2, ft2)
+    check("§8 :remove candidate carries the ProductionRule as payload",
+          cand2.kind == :remove && cand2.payload isa ProductionRule && cand2.payload.name == :DEAD2,
+          "kind=$(cand2.kind) payload=$(cand2.payload)")
+end
+
 println("="^64)
-println("ALL CHECKS PASSED — compression-removal :remove_rule transitive soundness")
+println("ALL CHECKS PASSED — compression-removal (:remove_rule transitive + :remove_feature)")
 println("="^64)


### PR DESCRIPTION
## What

`:remove_feature` — the symmetric MDL partner of `:remove_rule` — plus the `PerturbationCandidate` struct
refactor it needed. **PR 3 of 3** for #174; **closes #174** (with PR 1).

## Two commits

**Commit 1 — `PerturbationCandidate` struct (behaviour-preserving).** The compression-class argmax candidate
was a positional 5-tuple `(voc, is_remove, name, kind, rule)`. Replaced with a first-class declared
`PerturbationCandidate` struct (`kind` + typed `payload`) — the structure Move 5's combined single-currency
argmax extends by adding `kind`s, not by widening a positional tuple whose conventions live in slot order
(Invariant 2/3). Verified behaviour-preserving (`test_voc_gate` incl. the §5c tiebreak, `test_saturation`,
`test_program_space`, `test_perturb_consumption`, `test_compression_removal` all green).

**Commit 2 — `:remove_feature`.** A feature in `g.feature_set` referenced by NEITHER a posterior-support
program NOR any rule body is dead — removing it reclaims exactly 1 symbol (`length(feature_set)` drops;
thresholds are grid-count-invariant) at zero fit cost (prior-only). It rides inside `perturb_grammar`'s
`net_voc` argmax with `:add_rule`/`:remove_rule` — **no new meta-action**.
- `SubprogramFrequencyTable.referenced_features` (additive; the 3-arg convenience defaults both analysis
  fields to `nothing`, so hand-built test tables are unaffected).
- `collect_feature_refs!` — the feature-side mirror of `collect_nonterminal_refs!` (one method per
  `ProgramExpr` subtype, no fallback; `NonterminalRef` contributes nothing directly — the rule-body union
  handles transitivity). Internal.
- `_feature_removal_payoff` = program refs ∪ **ALL** rule-body refs (Q3), dead ⇒ candidate, payoff 1.
- `_best_compression_candidate` folds it into the argmax; `perturb_grammar` applies it (drop the feature +
  its grid, fresh id, `|G|` −1).

## Tests

`test_compression_removal.jl` §5–§8 (25 checks total): `collect_feature_refs!` soundness,
`_feature_removal_payoff` (dead detection + transitive protection + fail-closed `nothing` sentinel), the
apply surgery (grid dropped, complexity −1), the unified argmax (a dead rule beats a dead feature), and the
`PerturbationCandidate` contract (`:remove_feature` carries the feature Symbol; `:remove` the ProductionRule).
Full local suite (52 files) + lint before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
