### PR TITLE
feat(skin): belief-derived tail + structure_expect read verb (protocol 1.13)

### DIFF
--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -1,6 +1,6 @@
 # Credence Skin Protocol
 
-Protocol-Version: 1.12
+Protocol-Version: 1.13
 
 JSON-RPC 2.0 over stdio. Skin reads newline-delimited JSON from stdin,
 writes newline-delimited JSON to stdout, logs to stderr.
@@ -13,6 +13,22 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
 
 ### Changelog
 
+- **1.13** — the belief-derived tail + the per-context read (one additive unit; the
+  governor wire requests R1+R2). (a) `structure_decide` gains an optional `tail` object
+  `{model_id, state_id, features, function}`: a continuation model + belief + context plus a
+  CONSUMER-DECLARED functional whose posterior expectation sets `expected_repeats` — e.g.
+  `{"type": "geometric_tail"}` prices the tail as `m = E[ρ/(1−ρ)] = α/(β−1)`. The declared
+  functional is the consumer's world-model crossing the wire as data; the engine hardcodes no
+  distributional commitment, computes `m` brain-side, and the scalar never transits the
+  consumer. **Precedence:** a present `tail` supersedes the scalar `expected_repeats`.
+  Sending both is a *transient rolling-upgrade fallback only* — a pre-1.13 engine ignores the
+  unknown `tail` and falls back to the hand-typed scalar, but since `structure_expect` is
+  also 1.13 no belief-derived `m` exists there either; the scalar bridge is not a standing
+  endorsement of the typed constant this surface exists to retire. (b) `structure_expect`
+  read verb — a per-context scalar expectation off a structure belief (`function` from the
+  same vocabulary; `geometric_tail` added to it). Read-only; for display, audit, and offline
+  calibration — **not a decision channel** (see the verb section). Version negotiation stays
+  the consumer's job.
 - **1.12** — the lookup ρ-latent goes EXACT (discretisation-antipattern disposal, Phase C). One
   addition, one removal, one reshaped kernel: (a) `reliability_categorical` belief-spec — a
   categorical V (`v_log_weights`, the candidate atoms + NONE, 1-based) with a Beta(`alpha`,`beta`)
@@ -508,9 +524,10 @@ belief `state_id` is unchanged.
 ### structure_decide
 
 The proceed/block/ask EU decision at a context (engine stdlib `decide_with_voi`). The
-client ships only utility scalars; the engine assembles all coefficients, the VOI ask-gate,
-and the argmax. An optional `harm` object adds a second outcome (a separate harm model +
-belief + context) integrated in one EU.
+client ships only utility scalars and declarations; the engine assembles all coefficients,
+the VOI ask-gate, and the argmax. An optional `harm` object adds a second outcome (a
+separate harm model + belief + context) integrated in one EU. An optional `tail` object
+(1.13) derives `expected_repeats` from a continuation belief instead of a hand-typed scalar.
 
 ```json
 {"method": "structure_decide", "params": {
@@ -519,7 +536,10 @@ belief + context) integrated in one EU.
   "cost": 1.0, "aversion": 1.0, "interrupt_cost": 0.5,
   "expected_repeats": 0.0, "w_time": 0.0, "exp_time": 0.0,
   "harm": {"model_id": "m_2", "state_id": "s_2",
-           "features": {"tool": "bash", "rep": "rep3"}, "harm_cost": 2.0}
+           "features": {"tool": "bash", "rep": "rep3"}, "harm_cost": 2.0},
+  "tail": {"model_id": "m_3", "state_id": "s_3",
+           "features": {"tool": "bash", "rep": "rep3"},
+           "function": {"type": "geometric_tail"}}
 }}
 ```
 
@@ -528,10 +548,23 @@ belief + context) integrated in one EU.
 ```
 
 `action` is `"proceed"`, `"block"`, or `"ask"`. `expected_repeats` (m, the multi-turn
-tail), `w_time`/`exp_time` (the wall-clock saving), and `harm` are optional; omitting all
-of them gives the myopic single-outcome decision. `belief_at_context` is intentionally not
-a verb — `structure_decide` consumes the per-context view internally and no consumer reads
-it across the wire.
+tail), `w_time`/`exp_time` (the wall-clock saving), `harm`, and `tail` are optional;
+omitting all of them gives the myopic single-outcome decision.
+
+The `tail` object is a continuation model + belief + context whose posterior expectation
+under the **required, consumer-declared** `function` sets `expected_repeats`:
+`{"type": "geometric_tail"}` declares a geometric repeat process and prices the tail as
+`m = E[ρ/(1−ρ)]` (closed form `α/(β−1)` on Beta cells; `β ≤ 1` fails loud as an inference
+error). The declaration is the consumer's world-model crossing the wire as data — the
+engine never chooses a distributional commitment on the consumer's behalf, and the
+belief-derived `m` never transits the consumer. **Precedence:** a present `tail` supersedes
+the scalar `expected_repeats`; sending both is a transient rolling-upgrade fallback only
+(see the 1.13 changelog). A missing or unknown `tail.function` fails loud as a DSL error.
+
+`belief_at_context` is intentionally not a verb — `structure_decide` consumes the
+per-context view internally, and the belief object never crosses the wire. Scalar
+*expectations* of it are readable via `structure_expect` (1.13) for audit and calibration;
+that verb is not a decision channel (see its section).
 
 ## Routing (protocol 1.5)
 

--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -566,6 +566,38 @@ per-context view internally, and the belief object never crosses the wire. Scala
 *expectations* of it are readable via `structure_expect` (1.13) for audit and calibration;
 that verb is not a decision channel (see its section).
 
+### structure_expect
+
+A per-context scalar expectation read off a structure belief (protocol 1.13): the
+posterior expectation of a declared `function` at the context. Read-only — no state
+mutation; only the scalar crosses the wire (the belief stays server-side, Invariant 1).
+
+**Usage contract: `structure_expect` is a read for display, audit, and offline
+calibration — it is NOT a decision channel; decisions are `structure_decide`'s job
+(EU-max).** Branching app-side on the returned float (`if P(unsafe) > k: block`)
+reintroduces exactly the hardcoded threshold `structure_decide`'s EU-max exists to
+eliminate. The engine cannot enforce this — it returns a float — so the contract lives
+here, on the surface both sides read, and binds consumers of this protocol.
+
+```json
+{"method": "structure_expect", "params": {
+  "model_id": "m_1", "state_id": "s_1",
+  "features": {"tool": "bash", "rep": "rep3"},
+  "function": {"type": "identity"}
+}}
+```
+
+```json
+{"result": {"value": 0.714285714285714}}
+```
+
+`function` uses the same declared-functional vocabulary as `expect`:
+`{"type": "identity"}` reads the posterior mean `P(unsafe|X) = α/(α+β)`;
+`{"type": "geometric_tail"}` reads the tail `m = E[ρ/(1−ρ)] = α/(β−1)` — the same `m`
+`structure_decide`'s `tail` folds into a decision, so every tail-driven block is
+auditable from the same belief. Unknown `model_id`/`state_id` → `StateNotFound`
+(`-32000`); an unknown `function` fails loud as a DSL error.
+
 ## Routing (protocol 1.5)
 
 A non-embedding consumer drives EU-max model routing over the wire — no probability

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -586,6 +586,11 @@ function build_function(spec)::Functional
         ]
         offset = Float64(get(spec, "offset", 0.0))
         LinearCombination(terms, offset)
+    elseif t == "geometric_tail"
+        # E[θ/(1−θ)] — the posterior-predictive tail of a geometric repeat process
+        # (closed form α/(β−1) on Beta leaves). A consumer-declared world-model: used by
+        # structure_decide's `tail.function` and readable via structure_expect (1.13).
+        GeometricTail()
     elseif t == "opaque_bdsl" || t == "bdsl"
         env_id = spec["env_id"]
         env = get(DSL_ENVS, env_id, nothing)
@@ -718,7 +723,7 @@ end
 # rides the `credence-skin` image tag). MAJOR bumps on a breaking protocol
 # change; MINOR on additive. Apps pin the major in code and `initialize`
 # rejects a mismatching major with -32010. See docs/decouple/master-plan.md.
-const PROTOCOL_VERSION = "1.12"
+const PROTOCOL_VERSION = "1.13"
 protocol_major(v) = String(first(split(String(v), ".")))
 
 # Advertised method set, returned by `initialize` for client capability
@@ -1255,6 +1260,15 @@ end
 _structure_X(model, features) =
     context_from_features(model, Dict(string(k) => string(v) for (k, v) in pairs(features)))
 
+# A wire belief reference {model_id, state_id, features} → the per-context belief view.
+# Shared by the main, harm, and tail arms of handle_structure_decide and by
+# handle_structure_expect; the belief stays server-side (only scalars cross the wire).
+function _belief_from_ref(obj)
+    m = get_model(string(obj["model_id"]))
+    t = get_state(string(obj["state_id"]))
+    belief_at_context(m, t, _structure_X(m, obj["features"]))
+end
+
 function handle_structure_bma(params)
     names = String[string(n) for n in params["feature_names"]]
     values = Vector{String}[String[string(v) for v in vs] for vs in params["feature_values"]]
@@ -1298,30 +1312,42 @@ function handle_structure_observe(params)
 end
 
 function handle_structure_decide(params)
-    model = get_model(string(params["model_id"]))
-    top = get_state(string(params["state_id"]))
     # Belief view + optional harm coordinate (a second model+belief+context for the unsafe
-    # outcome). Context build is a protocol concern (vocabulary), so wrap as DSLError.
-    bx, harm_belief, harm_cost = try
-        bx0 = belief_at_context(model, top, _structure_X(model, params["features"]))
+    # outcome) + optional tail coordinate (a continuation model+belief+context plus a
+    # CONSUMER-DECLARED functional whose expectation sets expected_repeats — the engine
+    # hardcodes no distributional commitment; the world-model crosses the wire as data).
+    # Context + functional build is a protocol concern (vocabulary), so wrap as DSLError.
+    bx, harm_belief, harm_cost, tail_belief, tail_fn = try
+        bx0 = _belief_from_ref(params)
         hb, hc = nothing, 0.0
         if get(params, "harm", nothing) !== nothing
             h = params["harm"]
-            hmodel = get_model(string(h["model_id"]))
-            htop = get_state(string(h["state_id"]))
-            hb = belief_at_context(hmodel, htop, _structure_X(hmodel, h["features"]))
+            hb = _belief_from_ref(h)
             hc = Float64(get(h, "harm_cost", 0.0))
         end
-        (bx0, hb, hc)
+        tb, tfn = nothing, nothing
+        if get(params, "tail", nothing) !== nothing
+            t = params["tail"]
+            tb = _belief_from_ref(t)
+            tfn = build_function(t["function"])
+        end
+        (bx0, hb, hc, tb, tfn)
     catch e
         _wrap_dsl("structure decision context build failed")(e)
     end
     action = try
+        # Precedence: a tail belief supersedes the scalar expected_repeats (the belief-
+        # derived expectation wins — for the declared geometric_tail, m = E[ρ/(1−ρ)] =
+        # α/(β−1)). The expectation compute — and e.g. geometric_tail's β≤1 divergence
+        # guard — is inference, so it correctly lands in this _wrap_inf arm.
+        er = tail_belief === nothing ?
+             Float64(get(params, "expected_repeats", 0.0)) :
+             Float64(expect(tail_belief, tail_fn))
         decide_with_voi(bx, structure_decision_kernel();
                         cost = Float64(params["cost"]),
                         aversion = Float64(params["aversion"]),
                         interrupt_cost = Float64(params["interrupt_cost"]),
-                        expected_repeats = Float64(get(params, "expected_repeats", 0.0)),
+                        expected_repeats = er,
                         w_time = Float64(get(params, "w_time", 0.0)),
                         exp_time = Float64(get(params, "exp_time", 0.0)),
                         harm_belief = harm_belief, harm_cost = harm_cost)

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -736,7 +736,7 @@ const SKIN_METHODS = [
     "perturb_grammar", "add_programs", "sync_prune", "sync_truncate",
     "top_grammars", "belief_summary", "condition_and_prune", "eu_interact",
     "call_dsl", "factor", "replace_factor", "n_factors",
-    "structure_bma", "structure_observe", "structure_decide",
+    "structure_bma", "structure_observe", "structure_decide", "structure_expect",
     "routing_init", "routing_decide", "routing_escalate", "routing_outcome",
     "routing_belief", "destroy_routing",
 ]
@@ -778,6 +778,8 @@ function handle_request(method::String, params, id)
         handle_structure_observe(params)
     elseif method == "structure_decide"
         handle_structure_decide(params)
+    elseif method == "structure_expect"
+        handle_structure_expect(params)
     elseif method == "routing_init"
         handle_routing_init(params)
     elseif method == "routing_decide"
@@ -1252,7 +1254,9 @@ end
 # ALL arithmetic — the chain-rule reweight, the EU coefficient assembly — is engine-side
 # (src/structure_bma.jl, src/stdlib.jl `decide_with_voi`); the verbs only marshal JSON,
 # so Invariant 1 holds across the wire by construction. `belief_at_context` is deliberately
-# NOT a verb: no consumer reads the per-context belief across the wire (Move-3 Q2).
+# NOT a verb: the per-context belief object never crosses the wire (Move-3 Q2). Scalar
+# EXPECTATIONS of it are readable via `structure_expect` (1.13) — an audit/calibration
+# read, contractually not a decision channel (protocol.md).
 # ═══════════════════════════════════════
 
 # A features dict {name: bucket} → X (positional, validated against the model's declared
@@ -1355,6 +1359,29 @@ function handle_structure_decide(params)
         _wrap_inf("decide_with_voi failed")(e)
     end
     Dict{String, Any}("action" => string(action))
+end
+
+# The per-context scalar read (protocol 1.13): a declared functional's posterior
+# expectation at a context. Read-only; the belief never crosses the wire (only the
+# scalar does). Per protocol.md this is a display/audit/calibration surface, NOT a
+# decision channel — decisions stay in structure_decide's EU-max.
+function handle_structure_expect(params)
+    bx = try
+        _belief_from_ref(params)
+    catch e
+        _wrap_dsl("structure_expect context build failed")(e)
+    end
+    f = try
+        build_function(params["function"])
+    catch e
+        _wrap_dsl("build_function failed")(e)
+    end
+    v = try
+        Float64(expect(bx, f))
+    catch e
+        _wrap_inf("structure_expect failed")(e)
+    end
+    Dict{String, Any}("value" => v)
 end
 
 # ═══════════════════════════════════════

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -1240,6 +1240,72 @@ def test_structure_bma_roundtrip():
         skin.shutdown()
 
 
+def test_structure_decide_tail():
+    """R1 (protocol 1.13): the optional `tail` coordinate on structure_decide folds a
+    belief-derived expected_repeats into the EU decision. The consumer DECLARES the
+    functional (its world-model crosses the wire as data — the engine hardcodes no
+    distributional commitment); the engine computes m = E[f(ρ)] brain-side and prices a
+    block as preventing tf = 1+m calls. Asserts the tail flips proceed→block (a),
+    supersedes the scalar expected_repeats (b), omitting it reproduces the 1.12 decision
+    (c, regression pin), and a missing/unknown declared function fails loud (d) — with
+    ZERO probability arithmetic client-side (Invariant 1 across the wire)."""
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        spec = {"feature_names": ["tool", "rep"],
+                "feature_values": [["bash", "read"], ["rep0", "rep3"]]}
+        ctx = {"tool": "bash", "rep": "rep3"}
+        HUGE = 1.0e9  # interrupt cost that removes :ask from contention
+
+        # Approve belief: three approvals ⇒ every component cell Beta(5,2) ⇒ θ = 5/7.
+        bma = skin._call("structure_bma", dict(spec))
+        mid, sid = bma["model_id"], bma["state_id"]
+        for _ in range(3):
+            skin._call("structure_observe",
+                       {"model_id": mid, "state_id": sid, "features": ctx, "observation": 1})
+
+        def decide(extra=None):
+            p = {"model_id": mid, "state_id": sid, "features": ctx,
+                 "cost": 1.0, "aversion": 1.0, "interrupt_cost": HUGE}
+            if extra:
+                p.update(extra)
+            return skin._call("structure_decide", p)["action"]
+
+        # (c) Baseline without tail: tf = 1 ⇒ block iff θ < 1/2; θ = 5/7 ⇒ proceed.
+        assert decide() == "proceed", "baseline without tail should proceed"
+
+        # Tail belief: three continuations at the context ⇒ cells Beta(5,2) ⇒ per-component
+        # m = α/(β−1) = 5, identical across components so mixture-exact ⇒ tf = 6.
+        # Block iff θ < tf/(tf+λ) = 6/7; θ = 5/7 < 6/7 ⇒ the SAME decision flips to block.
+        tail_bma = skin._call("structure_bma", dict(spec))
+        tmid, tsid = tail_bma["model_id"], tail_bma["state_id"]
+        for _ in range(3):
+            skin._call("structure_observe",
+                       {"model_id": tmid, "state_id": tsid, "features": ctx, "observation": 1})
+        tail = {"model_id": tmid, "state_id": tsid, "features": ctx,
+                "function": {"type": "geometric_tail"}}
+
+        # (a) The declared tail flips proceed→block at unchanged utility data.
+        assert decide({"tail": tail}) == "block", "tail m=5 should flip proceed→block"
+        # (b) Precedence: the belief-derived tail supersedes the scalar expected_repeats.
+        assert decide({"tail": tail, "expected_repeats": 0.0}) == "block", \
+            "tail must supersede the scalar expected_repeats"
+        # (c) Regression pin: omitting tail still reproduces the pre-tail decision.
+        assert decide() == "proceed", "omitting tail reproduces 1.12 behaviour"
+
+        # (d) The world-model declaration is mandatory inside `tail`: an unknown or
+        # missing `function` fails loud as a clean SkinError, not a stacktrace.
+        with pytest.raises(SkinError):
+            decide({"tail": {"model_id": tmid, "state_id": tsid, "features": ctx,
+                             "function": {"type": "bogus"}}})
+        with pytest.raises(SkinError):
+            decide({"tail": {"model_id": tmid, "state_id": tsid, "features": ctx}})
+
+        print("PASS: structure_decide tail coordinate (flip + precedence + pin + fail-loud)")
+    finally:
+        skin.shutdown()
+
+
 def test_routing_verbs_roundtrip():
     """A non-embedding consumer drives EU-max model routing over the wire only: build the
     session (`routing_init`, warm counts inline), pick the EU-max model (`routing_decide`),
@@ -1462,6 +1528,8 @@ if __name__ == "__main__":
     test_call_dsl_belief_roundtrip()
     print()
     test_structure_bma_roundtrip()
+    print()
+    test_structure_decide_tail()
     print()
     test_routing_verbs_roundtrip()
     print()

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -1306,6 +1306,58 @@ def test_structure_decide_tail():
         skin.shutdown()
 
 
+def test_structure_expect():
+    """R2 (protocol 1.13): `structure_expect` reads a per-context scalar expectation off a
+    structure belief — the numerator of a rationale, the audit trail for R1's tail, the
+    offline-calibration read. Read-only (no state mutation), scalar-only across the wire;
+    per protocol.md it is NOT a decision channel (decisions are structure_decide's EU-max).
+    Asserts exact analytic values: identity == α/(α+β) and geometric_tail == α/(β−1) on
+    the same belief R1 folds in, plus clean errors on unknown state and unknown function."""
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        bma = skin._call("structure_bma", {
+            "feature_names": ["tool", "rep"],
+            "feature_values": [["bash", "read"], ["rep0", "rep3"]]})
+        mid, sid = bma["model_id"], bma["state_id"]
+        ctx = {"tool": "bash", "rep": "rep3"}
+        # Three approvals at one context: every component cell Beta(5,2), and all four
+        # structures share the (2,2)-seeded marginal likelihood so the mixture stays
+        # uniform ⇒ E[θ] = 5/7 and E[ρ/(1−ρ)] = α/(β−1) = 5 exactly (up to fp summation).
+        for _ in range(3):
+            skin._call("structure_observe",
+                       {"model_id": mid, "state_id": sid, "features": ctx, "observation": 1})
+
+        def read(fn):
+            return skin._call("structure_expect", {
+                "model_id": mid, "state_id": sid, "features": ctx, "function": fn})["value"]
+
+        v_mean = read({"type": "identity"})
+        assert abs(v_mean - 5 / 7) < 1e-12, f"identity should read α/(α+β) = 5/7, got {v_mean}"  # credence-lint: allow — precedent:test-oracle — Beta(5,2) mean, exact analytic
+        v_tail = read({"type": "geometric_tail"})
+        assert abs(v_tail - 5.0) < 1e-12, f"geometric_tail should read α/(β−1) = 5, got {v_tail}"  # credence-lint: allow — precedent:test-oracle — Beta(5,2) tail, exact analytic
+
+        # The read mutates nothing: the decision after the reads matches the belief.
+        a = skin._call("structure_decide", {
+            "model_id": mid, "state_id": sid, "features": ctx,
+            "cost": 1.0, "aversion": 1.0, "interrupt_cost": 1.0e9})["action"]
+        assert a == "proceed", "structure_expect must not mutate the belief"
+
+        # Clean errors, not stacktraces: unknown state ⇒ StateNotFound (-32000);
+        # unknown declared function ⇒ DSL error.
+        with pytest.raises(SkinError) as info:
+            skin._call("structure_expect", {
+                "model_id": mid, "state_id": "s_99999", "features": ctx,
+                "function": {"type": "identity"}})
+        assert info.value.code == -32000, f"expected StateNotFound, got {info.value.code}"
+        with pytest.raises(SkinError):
+            read({"type": "bogus"})
+
+        print("PASS: structure_expect (posterior mean + geometric tail, exact; read-only; fail-loud)")
+    finally:
+        skin.shutdown()
+
+
 def test_routing_verbs_roundtrip():
     """A non-embedding consumer drives EU-max model routing over the wire only: build the
     session (`routing_init`, warm counts inline), pick the EU-max model (`routing_decide`),
@@ -1376,12 +1428,13 @@ def test_initialize_returns_contract():
     skin = SkinClient()
     try:
         result = skin.initialize()
-        assert result["protocol"] == "1.12", f"protocol: {result.get('protocol')}"
+        assert result["protocol"] == "1.13", f"protocol: {result.get('protocol')}"
         assert "version" in result, "engine version missing"
         methods = result["methods"]
         # Core canalised verbs + the Move-3 structure-BMA verbs must be advertised.
         for verb in ("create_state", "condition", "expect", "optimise", "draw",
-                     "structure_bma", "structure_observe", "structure_decide"):
+                     "structure_bma", "structure_observe", "structure_decide",
+                     "structure_expect"):
             assert verb in methods, f"{verb} missing from advertised methods"
         print("PASS: initialize returns {protocol, version, methods}")
     finally:
@@ -1530,6 +1583,8 @@ if __name__ == "__main__":
     test_structure_bma_roundtrip()
     print()
     test_structure_decide_tail()
+    print()
+    test_structure_expect()
     print()
     test_routing_verbs_roundtrip()
     print()


### PR DESCRIPTION
The governor wire handoff (R1+R2 of `credence-governor`'s engine-wire-requests brief), one additive MINOR unit: `1.12 → 1.13`.

## R1 — `tail` coordinate on `structure_decide`

Optional `tail` object `{model_id, state_id, features, function}`: a continuation model + belief + context whose posterior expectation under the **consumer-declared** functional sets `expected_repeats`. For the governor's `{"type": "geometric_tail"}`, `m = E[ρ/(1−ρ)] = α/(β−1)` — computed brain-side; the scalar never transits the consumer. **Precedence:** tail supersedes the scalar `expected_repeats` (always-send-both documented as a transient rolling-upgrade fallback only). The declared functional is the decoupling point: the engine hardcodes no distributional commitment on the consumer's behalf — the world-model crosses the wire as data.

## R2 — `structure_expect` read verb

Per-context scalar expectation off a structure belief: `identity` reads `P(unsafe|X) = α/(α+β)`; `geometric_tail` reads the same `m` R1 folds in, so every tail-driven block is auditable. Read-only; the belief stays server-side. `protocol.md` carries the **binding usage contract**: display, audit, and offline calibration — **not a decision channel** (app-side thresholding on the returned float would reintroduce the hardcoded cut EU-max exists to eliminate; the engine cannot enforce a float's use, so the contract lives on the surface both sides read).

## Shape

- Pure `apps/skin/` marshalling — no `src/` change; the `expect(MixturePrevision, GeometricTail)` chain already exists (`ontology.jl` forwarder → `BetaPrevision` closed form, β≤1 fails loud as InferenceError by construction of the two-arm error taxonomy).
- `_belief_from_ref` extracted for the main/harm/tail arms (third repetition of the wire-belief-ref pattern).
- TDD both steps (genuine RED at the missing feature / MethodNotFound, then GREEN); the version-pin test forced the conscious `1.13` touch and now also pins `structure_expect` advertisement.

## Verification

- Full wire suite (CI gate): all tests green incl. the 2 new (`test_structure_decide_tail`: flip + precedence + regression pin + fail-loud; `test_structure_expect`: exact analytic α/(α+β) and α/(β−1), read-only pin, clean StateNotFound/DSL errors).
- Protocol invariant: `protocol.md` header == `PROTOCOL_VERSION` == `1.13`.
- credence-lint: 173 files, 0 violations.
- Full local Julia core suite: 40 files, no errors.

**Merge note:** squash-merge (one versioned unit — the landed commit's version, docs, and handlers agree; avoids an intermediate commit advertising 1.13 without the R2 handler).

R3 (duration tier) stays a documented gap; R4 (exploration accessors) rides the dominance track — both per the brief's own scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)