### PR TITLE
Move 5 — close the currency question, name the fidelity frontier (exploration-budget capstone)

### DIFF
--- a/docs/exploration-budget/master-plan.md
+++ b/docs/exploration-budget/master-plan.md
@@ -14,6 +14,17 @@
 > seam (§3.1) scopes what each move may *claim*. All five open questions ratified as recommended, with the
 > reasoning strengthened from "preferred" to "forced" where it is forced (§5). The move sequence is final.
 > Move 1's design doc may open.
+>
+> **UPDATE 2026-06-30 — ARC COMPLETE THROUGH MOVE 5.** Moves 1–4 landed; the #174 compression-removal
+> follow-up landed; Move 5 (the capstone) attempted the combined single-currency `argmax` and **refined
+> Q5/§4**: it is **one currency — Δ log-evidence — with two *fidelities*** (a cheap depth-one prior-only
+> surrogate, compression's `net_voc`; vs a re-conditioned exact lookahead, exploration's VOI), NOT two
+> currencies. `explore_features` already sums the prior and likelihood terms in one `net_value`, proving
+> the single currency. The invariant that must not be flattened is the **compute-tier cascade** (EU-max
+> via Russell–Wefald on the cost of evaluation), not a currency incommensurability. **One outstanding
+> empirical gate:** dominance (§3.2 prediction 2 — beat random + fixed-schedule baselines) has no
+> comparative benchmark; **deferred to a paper-gated task** (discovery §3.1 and graceful degradation §3.3
+> are unit-validated). See `docs/exploration-budget/move-5-design.md`.
 
 ## 1. Context — what Scope A left undone, and why it is hard
 
@@ -176,17 +187,27 @@ moves:
   proposed features," never "EU-max feature *generation*"** (§3.1); novel-dimension synthesis is named as
   the standing creative frontier, not implemented. `:remove_feature` reuses Move 1's reference-count
   soundness.
-- **Move 5 — The combined single-currency `argmax`: attempt, expect to stop (close-or-name the headline).**
-  Exploration's lookahead VOI is *already* in utility (realised value gain), so it unifies with the object
-  level for free — the lone outlier is **compression**, priced in prior nats. So the combined `argmax`
-  faces *one* question, not two currencies: can compression's nats become utility? The prediction is **no,
-  and stopping is correct**: compression is cheap *because* it is depth-one prior-priced; pricing it in
-  utility means pricing it by lookahead, which makes it as expensive as exploration and **destroys the
-  cheap-screen-first ordering the whole design rests on**. So the currency gap is not a representational
-  accident to convert away — it is the **signature of the two compute tiers** (cheap prior screen vs
-  expensive utility lookahead). Move 5 attempts the unification, and on hitting this, **names it a permanent
-  frontier with that reasoning** (Phase-5 precedent — do not force a fake common currency). May fold into
-  Move 4 (OQ-5).
+- **Move 5 — The combined single-currency `argmax`: attempted; closed the currency question, named the
+  fidelity frontier (LANDED 2026-06-30).** The attempt found §4's original "two currencies (compression in
+  prior nats, exploration in utility)" framing imprecise on both labels. There is **one** currency —
+  **Δ log-evidence** (`Δlog P(g) + Δlog P(data|g)`, the log joint) — and `explore_features` *already sums
+  its two terms in one `net_value`*, which proves it (a unit mismatch would make that `+` incoherent). The
+  three meta-action classes are three **instances** of one functional, differing in **fidelity** not
+  currency: `explore_features` = the exact, general instance (both terms, re-conditioned); `explore_grammar`
+  = the exact `Δprior = 0` instance; compression's `net_voc` = the cheap **prior-only surrogate** (the
+  likelihood term *dropped* — not because it is zero, but because the depth-one prior-only signature cannot
+  afford to re-condition and measure it, Russell–Wefald). "Utility" also mislabels exploration: `Δℓ` is
+  predictive/log-evidence, not realised ΔEU. **The conclusion stands — do not build the flat exact
+  `argmax`** — but for a sharper reason: ranking compression in the *same exact* `argmax` forces measuring
+  its likelihood term (re-conditioning it), making the cheap screen as expensive as the lookahead. The
+  invariant is therefore the **compute-tier cascade** (cheap surrogate screen → expensive exact lookahead,
+  ordered by the Move-2 saturation gate), which is *itself* EU-max (Russell–Wefald prices the cost of
+  evaluation), **not** a currency incommensurability. Two frontiers, cleanly named: (a) the surrogate/exact
+  **fidelity** cascade is the permanent structure; (b) the genuine log-evidence → realised ΔEU conversion
+  (needs decision-lookahead, the `net_voi` form) is a *separate* standing frontier, shared equally by both
+  classes so it does not separate them. Lands stand-alone (not folded into Move 4). Code footprint: this
+  master-plan refinement + two docstring precision notes; **no `net_evidence_voc` merge** (it would blur
+  the §2 prior/belief seam). See `docs/exploration-budget/move-5-design.md`.
 
 Each move lands design-doc-then-code; the empirical predictions (§3) are checked at Moves 3–5 on a
 purpose-built task (a paper-style figure, per the paper-as-gating-artifact discipline if this feeds a
@@ -212,9 +233,12 @@ publication).
 >   waiting for. The lossy `freq_table` cannot supply soundness; lowering `min_complexity` changes
 >   `freq_table` semantics for *every* consumer (non-local blast radius for a local need). Thread the count
 >   — sound by construction.
-> - **Q5 — attempt, expect to stop; the currency gap *is* the architecture** (see Move 5, §4). Name it a
->   permanent frontier with the two-compute-tiers reasoning, rather than forcing a conversion that would
->   quietly defeat cheap compression.
+> - **Q5 — attempted; REFINED 2026-06-30 (see Move 5, §4).** Not "two currencies that can't merge": **one
+>   currency (Δ log-evidence), two fidelities** (cheap prior-only surrogate vs re-conditioned exact). The
+>   invariant that must not be flattened is the **compute-tier cascade** (EU-max, Russell–Wefald on the
+>   cost of evaluation), not a currency incommensurability — `explore_features` already sums prior and
+>   likelihood nats in one `net_value`, proving the single currency. The separate, genuine frontier is
+>   log-evidence → realised ΔEU (shared by both classes). Do not force the flat exact `argmax`.
 >
 > The prose below is retained as the rationale of record.
 
@@ -244,7 +268,12 @@ publication).
    exploration has a (lookahead-derived) utility-currency value commensurable with compression's prior
    value — or does the currency gap Phase-5 flagged remain, leaving Move 5 a *named* frontier rather than
    a *closed* one? *Recommendation: attempt it at Move 5; if the commensurability doesn't hold honestly,
-   stop and name it* (do not force a fake common currency — the Phase-5 precedent).
+   stop and name it* (do not force a fake common currency — the Phase-5 precedent). **Resolved 2026-06-30
+   (Move 5 §4): the *currency* question closes — it is one currency (Δ log-evidence), shown by
+   `explore_features` summing both terms; the commensurability the question worried about holds. What
+   remains a named frontier is the **fidelity** cascade (cheap prior-only surrogate vs re-conditioned
+   exact), an EU-max compute-tier structure, plus the separate log-evidence → ΔEU conversion. The premise
+   "exploration has a utility-currency value" was itself imprecise: exploration is log-evidence, not ΔEU.**
 
 ## 6. Hard constraints (inherited)
 

--- a/docs/exploration-budget/move-5-design.md
+++ b/docs/exploration-budget/move-5-design.md
@@ -1,0 +1,243 @@
+# Move 5 design — the combined single-currency `argmax`: attempt, and the honest finding
+
+> Exploration-budget arc, Move 5 (the capstone). Master plan: `docs/exploration-budget/master-plan.md`
+> §4 ("attempt, expect to stop") + Q5. This doc is the **attempt**. It reaches the wall the master plan
+> predicted — but the wall is in a sharper place than §4's prose, and the refinement is the deliverable.
+> Per the arc discipline this design doc lands and is ratified before any code; the recommended code
+> footprint is small-to-zero (a naming/closing move), which OQ-5.2 puts to the reviewer.
+
+## 0. Ratification (2026-06-30, author)
+
+Ratified in conversation:
+- **OQ-5.1 — RATIFIED.** Refine master-plan §4 + Q5 from "two currencies (prior nats vs utility)" to
+  **one currency (Δ log-evidence), two fidelities** (cheap prior-only surrogate vs re-conditioned exact);
+  the invariant is the **compute-tier cascade** (EU-max, Russell–Wefald), not a currency incommensurability.
+- **OQ-5.3 — DEFER + NAME.** The dominance benchmark (thesis prediction §3.2) is the one outstanding
+  empirical gate; it is **deferred to a paper-gated task and named as such** in the master-plan status,
+  not built here. (Discovery §3.1 and graceful degradation §3.3 are already unit-validated.)
+- **OQ-5.2 → (b):** ship the two docstring precision notes (`net_voc`, `explore_features`) naming the
+  surrogate / exact instances; **no** `net_evidence_voc` merge (it would blur the §2 prior/belief seam).
+- **OQ-5.4 → stand-alone:** Move 5 lands as its own move (the §4 refinement deserves its own status line),
+  not a Move-4 addendum.
+
+The OQ prose in §5 is retained as the rationale of record.
+
+## 1. Purpose
+
+Move 5 as scoped in the master plan (§4): **attempt the combined single-currency `argmax` over the whole
+meta-action space** — compression (`:add_rule` / `:remove_rule` / `:remove_feature`, priced by `net_voc`)
+*and* exploration (`explore_grammar` thresholds, `explore_features` features, priced by lookahead VOI) —
+and either close the headline ("the metalevel is one `argmax EU`") or **name the residue as a permanent
+frontier with the reasoning** (the Phase-5 precedent: do not force a fake common currency).
+
+The master plan **predicted stop**, and stop is correct. But doing the attempt honestly relocates the
+wall, and the relocation matters:
+
+> **Master plan §4 reads the gap as "two currencies — compression in prior nats, exploration in
+> utility — that cannot merge."** The attempt finds that framing imprecise on both labels. There is
+> **one** currency — **Δ log-evidence** (`Δlog P(g) + Δlog P(data|g)`, the log joint) — and
+> `explore_features` already *sums its two terms in a single `net_value`*. Compression and exploration
+> are not two currencies; they are **two fidelities of the one currency**: a cheap depth-one
+> **prior-only surrogate** (compression's `net_voc`, the likelihood term dropped because the prior-only
+> signature cannot afford to measure it) versus an expensive re-conditioned **exact** evaluation
+> (exploration's lookahead). The thing that must not be flattened is the **compute-tier cascade**
+> between those fidelities — and the cascade is *itself* EU-max (Russell–Wefald on the cost of
+> evaluation), not a currency incommensurability.
+
+So Move 5 **closes the currency question** (one currency, named and shown) and **names the residue
+precisely** (the cheap-surrogate/exact-lookahead fidelity cascade is the permanent structure; and
+*separately*, the genuine log-evidence→realised-ΔEU conversion is the standing frontier, shared equally
+by both classes so it does not separate them). What unblocks: the arc's headline is settled, with the
+master-plan §4 framing upgraded from "two currencies" to "one currency, two fidelities."
+
+## 2. Files touched
+
+This is a naming/closing move. The **only required** artifact is this design doc plus a precision edit to
+the master plan; the code touches are all OQ-gated (OQ-5.2) and behaviour-preserving.
+
+- `docs/exploration-budget/move-5-design.md` — **new** (this doc).
+- `docs/exploration-budget/master-plan.md` §4 + Q5 — **modify** (required): upgrade "two currencies
+  (prior nats vs utility)" to "one currency (Δ log-evidence), two fidelities (prior-only surrogate vs
+  re-conditioned exact); the cascade is the invariant." This is a *refinement of a ratified plan* —
+  surfaced for ratification as OQ-5.1, not applied unilaterally.
+- `src/program_space/perturbation.jl` `net_voc` docstring (~296-315) — **modify, OQ-5.2** (optional):
+  one sentence naming `net_voc` as the **Δℓ-dropped prior-only-surrogate instance** of the shared
+  Δ log-evidence VOC, pointing at `explore_features` as the exact general instance. Pure comment.
+- `src/program_space/exploration.jl` `explore_features` docstring (~316-340) — **modify, OQ-5.2**
+  (optional): one sentence naming its `Δℓ + complexity_logprior(Δc)` as the **exact general instance**
+  of the same functional, with `explore_grammar` the `Δprior=0` instance and `net_voc` the surrogate.
+- **No new code file. No `net_evidence_voc` merge** (rejected in §4 below — it would blur the §2
+  prior/belief seam). **No behaviour change** anywhere.
+
+The dominance benchmark (the one un-validated empirical gate, §6) is **out of scope here pending OQ-5.3**
+— it is an empirical/paper deliverable, a different kind of work from this conceptual close.
+
+## 3. Behaviour preserved
+
+Move 5 changes no arithmetic and selects no action differently. There is nothing to compute-equivalence
+because there is no computational change:
+
+- If Move 5 ships **doc-only** (recommended, §5): the entire `test/test_*.jl` suite is `==` unchanged;
+  the assertion is "no source byte under `src/` changed," verified by `git diff --stat src/`.
+- If OQ-5.2 elects the docstring precision notes: docstrings only; `julia test/test_voc_gate.jl`,
+  `test_threshold_explore.jl`, `test_feature_discovery.jl`, `test_grid_world_meta.jl` stay `==` green
+  (capture-before-refactor is trivial — no executable line moves).
+
+There is deliberately **no** `net_evidence_voc` refactor whose equivalence we would have to pin (§4
+rejects it), so the strata-1/2/3 tolerance ladder of the template does not apply: this move has no
+behaviour-preserving code transform to bound.
+
+## 4. Worked end-to-end example — the three meta-action classes through the one currency
+
+The centrepiece claim is "one currency, three instances, two fidelities." Trace a concrete grammar with
+all three classes available. Let `g` have features `{food, enemy}`, one rule `R`, and a residual buffer
+`obs` on which the posterior mispredicts.
+
+**The one functional (the currency).** For any grammar edit `g → g'`, the honest value is the change in
+log joint evidence, minus the compute spent to evaluate it:
+
+```
+net_evidence_voc(g → g') = [ Δlog P(g) + Δlog P(data | g) ] − compute_cost
+                         = [ complexity_logprior(Δcomplexity; λ=log2)  +  (mll(obs|g) − mll(obs|g')) ] − cc
+                            └────────── prior term ──────────┘     └──────── likelihood term ───────┘
+```
+
+Now the three classes, each a special case — and the fidelity each can afford:
+
+1. **Feature discovery** `:add_feature` (owner: `explore_features`, `exploration.jl:342`). `g' = g ∪
+   {moved}`. Both terms non-zero: `Δcomplexity = +1` (prior term `−log2`), `Δℓ = mll(obs|g) −
+   mll(obs|g') > 0` (a feature the posterior needed). `explore_features` computes
+   `net_value((baseline − mll) + complexity_logprior(+1; λ=log2), cc)` — **the exact, general instance,
+   both terms, re-conditioned.** Fidelity: **exact (expensive)**.
+
+2. **Threshold refinement** `:modify_threshold` (owner: `explore_grammar`, `exploration.jl:273`). `g'` =
+   `g` with a finer grid on `food`. A threshold constant is complexity-invariant
+   (`expr_complexity(::GTExpr)=1`), so `Δcomplexity = 0` → prior term vanishes; only `Δℓ` remains.
+   `explore_grammar` computes `net_value(baseline − mll, cc)` — **the exact `Δprior = 0` instance,
+   re-conditioned.** Fidelity: **exact (expensive)**.
+
+3. **Compression** `:add_rule` (owner: `net_voc` via `perturb_grammar`, `perturbation.jl:314`). `g'` = `g`
+   with a frequent subtree abbreviated as a nonterminal. `Δcomplexity < 0` (the dictionary shrinks the
+   description) → prior term `log2·Δsymbols > 0`. **The likelihood term is *not zero*** — abbreviating
+   reweights the mixture toward compressible programs, which shifts `mll`. But `perturb_grammar` has **no
+   belief, no `obs`, no re-conditioning** (the §2 prior-only signature), so it **cannot measure the
+   likelihood term and drops it**, scoring `net_value(complexity_logprior(−Δsymbols; λ=log2), cc)` =
+   `log2·Δsymbols − cc`. The docstring already names this honestly: *"achievable EU is unaffordable
+   depth-one (Russell–Wefald); the affordable value-**proxy** is the change in the complexity prior."*
+   Fidelity: **prior-only surrogate (cheap)**.
+
+**What the trace shows.** The same `net_evidence_voc` row, read at three settings of (which terms, what
+fidelity): feature = (both, exact), threshold = (likelihood only, exact), compression = (prior only,
+**surrogate**). The currency never changes — `explore_features` *proves* prior nats and predictive nats
+add coherently (they are both log-evidence; a unit mismatch would make that `+` type-incoherent). So
+**the single currency exists and is already in the code.**
+
+**Why the flat argmax is still wrong — the cascade is EU-max, not a workaround.** Suppose Move 5 built the
+honest flat argmax: rank *every* candidate by the *exact* `net_evidence_voc`. Then compression's
+likelihood term must be measured too — i.e. compression must be re-conditioned — making the cheap screen
+as expensive as the lookahead. Russell–Wefald forbids exactly this: the **cost of evaluating** a
+candidate nets against its value, and you do not pay the expensive exact evaluation when a cheap
+**surrogate-positive** compression win is in hand. The saturation gate (`compression_exhausted ∧
+plateau`, Move 2) is the *already-EU-derived* form of that meta-meta-decision: spend the expensive exact
+lookahead only when (a) no cheap surrogate-positive compression remains and (b) the residual predicts the
+lookahead will pay. So the "combined `argmax`" exists — but as a **two-tier cascade** (cheap prior-only
+surrogate screen → expensive exact lookahead, ordered by saturation), each tier an `argmax` in the one
+shared log-evidence currency. A flat one-shot `argmax` is not *more* unified; it is the cascade with its
+EU-optimal evaluation-cost ordering deleted.
+
+**The genuine residue (named, not closed).** None of the three is realised **ΔEU** (object-level decision
+value, A2). All are **log-evidence** (information / model improvement). Converting log-evidence → ΔEU
+needs decision-lookahead — the `net_voi` form (re-decide, measure the EU gain), which is depth-≥1 *over
+actions* on top of the depth-≥1 over grammars. That conversion is the standing frontier — but it is
+**shared equally** by compression and exploration (both improve the model; neither's model-improvement is
+yet cashed into decision value), so it is **not** the wall that separates the two classes. The wall that
+separates them is the **fidelity/compute-tier** boundary above. Two distinct frontiers, cleanly named.
+
+## 5. Open design questions
+
+1. **OQ-5.1 — Ratify the §4 refinement, or defend the original "two currencies."** The attempt finds
+   master-plan §4's "compression in prior nats vs exploration in utility, cannot merge" imprecise: it is
+   one currency (Δ log-evidence — `explore_features` sums both terms), two **fidelities** (prior-only
+   surrogate vs re-conditioned exact), and the invariant is the **compute-tier cascade** (EU-max via
+   Russell–Wefald), not a currency incommensurability; "utility" mislabels exploration's predictive-nats
+   too. **Recommendation: ratify the refinement** and edit §4 + Q5 to the "one currency, two fidelities"
+   framing — it is more correct (the `+` in `explore_features` is the proof), it strengthens rather than
+   weakens the "don't flatten" conclusion (Russell–Wefald is a sharper reason than "different units"),
+   and it adds **no constitutional text** (it is a precision edit to an arc plan, not to CLAUDE.md/SPEC).
+   Counter to weigh: a ratified master plan changing its central §4 wording is not free; if the reviewer
+   reads the surrogate-vs-exact distinction as *already implied* by §4's "depth-one prior-priced," then
+   the edit is a clarification, not a correction, and could stay a footnote rather than a rewrite.
+
+2. **OQ-5.2 — Code footprint: doc-only, or the two docstring precision notes?** The single currency is
+   already in the code (shared `net_value`; `explore_features` sums the terms). The options are (a)
+   **doc-only** — this design doc + the §4 edit, no `src/` change; or (b) **+ two docstring notes** on
+   `net_voc` and `explore_features` naming them the surrogate / exact-general instances of the one
+   functional, so the relationship is legible at the call sites. **Recommendation: (b), the two docstring
+   notes** — they cost nothing, change no behaviour, and put the move's finding where the next reader of
+   `net_voc` will see it (executable-documentation spirit), without the rejected merge. A full
+   `net_evidence_voc` refactor routing all three through one function is **rejected**, not deferred:
+   compression is prior-only by signature and exploration belief-aware (§2), so a shared functional would
+   blur the prior/belief seam the architecture deliberately draws — the `measure-as-view` lesson
+   (carrier-free vs carrier-bound stays split). Counter: even docstring edits touch `src/` on a move
+   whose honest footprint might be zero; if the reviewer prefers the cleanest possible "naming move,"
+   (a) is defensible and the notes move into this doc only.
+
+3. **OQ-5.3 — The dominance benchmark (prediction §3.2): fold into Move 5, or name-and-defer?** Of the
+   thesis's three empirical gates, **discovery** (§3.1) and **graceful degradation** (§3.3) are validated
+   by unit tests (`test_feature_discovery`, `test_threshold_explore` §3c's continuous explore/no-op flip
+   at `cc = Δℓ`); **dominance** — beating both random exploration and a fixed-schedule baseline — has **no
+   comparative benchmark** in the suite. It is the one outstanding gate. **Recommendation: name it as the
+   single outstanding empirical gate and treat it as a separate paper-gated deliverable, NOT part of this
+   conceptual close** — the currency finding stands or falls on the analysis in §4, not on a benchmark,
+   and a dominance figure is benchmark/figure work (closer to the `paper-as-gating-artifact` track) that
+   would balloon a naming move. Fold it in **iff** this arc is feeding a specific paper now (then Move 5
+   becomes "conceptual close + empirical capstone"); otherwise defer with the gate named. Reviewer
+   decides based on whether exploration-budget feeds paper1-4 this cycle.
+
+4. **OQ-5.4 — Does Move 5 stand alone, or fold into Move 4 retroactively (master plan's "May fold into
+   Move 4 (OQ-5)")?** Given the recommended doc-only/near-zero footprint, Move 5 could be recorded as a
+   §-appendix to Move 4 rather than its own move. **Recommendation: stand alone as Move 5.** The attempt
+   *refines a ratified plan* (OQ-5.1) and *names two distinct frontiers* — that is a substantive close
+   deserving its own ratifiable artifact and its own master-plan status line, even at near-zero code.
+   Folding it into Move 4 would bury the §4 refinement in a move that has already landed. Counter: if
+   OQ-5.1 resolves to "clarification, not correction" and OQ-5.2 to "doc-only," the move is light enough
+   that a reviewer could reasonably prefer it as a Move-4 addendum.
+
+## 6. Risk + mitigation
+
+- **Over-claiming the unification (the headline risk).** Failure mode: reading "one currency" as "the
+  flat single `argmax` is fine, build it." Blast radius: would motivate replacing the cheap compression
+  screen with an exact re-conditioned evaluation — destroying the resource-rational cascade the whole arc
+  rests on (the precise harm the master plan warned of). Mitigation: §4's worked example makes the
+  flat-argmax-is-wrong argument explicitly and EU-theoretically (Russell–Wefald on evaluation cost), and
+  the **recommendation ships no merge** — the cascade stays exactly as built; nothing in this move
+  changes a selection path. The `average-not-collapse` precedent is adjacent but distinct (that forbids
+  collapsing a *posterior* to its MAP to drive a decision; here we forbid collapsing a *two-fidelity
+  cascade* to a flat exact argmax) — no pragma site, because no code asserts the flattening.
+
+- **Contradicting a ratified master plan without consent.** Failure mode: silently rewriting §4. Blast
+  radius: the master plan is the arc's durable record; an unratified edit erodes it. Mitigation: the §4
+  edit is **gated on OQ-5.1** and applied only on ratification; until then this doc carries the refinement
+  and the master plan is untouched. No CLAUDE.md/SPEC text changes (the arc's hard constraint): the
+  refinement lives entirely in arc-local docs.
+
+- **Scope creep via the dominance benchmark.** Failure mode: a naming move silently growing into a
+  benchmark/figure build. Blast radius: Move 5 stops being bisectable/small and the conceptual close gets
+  held hostage to figure tuning. Mitigation: OQ-5.3 makes the fold-in an explicit, defaulted-to-defer
+  decision; the gate is **named** either way (no silent cap on the thesis — the outstanding gate is
+  recorded, not buried).
+
+## 7. Verification cadence
+
+- **Doc-only path (recommended):** `git diff --stat src/ apps/` shows zero lines; lint self-test
+  `python tools/credence-lint/credence_lint.py` + `check apps/` pass (no new pragmas, slug index intact).
+  No skin smoke needed — Move 5 changes nothing crossing the wire (template: skin smoke optional for
+  Moves 1/2/5/8).
+- **If OQ-5.2 (b) docstring notes land:** additionally run the arc suite to confirm docstrings did not
+  disturb executable lines — `julia test/test_voc_gate.jl && julia test/test_threshold_explore.jl &&
+  julia test/test_feature_discovery.jl && julia test/test_grid_world_meta.jl &&
+  julia test/test_compression_removal.jl && julia test/test_saturation.jl` — all `==` green. Then the
+  full `test/test_*.jl` suite green before commit.
+- **Halt-the-line:** any test failure, or any non-zero `src/` diff on the doc-only path, is a halt — the
+  branch never sleeps red, and a "naming move" that mutated behaviour is a contradiction to stop and
+  investigate, not to patch forward.

--- a/src/program_space/exploration.jl
+++ b/src/program_space/exploration.jl
@@ -332,6 +332,15 @@ case); a new feature adds a symbol (Δcomplexity = +1 ⇒ the feature must repay
 threshold never owed). fine-before-coarse, made endogenous: the cheap rung clears while it pays; the dear
 rung waits until it doesn't. Asserted by test_feature_discovery.jl §4 (the boundary sits at Δℓ − log2, not Δℓ).
 
+**Move 5 (one currency, two fidelities).** This two-axis sum *is* the **exact, general instance** of the
+single **Δ log-evidence** VOC — `Δlog P(data|g)` (fit) plus `Δlog P(g)` (prior) in one `net_value`, which
+is *why* the `+` is coherent: both are log-evidence nats, not two currencies. `explore_grammar` is the
+`Δprior = 0` instance of the same functional; compression's `net_voc` (`perturbation.jl`) is the cheap
+**prior-only surrogate** (the likelihood term dropped — its prior-only signature cannot afford to measure
+it). The fidelity gap between the surrogate and this exact re-conditioned eval — *not* a currency gap — is
+the arc's permanent frontier; the two-tier cascade (cheap screen → exact lookahead) orders it and is
+itself EU-max (Russell–Wefald). See `docs/exploration-budget/move-5-design.md`.
+
 Soundness is trivial for `:add_feature` — enlarging the alphabet can only ADD representable programs, never
 break an existing one — so no reference count is needed (contrast `:remove_feature`, the MDL-compression
 partner). Full-eval argmax over the (small, host-furnished) candidate set in sorted order: deterministic, no

--- a/src/program_space/perturbation.jl
+++ b/src/program_space/perturbation.jl
@@ -301,9 +301,16 @@ prior (CLAUDE.md §1.3). A compression saving `net_payoff_symbols` raises the lo
 
     complexity_logprior(−net_payoff_symbols; λ = log(2)) = log(2) · net_payoff_symbols      [nats]
 
-(the program-axis λ is pinned to `log(2)` by §1.3). The structural twin of `net_voi` (`stdlib.jl`):
-the same `net_value` form, in the prior's currency rather than utility — the third representation,
-after scalar `net_voi` and Functional-offset routing EU. At `compute_cost = 0` the gate `net_voc > 0`
+(the program-axis λ is pinned to `log(2)` by §1.3). The structural twin of `net_voi` (`stdlib.jl`): the same `net_value` form — the third representation,
+after scalar `net_voi` and Functional-offset routing EU. **Move 5 (one currency, two fidelities):** this
+is NOT a different currency from exploration's lookahead VOI — both are **Δ log-evidence**
+(`Δlog P(g) + Δlog P(data|g)`). `net_voc` scores the **prior-only term**, dropping the likelihood term —
+not because it is zero (abbreviating reweights the mixture) but because the prior-only signature (no
+belief, no re-conditioning) cannot afford to measure it (Russell–Wefald). So `net_voc` is the
+**cheap-surrogate** fidelity of the one currency `explore_features` computes **exactly** (the general
+instance, both terms); `explore_grammar` is the `Δprior = 0` instance; `net_voc` is the Δℓ-dropped
+instance. The cheap/exact fidelity gap — not a currency gap — is what the two-tier cascade orders
+(`docs/exploration-budget/move-5-design.md`). At `compute_cost = 0` the gate `net_voc > 0`
 is exactly `propose_nonterminal`'s `net_payoff > 0`. Governs the COMPRESSION class — `:add_rule`
 (payoff = compression saving), `:remove_rule` (payoff = the dead rule's reclaimed cost,
 `1 + expr_complexity(body)`), AND `:remove_feature` (#174; payoff = 1, a dead feature's reclaimed symbol).


### PR DESCRIPTION
## Move 5 — the exploration-budget capstone

The arc's final move: attempt the combined single-currency `argmax` over the whole meta-action space, and close-or-name the headline (master plan §4 + Q5). **The attempt closes the currency question and names the fidelity frontier** — a sharper result than §4's original framing, ratified in conversation (OQ-5.1).

### The finding (refines master-plan §4/Q5)

§4 originally read the wall as *"two currencies — compression in prior nats, exploration in utility — that can't merge."* The attempt finds that imprecise on both labels:

- **It's one currency: Δ log-evidence** (`Δlog P(g) + Δlog P(data|g)`). The proof is already in the code — `explore_features` computes `net_value((baseline − mll) + complexity_logprior(Δc; λ=log2), cc)`, **summing prior nats and predictive nats in one `net_value`**. A unit mismatch would make that `+` incoherent; it isn't.
- **The three meta-action classes are three fidelities of that one currency**, not two currencies:
  - `explore_features` = exact, **general** instance (both terms, re-conditioned)
  - `explore_grammar` = exact, **Δprior=0** instance (a finer threshold adds no symbol)
  - `net_voc` (compression) = the cheap **prior-only surrogate** — likelihood term *dropped*, not because it's zero but because the depth-one prior-only signature can't afford to re-condition (Russell–Wefald; the docstring already called it a "value-proxy").
- **"Utility" also mislabels exploration**: `Δℓ` is predictive/log-evidence, not realised ΔEU.

**The "don't flatten" conclusion stands**, but for a sharper reason: ranking compression in the *same exact* `argmax` forces measuring its likelihood term (re-conditioning it), making the cheap screen as expensive as the lookahead. So the invariant is the **compute-tier cascade** (cheap surrogate screen → expensive exact lookahead, ordered by the Move-2 saturation gate) — itself EU-max via Russell–Wefald on the cost of evaluation — **not** a currency incommensurability.

Two frontiers, cleanly named: (a) the surrogate/exact **fidelity cascade** is the permanent structure; (b) the genuine **log-evidence → realised ΔEU** conversion (needs decision-lookahead) is a separate standing frontier, shared equally by both classes so it doesn't separate them.

### What's in this PR

- **`docs/exploration-budget/move-5-design.md`** (new) — the design doc: the genuine attempt, the worked three-class trace through the one functional, and the OQs (ratified in §0).
- **`master-plan.md`** §4 + Q5 + status — refined to "one currency, two fidelities"; the dominance gate named as deferred.
- **Two docstring precision notes** (`net_voc`, `explore_features`) — naming the surrogate/exact instances. **No behaviour change**; no `net_evidence_voc` merge (rejected — would blur the §2 prior/belief seam).

### Outstanding (named, deferred — OQ-5.3)

Of the thesis's three empirical gates: **discovery** (§3.1) and **graceful degradation** (§3.3) are unit-validated; **dominance** (§3.2 — beat random + fixed-schedule baselines) has no comparative benchmark. Deferred to a paper-gated task and named in the master-plan status.

### Verification

- `src/` change is **docstring-only** (`git diff` confirmed) — no executable line moves, no behaviour change.
- Arc suite green: `test_voc_gate`, `test_feature_discovery`, `test_threshold_explore`, `test_grid_world_meta`, `test_compression_removal`, `test_saturation`.
- Full `test/test_*.jl` suite green (52 files); lint corpus self-test intact + `check apps/` 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
