### PR TITLE
Gather VOI: engine grow pricing + structure-BMA g + the /decide grow lane (ask-as-connection)

### DIFF
--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -28,6 +28,9 @@ module AnswerBrain
 using Main.Credence: CategoricalMeasure, Finite, Kernel, PushOnly, condition, weights,
                      Tabular, Functional
 import Main.Credence.Ontology: optimise, value, net_voi
+# Gather VOI is engine stdlib (src/gather_voi.jl — upstreamed); imported so the app
+# surface (exports below) stays stable for the daemon/tests.
+import Main.Credence: grow_value, best_grow
 
 export Obs, ChannelParams, CANONICAL_CHANNEL,
        candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather,
@@ -177,40 +180,6 @@ function terminal_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
                          cp::ChannelParams = CANONICAL_CHANNEL)
     act, eu = _decide(state, k, u_bar, cp)
     (_action_name(act, k), eu)
-end
-
-"""
-    grow_value(g, u_correct, eu, cost) -> Float64
-
-The gather VOI of one grow (recall/discovery) actuator — the ruling's "B half"
-(life-agent `docs/ask-as-connection.md` §4, §7). A grow move may enlarge the candidate set K to admit
-a missing truth; `g = P(recover the answer | sensors)` is the engine's structure-BMA belief at the
-sensor context. The value is the gain from converting the current terminal outcome (EU `eu`, from
-`decide_full` — untouched) into a correct report (`u_correct`), realised with probability `g`, net of
-`cost`. The missing-mass **self-gates through `eu`**: a confident report has `eu ≈ u_correct` ⇒ prices
-`≈ −cost` (don't grow a solved question); a withhold has low `eu` ⇒ a large gain. There is no `p_none`
-branch — `p_none`/entropy are features of the sensor context that shape `g`. Optimistic in the
-post-recovery value (a bound; `g` carries the realism — autonomous-recall Open-Q1).
-"""
-grow_value(g::Float64, u_correct::Float64, eu::Float64, cost::Float64)::Float64 =
-    g * (u_correct - eu) - cost
-
-"""
-    best_grow(actuators, u_correct, eu) -> (probe::Union{String,Nothing}, value::Float64)
-
-The which-gather argmax over grow actuators — the ruling's "B half" discriminating (e.g.) re-extract
-vs retrieve-wider. Each actuator is `(probe::String, g::Float64, cost::Float64)`; the winner is the
-`grow_value` argmax, returned iff it strictly clears 0 (mirrors the `:voi` `net_voi > 0` gate). None
-clears ⇒ `(nothing, 0.0)` — no grow, the terminal decision stands.
-"""
-function best_grow(actuators, u_correct::Float64, eu::Float64)
-    best = nothing
-    best_v = 0.0
-    for (probe, g, cost) in actuators
-        v = grow_value(Float64(g), u_correct, eu, Float64(cost))
-        v > best_v && (best_v = v; best = String(probe))
-    end
-    (best, best_v)
 end
 
 """

--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -30,7 +30,8 @@ using Main.Credence: CategoricalMeasure, Finite, Kernel, PushOnly, condition, we
 import Main.Credence.Ontology: optimise, value, net_voi
 
 export Obs, ChannelParams, CANONICAL_CHANNEL,
-       candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather, grow_value,
+       candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather,
+       grow_value, best_grow,
        provisional_leader, gather_decide,
        Transform, ScheduleCtx, default_registry, registry_from_wire, schedule_decide
 
@@ -193,6 +194,24 @@ post-recovery value (a bound; `g` carries the realism — autonomous-recall Open
 """
 grow_value(g::Float64, u_correct::Float64, eu::Float64, cost::Float64)::Float64 =
     g * (u_correct - eu) - cost
+
+"""
+    best_grow(actuators, u_correct, eu) -> (probe::Union{String,Nothing}, value::Float64)
+
+The which-gather argmax over grow actuators — the ruling's "B half" discriminating (e.g.) re-extract
+vs retrieve-wider. Each actuator is `(probe::String, g::Float64, cost::Float64)`; the winner is the
+`grow_value` argmax, returned iff it strictly clears 0 (mirrors the `:voi` `net_voi > 0` gate). None
+clears ⇒ `(nothing, 0.0)` — no grow, the terminal decision stands.
+"""
+function best_grow(actuators, u_correct::Float64, eu::Float64)
+    best = nothing
+    best_v = 0.0
+    for (probe, g, cost) in actuators
+        v = grow_value(Float64(g), u_correct, eu, Float64(cost))
+        v > best_v && (best_v = v; best = String(probe))
+    end
+    (best, best_v)
+end
 
 """
     decide_full(state, k, u_bar; cp=CANONICAL_CHANNEL)

--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -30,7 +30,7 @@ using Main.Credence: CategoricalMeasure, Finite, Kernel, PushOnly, condition, we
 import Main.Credence.Ontology: optimise, value, net_voi
 
 export Obs, ChannelParams, CANONICAL_CHANNEL,
-       candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather,
+       candidate_posterior, terminal_decide, decide_full, decision_fpa, voi_gather, grow_value,
        provisional_leader, gather_decide,
        Transform, ScheduleCtx, default_registry, registry_from_wire, schedule_decide
 
@@ -177,6 +177,22 @@ function terminal_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
     act, eu = _decide(state, k, u_bar, cp)
     (_action_name(act, k), eu)
 end
+
+"""
+    grow_value(g, u_correct, eu, cost) -> Float64
+
+The gather VOI of one grow (recall/discovery) actuator — the ruling's "B half"
+(life-agent `docs/ask-as-connection.md` §4, §7). A grow move may enlarge the candidate set K to admit
+a missing truth; `g = P(recover the answer | sensors)` is the engine's structure-BMA belief at the
+sensor context. The value is the gain from converting the current terminal outcome (EU `eu`, from
+`decide_full` — untouched) into a correct report (`u_correct`), realised with probability `g`, net of
+`cost`. The missing-mass **self-gates through `eu`**: a confident report has `eu ≈ u_correct` ⇒ prices
+`≈ −cost` (don't grow a solved question); a withhold has low `eu` ⇒ a large gain. There is no `p_none`
+branch — `p_none`/entropy are features of the sensor context that shape `g`. Optimistic in the
+post-recovery value (a bound; `g` carries the realism — autonomous-recall Open-Q1).
+"""
+grow_value(g::Float64, u_correct::Float64, eu::Float64, cost::Float64)::Float64 =
+    g * (u_correct - eu) - cost
 
 """
     decide_full(state, k, u_bar; cp=CANONICAL_CHANNEL)

--- a/apps/answer-brain/brain/answer_brain.jl
+++ b/apps/answer-brain/brain/answer_brain.jl
@@ -254,8 +254,13 @@ end
 #   :guard — mandatory non-VOI refine. Defends an OUT-OF-MODEL risk the candidate belief cannot price
 #            (the belief has no atom for "misattributed to the owner"), so VOI over it is blind and
 #            the guard must fire unconditionally. (recency-on-era_split; the owner-scoped corroborate)
-# `:grow` (discovery/recall — enlarges K) cannot be priced by VOI over a closed categorical (Plan §1);
-# it is a non-VOI action the BODY triggers (a bridge capability + re-decide), never a registry probe.
+# `:grow` (discovery/recall — enlarges K) cannot be priced by `net_voi` over the closed categorical
+# (Plan §1) — but it IS priced (the conferred gather half, life-agent docs/ask-as-connection.md §4/§7):
+# by the engine's gather VOI (`grow_value`/`best_grow`/`recovery_g`, src/gather_voi.jl) against a
+# SEPARATE structure-BMA recovery belief `g = P(recover | sensors)`. Grow actuators ride their own
+# `grows` lane in `schedule_decide` (per-actuator `(probe, g, cost)` — no kernel over the candidate
+# space, so not a registry `Transform`), self-gating on the terminal EU. The body enacts; the agent
+# decides.
 struct Transform
     name::String        # registry id (unique within a registry)
     probe::String       # emitted wire-probe name (the body's capability; the `applied_probes` dedup key)
@@ -344,19 +349,23 @@ function registry_from_wire(descriptors; cp::ChannelParams = CANONICAL_CHANNEL):
 end
 
 """
-    schedule(state, k, u_bar, registry, ctx; cp=CANONICAL_CHANNEL)
+    schedule(state, k, u_bar, registry, ctx; cp=CANONICAL_CHANNEL, grows=[])
         -> (effector, report_index, probe, target, eu)
 
-The uniform VOI scheduler. Decide terminally once, then over the registry: every eligible, unapplied
-**guard** fires first (mandatory, registry order — it defends a risk the belief can't price); then
-every eligible, unapplied **:voi** transform is priced by `net_voi` and the argmax is gathered iff it
-clears its cost. None fire ⇒ the terminal decision stands. `applied_probes` (keyed on the emitted
-`probe`, body-held and resent) makes each probe fire at most once ⇒ the loop terminates. Parity: an
-empty / fully-applied registry returns exactly `decide_full`'s terminal tuple.
+The uniform VOI scheduler. Decide terminally once, then: every eligible, unapplied **guard** fires
+first (mandatory, registry order — it defends a risk the belief can't price); then the eligible,
+unapplied **:voi** transforms are priced by `net_voi` and the **grow** actuators by `grow_value`
+(the engine gather VOI — `g` per actuator, already read from the gather structure-BMA), and the
+overall argmax is gathered iff it clears 0. None fire ⇒ the terminal decision stands.
+`applied_probes` (keyed on the emitted `probe`, body-held and resent) makes each probe — registry
+and grow alike — fire at most once ⇒ the loop terminates. Parity: an empty / fully-applied registry
+with no `grows` returns exactly `decide_full`'s terminal tuple. Grow self-gates on the terminal EU
+(`grow_value(g, u_correct, eu, cost)`): a confident report prices ≈ −cost, so no `p_none` branch.
 """
 function schedule_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict,
                   registry::Vector{Transform}, ctx::ScheduleCtx;
-                  cp::ChannelParams = CANONICAL_CHANNEL)
+                  cp::ChannelParams = CANONICAL_CHANNEL,
+                  grows::AbstractVector = Tuple{String, Float64, Float64}[])
     action, report_index, eu = decide_full(state, k, u_bar; cp = cp)
     leader() = provisional_leader(state, k, u_bar; cp = cp)
     # Guards first: mandatory, registry order. A guard prices an out-of-model risk VOI is blind to.
@@ -365,7 +374,7 @@ function schedule_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict,
         t.probe in ctx.applied_probes && continue
         t.applies(action, ctx) && return ("gather", nothing, t.probe, leader(), eu)
     end
-    # :voi transforms: price each eligible, unapplied one; gather the argmax if its net_voi > 0.
+    # :voi transforms: price each eligible, unapplied one; keep the net_voi argmax if > 0.
     best = nothing; best_nv = 0.0
     for t in registry
         t.kind === :voi || continue
@@ -373,6 +382,12 @@ function schedule_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict,
         t.applies(action, ctx) || continue
         nv = voi_gather(state, k, u_bar, t.kernel_fn(k, cp), collect(Float64, 0:(k - 1)), t.cost; cp = cp)
         nv > best_nv && (best_nv = nv; best = t)
+    end
+    # Grow actuators: the engine gather VOI over the unapplied ones; one EU comparison vs :voi.
+    unapplied = [(p, g, c) for (p, g, c) in grows if !(String(p) in ctx.applied_probes)]
+    grow_probe, grow_v = best_grow(unapplied, Float64(u_bar["u_correct"]), eu)
+    if grow_probe !== nothing && grow_v > best_nv
+        return ("gather", nothing, grow_probe, leader(), eu)
     end
     best === nothing && return (action, report_index, nothing, nothing, eu)
     ("gather", nothing, best.probe, leader(), eu)
@@ -393,11 +408,12 @@ function gather_decide(state::CategoricalMeasure, k::Int, u_bar::AbstractDict;
                        gather_rho::Float64 = 0.0,
                        gather_cost::Float64 = 0.0,
                        applied_probes::AbstractVector{<:AbstractString} = String[],
-                       cp::ChannelParams = CANONICAL_CHANNEL)
+                       cp::ChannelParams = CANONICAL_CHANNEL,
+                       grows::AbstractVector = Tuple{String, Float64, Float64}[])
     reg = default_registry(; gather_rho = gather_rho, gather_cost = gather_cost)
     ctx = ScheduleCtx(era_split, owner_scoped, gather_rho, gather_cost,
                       collect(String, applied_probes))
-    schedule_decide(state, k, u_bar, reg, ctx; cp = cp)
+    schedule_decide(state, k, u_bar, reg, ctx; cp = cp, grows = grows)
 end
 
 end # module AnswerBrain

--- a/apps/answer-brain/daemon/server.jl
+++ b/apps/answer-brain/daemon/server.jl
@@ -16,8 +16,18 @@ body to *display* the withheld leader, not to select an action.
 
 Routes:
   POST /decide   {question_id?, observations[], candidates[], rho, u_bar, channel?,
-                  era_split?, owner_scoped?, applied_probes?}
-             →   {effector, report_index, value, probe, target, credences[], p_none, eu}
+                  era_split?, owner_scoped?, applied_probes?, transforms?,
+                  sensors?, grow?}
+             →   {effector, report_index, value, probe, target, credences[], p_none, eu,
+                  grow_g?}
+
+The grow lane (slice 5): `sensors` is the body's bucketed feature dict; `grow` carries the shared
+feature vocabulary (`features: {names, values}`) and per-actuator descriptors
+(`actuators: [{probe, cost, alpha0?, beta0?, warm_counts?}]`). The daemon rebuilds each actuator's
+outcome belief from the body-persisted `warm_counts` (exact — order-independence), reads the learned
+`g = recovery_g(model, top, sensors)` (cold ⇒ the declared Beta prior mean), and the scheduler
+prices the grow argmax against the :voi argmax, self-gating on the terminal EU. `grow_g` echoes the
+per-actuator g for the body's gather-outcome log.
   GET  /manifest → {effectors:[{name,parameters:[{name,type}]}], features:[{name,spaceName}]}
   GET  /ready    → "ok"
 
@@ -36,7 +46,8 @@ module Server
 
 using Main.AnswerBrain: Obs, ChannelParams, CANONICAL_CHANNEL, candidate_posterior, gather_decide,
                         ScheduleCtx, registry_from_wire, schedule_decide
-using Main.Credence: weights
+using Main.Credence: weights, build_structure_model, reconstruct_structure_prior_from_data,
+                     recovery_g
 using HTTP
 using JSON3
 
@@ -102,23 +113,52 @@ function decide_response(req::AbstractDict)::Dict{String, Any}
     gather_cost = Float64(get(req, "gather_cost", 0.0))  # … and its cost (utility units) — 0 ⇒ off
     applied = String[String(p) for p in get(req, "applied_probes", String[])]
 
+    # The grow lane (slice 5): bucketed `sensors` + a `grow` block — a shared feature vocabulary
+    # and per-actuator {probe, cost, alpha0?, beta0?, warm_counts?}. The stateless daemon rebuilds
+    # each actuator's outcome belief from the body-persisted counts (warm reconstruction is exact —
+    # order-independence) and reads the learned `g = recovery_g(model, top, sensors)`; a cold
+    # actuator's g is its declared Beta(alpha0, beta0) prior mean (the demoted hand-set g-prior).
+    grows = Tuple{String, Float64, Float64}[]
+    grow_g = Dict{String, Float64}()
+    if haskey(req, "grow")
+        haskey(req, "sensors") || error("`grow` requires `sensors` (the bucketed feature dict)")
+        gr = req["grow"]
+        feats = gr["features"]
+        names = String[String(n) for n in feats["names"]]
+        values = Vector{String}[String[String(v) for v in vs] for vs in feats["values"]]
+        sensors = Dict{String, String}(String(kk) => String(vv) for (kk, vv) in req["sensors"])
+        for a in gr["actuators"]
+            aprobe = String(a["probe"])
+            acost = Float64(get(a, "cost", 0.0))
+            alpha0 = Float64(get(a, "alpha0", 2.0))
+            beta0 = Float64(get(a, "beta0", 2.0))
+            model = build_structure_model(names, values; alpha0 = alpha0, beta0 = beta0)
+            wc = get(a, "warm_counts", nothing)
+            top = reconstruct_structure_prior_from_data(model, wc)
+            g = recovery_g(model, top, sensors)
+            push!(grows, (aprobe, g, acost))
+            grow_g[aprobe] = g
+        end
+    end
+
     post = candidate_posterior(k, obs, rho; cp = cp)
     w = weights(post)                                  # length k+1: candidates then NONE
     # The menu is data: when the body declares a `transforms` list (Slice 2 — e.g. the corroborate
     # model-tier ladder), build the registry from it and run the uniform scheduler; absent ⇒ the
-    # default registry built from the flags (byte-identical to the Stage-2a path).
+    # default registry built from the flags (byte-identical to the Stage-2a path). The grows lane
+    # rides both paths.
     effector, report_index, probe, target, eu =
         if haskey(req, "transforms")
             reg = registry_from_wire(req["transforms"]; cp = cp)
             ctx = ScheduleCtx(era_split, owner_scoped, gather_rho, gather_cost, applied)
-            schedule_decide(post, k, u_bar, reg, ctx; cp = cp)
+            schedule_decide(post, k, u_bar, reg, ctx; cp = cp, grows = grows)
         else
             gather_decide(post, k, u_bar; era_split = era_split, owner_scoped = owner_scoped,
                           gather_rho = gather_rho, gather_cost = gather_cost,
-                          applied_probes = applied, cp = cp)
+                          applied_probes = applied, cp = cp, grows = grows)
         end
 
-    Dict{String, Any}(
+    resp = Dict{String, Any}(
         "effector"     => effector,                    # report | hedge | ask_clarify | abstain | gather
         "report_index" => report_index,                # 0-based candidate idx (report), or nothing → null
         "value"        => report_index === nothing ? nothing : candidates[report_index + 1],
@@ -128,6 +168,10 @@ function decide_response(req::AbstractDict)::Dict{String, Any}
         "p_none"       => w[k + 1],
         "eu"           => eu,
     )
+    # Per-actuator g, exposed only when the body sent a grow block — for the body's
+    # gather-outcome log (Invariant 1: display/logging, never selection — the daemon already chose).
+    haskey(req, "grow") && (resp["grow_g"] = grow_g)
+    resp
 end
 
 # ── HTTP transport (adapted from apps/credence-pi/daemon/server.jl) ──────────────────────

--- a/apps/answer-brain/tests/julia/test_grow.jl
+++ b/apps/answer-brain/tests/julia/test_grow.jl
@@ -57,5 +57,23 @@ let u_c = 1.0, cost = 0.1
           approx(AnswerBrain.grow_value(0.5, 1.0, 0.0, 0.1), 0.5 * 1.0 - 0.1))
 end
 
+# ── Slice 2: best_grow — the which-gather argmax (fires only if the best clears 0) ─────────
+let u_c = 1.0, eu = -0.2
+    # Two actuators, different g at the same context ⇒ pick the higher-value one
+    # (this is B discriminating re-extract vs retrieve-wider — the ruling's raison d'être).
+    acts = [("re-extract", 0.7, 0.1), ("retrieve-wider", 0.4, 0.1)]
+    best, bv = AnswerBrain.best_grow(acts, u_c, eu)
+    check("best_grow picks the higher-value actuator", best == "re-extract")
+    check("best_grow value matches grow_value",
+          approx(bv, AnswerBrain.grow_value(0.7, u_c, eu, 0.1)))
+    # Cost can flip the choice: a cheaper, lower-g actuator can win.
+    acts2 = [("re-extract", 0.55, 0.5), ("retrieve-wider", 0.5, 0.05)]
+    best2, _ = AnswerBrain.best_grow(acts2, u_c, eu)
+    check("best_grow accounts for cost (the cheaper actuator wins)", best2 == "retrieve-wider")
+    # A solved question (eu ≈ u_correct) ⇒ nothing clears 0 ⇒ no grow.
+    best3, bv3 = AnswerBrain.best_grow(acts, u_c, u_c)
+    check("best_grow returns nothing when nothing clears cost", best3 === nothing && bv3 == 0.0)
+end
+
 println("-"^64)
-println("grow slice-1 (grow_value): ", length(PASSED), " checks passed")
+println("grow slices 1-2 (grow_value, best_grow): ", length(PASSED), " checks passed")

--- a/apps/answer-brain/tests/julia/test_grow.jl
+++ b/apps/answer-brain/tests/julia/test_grow.jl
@@ -49,5 +49,72 @@ let u_c = 1.0, eu = -0.2
           best == "re-extract" && approx(bv, AnswerBrain.grow_value(0.7, u_c, eu, 0.1)))
 end
 
+# ── Slice 4: the scheduler's third stanza — grow actuators on the priced menu ───────────
+# `schedule_decide`/`gather_decide` gain `grows` (per-actuator `(probe, g, cost)`, g already
+# read from the gather structure-BMA): guards fire first; then the grow argmax competes with
+# the :voi argmax in one EU comparison; `applied_probes` retires grow probes (termination).
+# Parity: `grows` empty ⇒ byte-identical to today.
+const UBAR = Dict("u_correct" => 1.0, "u_wrong" => -4.0, "u_hedged" => -0.5,
+                  "u_abstain" => 0.0, "lambda_int" => 1.0)
+
+# A dispersed (withholding) and a heavily-corroborated (confident-report) posterior.
+dispersed = candidate_posterior(2, Obs[Obs(0, 0, 0.9, 1.0, 1.0), Obs(1, 1, 0.9, 1.0, 1.0)], 0.7)
+confident = candidate_posterior(2, Obs[Obs(0, i, 0.95, 1.0, 1.0) for i in 0:4], 0.7)
+
+let (a_d, _, eu_d) = decide_full(dispersed, 2, UBAR),
+    (a_c, _, eu_c) = decide_full(confident, 2, UBAR)
+    check("precondition: dispersed withholds, confident reports above eu 0.6",
+          a_d != "report" && a_c == "report" && eu_c > 0.6 && eu_d < 0.4;
+          detail = "got a_d=$a_d a_c=$a_c eu_c=$eu_c eu_d=$eu_d")
+
+    grows = [("re-extract", 0.5, 0.2)]
+
+    # Parity: no grows ⇒ the terminal tuple exactly (dispersed, no registry flags).
+    let (eff, idx, probe, tgt, eu) = gather_decide(dispersed, 2, UBAR)
+        (eff2, idx2, probe2, tgt2, eu2) = gather_decide(dispersed, 2, UBAR; grows = Tuple{String,Float64,Float64}[])
+        check("grows=[] is parity-exact with today's call",
+              (eff, idx, probe, tgt, eu) == (eff2, idx2, probe2, tgt2, eu2))
+    end
+
+    # A withhold with a clearing grow ⇒ gather(probe), targeting the provisional leader.
+    let (eff, idx, probe, tgt, _) = gather_decide(dispersed, 2, UBAR; grows = grows)
+        check("withhold + clearing grow ⇒ gather(re-extract) at the leader",
+              eff == "gather" && probe == "re-extract" && idx === nothing &&
+              tgt == provisional_leader(dispersed, 2, UBAR);
+              detail = "got eff=$eff probe=$probe tgt=$tgt")
+    end
+
+    # Self-gating: the same grow at a confident report prices negative ⇒ the report stands.
+    let (eff, idx, _, _, _) = gather_decide(confident, 2, UBAR; grows = grows)
+        check("confident report + same grow ⇒ terminal stands (self-gating, no p_none branch)",
+              eff == "report" && idx == 0; detail = "got eff=$eff idx=$idx")
+    end
+
+    # Which-gather: the higher-value actuator's probe is returned.
+    let two = [("re-extract", 0.3, 0.05), ("retrieve-wider", 0.7, 0.05)]
+        (eff, _, probe, _, _) = gather_decide(dispersed, 2, UBAR; grows = two)
+        check("which-gather argmax through the scheduler", eff == "gather" && probe == "retrieve-wider";
+              detail = "got eff=$eff probe=$probe")
+    end
+
+    # applied_probes retires a grow probe (termination); the remaining one still prices.
+    let two = [("re-extract", 0.7, 0.05), ("retrieve-wider", 0.5, 0.05)]
+        (eff, _, probe, _, _) = gather_decide(dispersed, 2, UBAR; grows = two,
+                                              applied_probes = ["re-extract"])
+        check("an applied grow probe is retired; the next prices",
+              eff == "gather" && probe == "retrieve-wider"; detail = "got eff=$eff probe=$probe")
+        (eff2, _, _, _, _) = gather_decide(dispersed, 2, UBAR; grows = two,
+                                           applied_probes = ["re-extract", "retrieve-wider"])
+        check("all grow probes applied ⇒ terminal stands (terminates)", eff2 != "gather";
+              detail = "got $eff2")
+    end
+
+    # Guards keep precedence: era_split fires recency BEFORE any grow.
+    let (eff, _, probe, _, _) = gather_decide(dispersed, 2, UBAR; era_split = true, grows = grows)
+        check("guards precede grow (recency first on era_split)",
+              eff == "gather" && probe == "recency"; detail = "got eff=$eff probe=$probe")
+    end
+end
+
 println("-"^64)
 println("grow integration: ", length(PASSED), " checks passed")

--- a/apps/answer-brain/tests/julia/test_grow.jl
+++ b/apps/answer-brain/tests/julia/test_grow.jl
@@ -1,0 +1,61 @@
+#!/usr/bin/env julia
+# Role: tests
+"""
+    test_grow.jl — the gather VOI (the ruling's "B half"): grow actuators priced by a
+    structure-BMA `g_mechanism`, argmaxed for which-gather, self-gating on the terminal EU.
+
+The conferred factoring (life-agent `docs/ask-as-connection.md` §4, §7): report/abstain stays the
+exact terminal threshold (`terminal_decide`, untouched); only the *gather* decision is offloaded. A
+grow actuator's value is `grow_value(g, u_correct, eu, cost) = g·(u_correct − eu) − cost`, where
+`g = P(recover | sensors)` is the engine's structure-BMA belief and `eu` is the terminal EU — so the
+missing-mass gate is carried by `u_correct − eu` (a confident report prices ≈ −cost), not a `p_none`
+branch. `terminal_decide` is never touched.
+
+Run from the credence repo root:
+    julia --project=. apps/answer-brain/tests/julia/test_grow.jl
+"""
+
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "..", "..", "..", "src"))
+using Credence
+
+include(joinpath(@__DIR__, "..", "..", "brain", "answer_brain.jl"))
+using .AnswerBrain
+
+const PASSED = String[]
+function check(name::AbstractString, cond::Bool; detail::AbstractString = "")
+    if cond
+        push!(PASSED, name); println("PASSED: ", name)
+    else
+        println("FAILED: ", name, " — ", detail); error("assertion failed: $name")
+    end
+end
+approx(a, b; atol = 1e-9) = abs(a - b) <= atol
+
+println("="^64)
+println("answer-brain grow — the gather VOI (B half)")
+println("="^64)
+
+# ── Slice 1: grow_value — the pure pricing, self-gating on the terminal EU ────────────────
+# grow_value(g, u_correct, eu, cost) = g·(u_correct − eu) − cost
+let u_c = 1.0, cost = 0.1
+    # A confident terminal report (eu ≈ u_correct) has ~zero gain ⇒ net = −cost ⇒ no grow.
+    check("grow_value self-gates at a confident report",
+          approx(AnswerBrain.grow_value(0.9, u_c, u_c, cost), -cost))
+    # A withhold (low eu) with high g clears cost ⇒ positive (grow is worth it).
+    check("grow_value is positive for a high-g withhold",
+          AnswerBrain.grow_value(0.8, u_c, -0.2, cost) > 0.0)
+    # Monotone increasing in g (more likely to recover ⇒ more valuable).
+    check("grow_value is monotone in g",
+          AnswerBrain.grow_value(0.6, u_c, -0.2, cost) >
+          AnswerBrain.grow_value(0.3, u_c, -0.2, cost))
+    # The gain shrinks as the terminal EU rises toward u_correct (less to gain by growing).
+    check("grow_value decreases as terminal EU rises",
+          AnswerBrain.grow_value(0.7, u_c, 0.8, cost) <
+          AnswerBrain.grow_value(0.7, u_c, -0.2, cost))
+    # Cost enters linearly (exact).
+    check("grow_value subtracts cost exactly",
+          approx(AnswerBrain.grow_value(0.5, 1.0, 0.0, 0.1), 0.5 * 1.0 - 0.1))
+end
+
+println("-"^64)
+println("grow slice-1 (grow_value): ", length(PASSED), " checks passed")

--- a/apps/answer-brain/tests/julia/test_grow.jl
+++ b/apps/answer-brain/tests/julia/test_grow.jl
@@ -1,15 +1,12 @@
 #!/usr/bin/env julia
 # Role: tests
 """
-    test_grow.jl — the gather VOI (the ruling's "B half"): grow actuators priced by a
-    structure-BMA `g_mechanism`, argmaxed for which-gather, self-gating on the terminal EU.
+    test_grow.jl — app-side integration checks for the gather VOI (the ruling's "B half").
 
-The conferred factoring (life-agent `docs/ask-as-connection.md` §4, §7): report/abstain stays the
-exact terminal threshold (`terminal_decide`, untouched); only the *gather* decision is offloaded. A
-grow actuator's value is `grow_value(g, u_correct, eu, cost) = g·(u_correct − eu) − cost`, where
-`g = P(recover | sensors)` is the engine's structure-BMA belief and `eu` is the terminal EU — so the
-missing-mass gate is carried by `u_correct − eu` (a confident report prices ≈ −cost), not a `p_none`
-branch. `terminal_decide` is never touched.
+The pricing (`grow_value`) and the which-gather argmax (`best_grow`) are ENGINE stdlib
+(`src/gather_voi.jl`, behaviour pinned by `test/test_gather_voi.jl`); the app imports and
+re-exports them. These checks pin only the integration: the app surface IS the engine
+function (no shadowing fork), and one behavioural smoke each through the app name.
 
 Run from the credence repo root:
     julia --project=. apps/answer-brain/tests/julia/test_grow.jl
@@ -32,48 +29,25 @@ end
 approx(a, b; atol = 1e-9) = abs(a - b) <= atol
 
 println("="^64)
-println("answer-brain grow — the gather VOI (B half)")
+println("answer-brain grow — engine gather-VOI integration")
 println("="^64)
 
-# ── Slice 1: grow_value — the pure pricing, self-gating on the terminal EU ────────────────
-# grow_value(g, u_correct, eu, cost) = g·(u_correct − eu) − cost
-let u_c = 1.0, cost = 0.1
-    # A confident terminal report (eu ≈ u_correct) has ~zero gain ⇒ net = −cost ⇒ no grow.
-    check("grow_value self-gates at a confident report",
-          approx(AnswerBrain.grow_value(0.9, u_c, u_c, cost), -cost))
-    # A withhold (low eu) with high g clears cost ⇒ positive (grow is worth it).
-    check("grow_value is positive for a high-g withhold",
-          AnswerBrain.grow_value(0.8, u_c, -0.2, cost) > 0.0)
-    # Monotone increasing in g (more likely to recover ⇒ more valuable).
-    check("grow_value is monotone in g",
-          AnswerBrain.grow_value(0.6, u_c, -0.2, cost) >
-          AnswerBrain.grow_value(0.3, u_c, -0.2, cost))
-    # The gain shrinks as the terminal EU rises toward u_correct (less to gain by growing).
-    check("grow_value decreases as terminal EU rises",
-          AnswerBrain.grow_value(0.7, u_c, 0.8, cost) <
-          AnswerBrain.grow_value(0.7, u_c, -0.2, cost))
-    # Cost enters linearly (exact).
-    check("grow_value subtracts cost exactly",
-          approx(AnswerBrain.grow_value(0.5, 1.0, 0.0, 0.1), 0.5 * 1.0 - 0.1))
-end
+# The app surface is the engine function, not a fork.
+check("AnswerBrain.grow_value === Credence.grow_value",
+      AnswerBrain.grow_value === Credence.grow_value)
+check("AnswerBrain.best_grow === Credence.best_grow",
+      AnswerBrain.best_grow === Credence.best_grow)
 
-# ── Slice 2: best_grow — the which-gather argmax (fires only if the best clears 0) ─────────
+# One behavioural smoke each through the app name (self-gating + which-gather).
+let u_c = 1.0, cost = 0.1
+    check("grow_value self-gates at a confident report (≈ −cost)",
+          approx(AnswerBrain.grow_value(0.9, u_c, u_c, cost), -cost))
+end
 let u_c = 1.0, eu = -0.2
-    # Two actuators, different g at the same context ⇒ pick the higher-value one
-    # (this is B discriminating re-extract vs retrieve-wider — the ruling's raison d'être).
-    acts = [("re-extract", 0.7, 0.1), ("retrieve-wider", 0.4, 0.1)]
-    best, bv = AnswerBrain.best_grow(acts, u_c, eu)
-    check("best_grow picks the higher-value actuator", best == "re-extract")
-    check("best_grow value matches grow_value",
-          approx(bv, AnswerBrain.grow_value(0.7, u_c, eu, 0.1)))
-    # Cost can flip the choice: a cheaper, lower-g actuator can win.
-    acts2 = [("re-extract", 0.55, 0.5), ("retrieve-wider", 0.5, 0.05)]
-    best2, _ = AnswerBrain.best_grow(acts2, u_c, eu)
-    check("best_grow accounts for cost (the cheaper actuator wins)", best2 == "retrieve-wider")
-    # A solved question (eu ≈ u_correct) ⇒ nothing clears 0 ⇒ no grow.
-    best3, bv3 = AnswerBrain.best_grow(acts, u_c, u_c)
-    check("best_grow returns nothing when nothing clears cost", best3 === nothing && bv3 == 0.0)
+    best, bv = AnswerBrain.best_grow([("re-extract", 0.7, 0.1), ("retrieve-wider", 0.4, 0.1)], u_c, eu)
+    check("best_grow discriminates which-gather through the app surface",
+          best == "re-extract" && approx(bv, AnswerBrain.grow_value(0.7, u_c, eu, 0.1)))
 end
 
 println("-"^64)
-println("grow slices 1-2 (grow_value, best_grow): ", length(PASSED), " checks passed")
+println("grow integration: ", length(PASSED), " checks passed")

--- a/apps/answer-brain/tests/julia/test_server.jl
+++ b/apps/answer-brain/tests/julia/test_server.jl
@@ -307,6 +307,27 @@ let r = Server.decide_response(gather_request(; era_split = false))
           !haskey(r, "grow_g"))
 end
 
+# Live-HTTP grow round-trip: the nested grow block (actuators + warm_counts.contexts) must
+# survive JSON3-over-the-socket coercion, not just plain-Dict handler calls (review note on
+# #182 — the other wire shapes are proven above; this pins the new nested ones).
+let port = 8792
+    server = start_daemon(; port = port, host = "127.0.0.1")
+    try
+        http = HTTP.post("http://127.0.0.1:$port/decide",
+                         ["Content-Type" => "application/json"],
+                         JSON3.write(grow_request("extraction")); retry = false,
+                         readtimeout = 10)
+        resp = JSON3.read(String(http.body))
+        check("HTTP /decide grow: learned counts survive the socket ⇒ gather(re-extract)",
+              http.status == 200 && String(resp.effector) == "gather" &&
+              String(resp.probe) == "re-extract" && haskey(resp, :grow_g);
+              detail = "status=$(http.status) effector=$(get(resp, :effector, "∅")) " *
+                       "probe=$(get(resp, :probe, "∅"))")
+    finally
+        stop_daemon(server)
+    end
+end
+
 println("\n", "="^64)
 println("answer-brain Stage-2a: $(length(PASSED)) checks PASSED · $(length(data.cases)) wire-parity cases")
 println("="^64)

--- a/apps/answer-brain/tests/julia/test_server.jl
+++ b/apps/answer-brain/tests/julia/test_server.jl
@@ -228,6 +228,85 @@ let req = gather_request(; era_split = false)
           detail = "got effector=$(r["effector"]) probe=$(get(r, "probe", "∅"))")
 end
 
+# ── 5. The grow lane over the wire (slice 5): sensors + actuators, g read daemon-side ─────
+# The body ships bucketed `sensors` + a `grow` block (shared feature vocabulary; per-actuator
+# probe/cost, optional Beta g-prior, optional body-persisted `warm_counts`). The STATELESS daemon
+# rebuilds each actuator's outcome belief per call (`reconstruct_structure_prior_from_data`),
+# reads `g = recovery_g(model, top, sensors)`, and prices the `grows` lane in the scheduler.
+const GROW_VOCAB = Dict{String, Any}(
+    "names"  => ["miss", "p_none"],
+    "values" => [["extraction", "retrieval"], ["hi", "lo"]])
+
+# Outcome history: re-extract recovers on extraction-misses and fails on retrieval-misses;
+# retrieve-wider is the mirror image.
+counts(pairs...) = Dict{String, Any}("contexts" => [
+    Dict{String, Any}("ctx" => collect(ctx), "n1" => n1, "n0" => n0) for (ctx, n1, n0) in pairs])
+const RE_COUNTS = counts((("extraction", "hi"), 6, 0), (("retrieval", "hi"), 0, 6))
+const RW_COUNTS = counts((("extraction", "hi"), 0, 6), (("retrieval", "hi"), 6, 0))
+
+function grow_request(miss::String; applied::Vector{String} = String[], confident::Bool = false,
+                      transforms::Union{Nothing, Vector{Any}} = nothing)
+    req = gather_request(; era_split = false, applied = applied)
+    if confident   # five corroborating observations on candidate 0 ⇒ reports well above the bar
+        req["observations"] = [Dict{String, Any}("reports" => 0, "group" => i,
+                               "authority" => 0.95, "subject_factor" => 1.0, "time_factor" => 1.0)
+                               for i in 0:4]
+    end
+    req["sensors"] = Dict{String, Any}("miss" => miss, "p_none" => "hi")
+    req["grow"] = Dict{String, Any}(
+        "features" => GROW_VOCAB,
+        "actuators" => Any[
+            Dict{String, Any}("probe" => "re-extract", "cost" => 0.2, "warm_counts" => RE_COUNTS),
+            Dict{String, Any}("probe" => "retrieve-wider", "cost" => 0.2, "warm_counts" => RW_COUNTS)])
+    transforms === nothing || (req["transforms"] = transforms)
+    req
+end
+
+let r = Server.decide_response(grow_request("extraction"))
+    check("wire grow: extraction-miss sensors ⇒ gather(re-extract) from LEARNED counts",
+          r["effector"] == "gather" && r["probe"] == "re-extract";
+          detail = "got effector=$(r["effector"]) probe=$(get(r, "probe", "∅"))")
+    check("wire grow: per-actuator g exposed for the body's outcome log",
+          haskey(r, "grow_g") && r["grow_g"]["re-extract"] > 0.5 > r["grow_g"]["retrieve-wider"];
+          detail = "grow_g=$(get(r, "grow_g", "∅"))")
+end
+let r = Server.decide_response(grow_request("retrieval"))
+    check("wire grow: retrieval-miss sensors flip the which-gather ⇒ retrieve-wider",
+          r["effector"] == "gather" && r["probe"] == "retrieve-wider";
+          detail = "got effector=$(r["effector"]) probe=$(get(r, "probe", "∅"))")
+end
+let req = grow_request("extraction")   # a hand-set cold prior: Beta(8,2) ⇒ g = 0.8 exactly
+    req["grow"]["actuators"] = Any[Dict{String, Any}("probe" => "semantic", "cost" => 0.2,
+                                                     "alpha0" => 8.0, "beta0" => 2.0)]
+    r = Server.decide_response(req)
+    check("wire grow: a cold actuator's g is its declared Beta prior mean (the demoted g-prior)",
+          approx(r["grow_g"]["semantic"], 0.8) && r["probe"] == "semantic";
+          detail = "grow_g=$(get(r, "grow_g", "∅")) probe=$(get(r, "probe", "∅"))")
+end
+let r = Server.decide_response(grow_request("extraction"; confident = true))
+    check("wire grow: a confident report stands (self-gates through eu, no p_none branch)",
+          r["effector"] == "report"; detail = "got $(r["effector"])")
+end
+let r = Server.decide_response(grow_request("extraction";
+                                            applied = ["re-extract", "retrieve-wider"]))
+    check("wire grow: applied grow probes are retired ⇒ terminal stands (terminates)",
+          r["effector"] != "gather"; detail = "got $(r["effector"])")
+end
+let r = Server.decide_response(grow_request("extraction"; transforms = Any[]))
+    check("wire grow: the grows lane also rides the data-driven `transforms` path",
+          r["effector"] == "gather" && r["probe"] == "re-extract";
+          detail = "got effector=$(r["effector"]) probe=$(get(r, "probe", "∅"))")
+end
+let req = grow_request("extraction")
+    delete!(req, "sensors")
+    check("wire grow: `grow` without `sensors` fails loud (contract, not a silent cold g)",
+          (try Server.decide_response(req); false catch; true end))
+end
+let r = Server.decide_response(gather_request(; era_split = false))
+    check("wire grow: absent grow block ⇒ no grow_g key (backward-compatible response)",
+          !haskey(r, "grow_g"))
+end
+
 println("\n", "="^64)
 println("answer-brain Stage-2a: $(length(PASSED)) checks PASSED · $(length(data.cases)) wire-parity cases")
 println("="^64)

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -60,6 +60,7 @@ export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal, wrap_in_measure
 export ConjugatePrevision, maybe_conjugate, update
 export StructureBMA, build_structure_model, build_structure_prior, build_structure_prior_dense, structure_observe, structure_observe_soft, belief_at_context, context_from_features, structure_firing_tags, structure_decision_kernel, reconstruct_structure_prior_from_data
+export grow_value, best_grow
 export FamilyCandidate, FamilyBMA, build_family_model, build_family_prior, family_observe, family_posterior
 export initial_learning_regime, update_learning_regime, plateau_probability
 export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next, posterior_accuracy, route_outcome!, decode_correctness, latency_at, route_decide, escalate_decide, routing_belief_readout, reconstruct_latency_from_data, reconstruct_routing_tops_from_data, _ctx_key

--- a/src/Credence.jl
+++ b/src/Credence.jl
@@ -60,7 +60,7 @@ export factor, replace_factor
 export condition, expect, push_measure, density, log_density_at, log_predictive, log_marginal, wrap_in_measure
 export ConjugatePrevision, maybe_conjugate, update
 export StructureBMA, build_structure_model, build_structure_prior, build_structure_prior_dense, structure_observe, structure_observe_soft, belief_at_context, context_from_features, structure_firing_tags, structure_decision_kernel, reconstruct_structure_prior_from_data
-export grow_value, best_grow
+export grow_value, best_grow, recovery_g
 export FamilyCandidate, FamilyBMA, build_family_model, build_family_prior, family_observe, family_posterior
 export initial_learning_regime, update_learning_regime, plateau_probability
 export RoutingState, EmissionBelief, LatencyBelief, route, route_eu, escalation_next, posterior_accuracy, route_outcome!, decode_correctness, latency_at, route_decide, escalate_decide, routing_belief_readout, reconstruct_latency_from_data, reconstruct_routing_tops_from_data, _ctx_key

--- a/src/gather_voi.jl
+++ b/src/gather_voi.jl
@@ -40,3 +40,17 @@ function best_grow(actuators, u_correct::Float64, eu::Float64)
     end
     (best, best_v)
 end
+
+"""
+    recovery_g(model, top, features) -> Float64
+
+The learned `g = P(recover | sensors)` for one grow actuator: `E[θ | X]` of the actuator's
+structure-BMA outcome belief `top` at the sensor context (`context_from_features` on the
+`features` dict, then `expect` of `Identity` over the `belief_at_context` view). One
+outcome belief per actuator over one shared sensor model (routing's per-model `tops`
+shape); this readout is DECISION-GRADE — it is the pricing input to `grow_value`
+(`posterior_accuracy` is the inspection-only sibling).
+"""
+recovery_g(model::StructureBMA, top::MixturePrevision, features)::Float64 =
+    Float64(expect(belief_at_context(model, top, context_from_features(model, features)),
+                   Identity()))

--- a/src/gather_voi.jl
+++ b/src/gather_voi.jl
@@ -1,0 +1,42 @@
+# gather_voi.jl — the gather VOI: pricing + which-gather argmax for grow (recall/discovery)
+# actuators. `net_voi` prices observations over a *closed* hypothesis set; a grow actuator
+# instead proposes to ENLARGE the set so a missing truth can enter, so it is priced by a
+# separate recovery belief `g = P(recover | sensors)` — a structure-BMA readout
+# (`belief_at_context`) — against the consumer's terminal EU. Connection-generic: any body
+# with actuators + sensors uses this exactly as it uses `optimise`/`net_voi`.
+# Lifted from apps/answer-brain (the conferred gather half — life-agent
+# docs/ask-as-connection.md §4/§7); pure functions over the above, no new frozen type.
+
+"""
+    grow_value(g, u_correct, eu, cost) -> Float64
+
+The gather VOI of one grow (recall/discovery) actuator. A grow move may enlarge the
+consumer's hypothesis set to admit a missing truth; `g = P(recover | sensors)` is a
+structure-BMA belief at the sensor context. The value is the gain from converting the
+current terminal outcome (EU `eu`) into the correct-terminal value (`u_correct`), realised
+with probability `g`, net of `cost`. The missing mass **self-gates through `eu`**: a
+confident terminal has `eu ≈ u_correct` ⇒ prices `≈ −cost` (don't grow a solved decision);
+a withhold has low `eu` ⇒ a large gain. There is no missing-mass branch — `p_none`/entropy
+are features of the sensor context that shape `g`. Optimistic in the post-recovery value
+(a bound; `g` carries the realism).
+"""
+grow_value(g::Float64, u_correct::Float64, eu::Float64, cost::Float64)::Float64 =
+    g * (u_correct - eu) - cost
+
+"""
+    best_grow(actuators, u_correct, eu) -> (probe::Union{String,Nothing}, value::Float64)
+
+The which-gather argmax over grow actuators (e.g. re-extract vs retrieve-wider). Each
+actuator is `(probe::String, g::Float64, cost::Float64)`; the winner is the `grow_value`
+argmax, returned iff it strictly clears 0 (mirrors the `:voi` `net_voi > 0` gate). None
+clears ⇒ `(nothing, 0.0)` — no grow, the terminal decision stands.
+"""
+function best_grow(actuators, u_correct::Float64, eu::Float64)
+    best = nothing
+    best_v = 0.0
+    for (probe, g, cost) in actuators
+        v = grow_value(Float64(g), u_correct, eu, Float64(cost))
+        v > best_v && (best_v = v; best = String(probe))
+    end
+    (best, best_v)
+end

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -2207,6 +2207,12 @@ export StructureBMA, build_structure_model, build_structure_prior,
        belief_at_context, context_from_features, structure_firing_tags,
        structure_decision_kernel, reconstruct_structure_prior_from_data
 
+# Gather VOI: pricing + which-gather argmax for grow (set-enlarging) actuators, against a
+# structure-BMA recovery belief (above) — the open-set complement of stdlib's `net_voi`
+# (lifted from apps/answer-brain — the conferred gather half).
+include("gather_voi.jl")
+export grow_value, best_grow
+
 # Family-BMA: the complexity log-prior (complexity.jl) on a family index — a posterior over
 # likelihood families, conditioned through the per-component-routed MixturePrevision condition above.
 # collapse-towers Phase 2.

--- a/src/ontology.jl
+++ b/src/ontology.jl
@@ -2211,7 +2211,7 @@ export StructureBMA, build_structure_model, build_structure_prior,
 # structure-BMA recovery belief (above) — the open-set complement of stdlib's `net_voi`
 # (lifted from apps/answer-brain — the conferred gather half).
 include("gather_voi.jl")
-export grow_value, best_grow
+export grow_value, best_grow, recovery_g
 
 # Family-BMA: the complexity log-prior (complexity.jl) on a family index — a posterior over
 # likelihood families, conditioned through the per-component-routed MixturePrevision condition above.

--- a/test/test_gather_voi.jl
+++ b/test/test_gather_voi.jl
@@ -58,5 +58,55 @@ let u_c = 1.0, eu = -0.2
     check("best_grow returns nothing when nothing clears cost", best3 === nothing && bv3 == 0.0)
 end
 
+# ── recovery_g: the learned g — a structure-BMA readout at the sensor context ──────────
+# One outcome belief PER ACTUATOR (like routing's per-model `tops`) over one shared sensor
+# model; `g_c = recovery_g(model, top_c, sensors)` prices actuator c in `grow_value`.
+let model = build_structure_model(["miss", "p_none"],
+                                  [["extraction", "retrieval"], ["hi", "lo"]])
+    sensors_ex = Dict("miss" => "extraction", "p_none" => "hi")
+    sensors_rt = Dict("miss" => "retrieval", "p_none" => "hi")
+
+    # Cold start: every cell is Beta(alpha0=2, beta0=2) ⇒ g is exactly the prior mean.
+    cold = build_structure_prior(model)
+    check("recovery_g cold-starts at the prior mean",
+          approx(recovery_g(model, cold, sensors_ex), 0.5))
+
+    # Evidence moves g at the observed context and (by structure mixing) less elsewhere:
+    # re-extract keeps recovering on extraction-misses, failing on retrieval-misses.
+    top = cold
+    X_ex = context_from_features(model, sensors_ex)
+    X_rt = context_from_features(model, sensors_rt)
+    for _ in 1:6; top = structure_observe(model, top, X_ex, 1); end
+    for _ in 1:6; top = structure_observe(model, top, X_rt, 0); end
+    g_ex = recovery_g(model, top, sensors_ex)
+    g_rt = recovery_g(model, top, sensors_rt)
+    check("recovery_g rises where the actuator recovers", g_ex > 0.5, "g_ex=$g_ex")
+    check("recovery_g falls where it does not", g_rt < 0.5, "g_rt=$g_rt")
+
+    # Warm reconstruction from (n1, n0) counts is exact (order-independence): the
+    # body-shipped warm_counts path gives the SAME g as the sequential observes.
+    warm = reconstruct_structure_prior_from_data(model,
+        Dict("contexts" => [Dict("ctx" => ["extraction", "hi"], "n1" => 6, "n0" => 0),
+                            Dict("ctx" => ["retrieval", "hi"], "n1" => 0, "n0" => 6)]))
+    check("recovery_g from warm counts ≡ sequential observes",
+          approx(recovery_g(model, warm, sensors_ex), g_ex) &&
+          approx(recovery_g(model, warm, sensors_rt), g_rt))
+
+    # End-to-end: per-actuator beliefs feed best_grow — the learned g discriminates
+    # which-gather at the same sensor context.
+    top_re = top                              # re-extract: good on extraction-misses
+    top_rw = cold
+    for _ in 1:6; top_rw = structure_observe(model, top_rw, X_ex, 0); end
+    for _ in 1:6; top_rw = structure_observe(model, top_rw, X_rt, 1); end
+    acts_at(s) = [("re-extract", recovery_g(model, top_re, s), 0.05),
+                  ("retrieve-wider", recovery_g(model, top_rw, s), 0.05)]
+    b_ex, _ = best_grow(acts_at(sensors_ex), 1.0, -0.2)
+    b_rt, _ = best_grow(acts_at(sensors_rt), 1.0, -0.2)
+    check("learned g discriminates which-gather (extraction-miss ⇒ re-extract)",
+          b_ex == "re-extract", "got $b_ex")
+    check("learned g discriminates which-gather (retrieval-miss ⇒ retrieve-wider)",
+          b_rt == "retrieve-wider", "got $b_rt")
+end
+
 println("-"^64)
 println("gather VOI: all checks passed")

--- a/test/test_gather_voi.jl
+++ b/test/test_gather_voi.jl
@@ -1,0 +1,62 @@
+# test_gather_voi.jl — the gather VOI (grow pricing + which-gather argmax) lifted into
+# engine stdlib (src/gather_voi.jl). A grow (recall/discovery) actuator may enlarge a
+# consumer's hypothesis set to admit a missing truth; its value is
+# `grow_value(g, u_correct, eu, cost) = g·(u_correct − eu) − cost` where
+# `g = P(recover | sensors)` is a structure-BMA belief and `eu` is the consumer's terminal
+# EU — so the missing-mass gate is carried by `u_correct − eu` (a solved decision prices
+# ≈ −cost), never a hand-coded gate. `best_grow` argmaxes over `(probe, g, cost)` actuators
+# and fires only if the winner strictly clears 0 (mirrors the `net_voi > 0` gate).
+#
+# Lifted from apps/answer-brain/brain/answer_brain.jl (the conferred "B half",
+# life-agent docs/ask-as-connection.md §4/§7); Connection-generic, so it lives here.
+#
+# Run from repo root:
+#     julia --project=. test/test_gather_voi.jl
+
+push!(LOAD_PATH, "src")
+using Credence
+
+function check(name, cond, detail = "")
+    if cond
+        println("PASSED: $name")
+    else
+        println("FAILED: $name — $detail")
+        error("assertion failed: $name")
+    end
+end
+approx(a, b; atol = 1e-9) = abs(a - b) <= atol
+
+println("="^64)
+println("gather VOI (engine stdlib) — grow_value + best_grow")
+println("="^64)
+
+# ── grow_value: the pure pricing, self-gating on the consumer's terminal EU ────────────
+let u_c = 1.0, cost = 0.1
+    check("grow_value self-gates at a confident terminal (eu ≈ u_correct ⇒ ≈ −cost)",
+          approx(grow_value(0.9, u_c, u_c, cost), -cost))
+    check("grow_value is positive for a high-g withhold",
+          grow_value(0.8, u_c, -0.2, cost) > 0.0)
+    check("grow_value is monotone in g",
+          grow_value(0.6, u_c, -0.2, cost) > grow_value(0.3, u_c, -0.2, cost))
+    check("grow_value decreases as terminal EU rises",
+          grow_value(0.7, u_c, 0.8, cost) < grow_value(0.7, u_c, -0.2, cost))
+    check("grow_value subtracts cost exactly",
+          approx(grow_value(0.5, 1.0, 0.0, 0.1), 0.5 * 1.0 - 0.1))
+end
+
+# ── best_grow: the which-gather argmax (fires only if the best clears 0) ────────────────
+let u_c = 1.0, eu = -0.2
+    acts = [("re-extract", 0.7, 0.1), ("retrieve-wider", 0.4, 0.1)]
+    best, bv = best_grow(acts, u_c, eu)
+    check("best_grow picks the higher-value actuator", best == "re-extract")
+    check("best_grow value matches grow_value",
+          approx(bv, grow_value(0.7, u_c, eu, 0.1)))
+    acts2 = [("re-extract", 0.55, 0.5), ("retrieve-wider", 0.5, 0.05)]
+    best2, _ = best_grow(acts2, u_c, eu)
+    check("best_grow accounts for cost (the cheaper actuator wins)", best2 == "retrieve-wider")
+    best3, bv3 = best_grow(acts, u_c, u_c)
+    check("best_grow returns nothing when nothing clears cost", best3 === nothing && bv3 == 0.0)
+end
+
+println("-"^64)
+println("gather VOI: all checks passed")


### PR DESCRIPTION
The conferred gather offload (life-agent \`docs/ask-as-connection.md\` §4/§7 — factor the meta-decision by derivability): **report/abstain stays the exact app-side EU threshold (\`terminal_decide\`, untouched); only the gather decision is learned.**

- **Engine (\`src/gather_voi.jl\`, upstreamed per owner directive):** \`grow_value(g, u_correct, eu, cost)\` — self-gates on the terminal EU (no p_none branch); \`best_grow\` — the which-gather argmax; \`recovery_g\` — the learned \`g = P(recover | sensors)\` as a structure-BMA readout (\`belief_at_context\` ∘ \`context_from_features\`), decision-grade sibling of \`posterior_accuracy\`. Warm reconstruction from body-shipped counts is exact (order-independence) so the daemon stays stateless.
- **App:** \`schedule_decide\`/\`gather_decide\` gain a \`grows\` lane (guards keep precedence; grow argmax competes with :voi in one EU comparison; \`applied_probes\` termination; \`grows=[]\` parity-exact). \`/decide\` accepts \`sensors\` + a \`grow\` block (feature vocabulary, per-actuator cost + cold Beta g-prior + \`warm_counts\`); \`grow_g\` echoed for the body's outcome log.
- **0-CW is structural:** the learned belief never owns reporting.

Paired with life-agent PR (grow lane body + instrumentation). Suites: engine \`test_gather_voi\` (15) + app 5/5 (test_server 65, test_grow 12) green; RED-first throughout. Merge owner-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)