### PR TITLE
feat(skin): learning-policy knobs wire-declared + engine-template-guard precedent (protocol 1.14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,8 @@ The slug index below is the lint's source of truth for valid slugs (regex `^\*\*
 
 **Slug:** `untyped-mixture-construction` — Untyped container literals (`Any[]`, bare `[]`, `Vector{Any}(...)`, `convert(Vector{Any}, ...)`) passed to Mixture/Product/Particle/Enumeration constructors. Use a typed Vector literal (e.g. `TaggedBetaPrevision[]`). Escape hatch for justified heterogeneous construction (e.g. deserialisation). (Invariant 3)
 
+**Slug:** `engine-template-guard` — Domain templates (e.g. `decide_with_voi`, the routing state machine) may live engine-side ONLY under the five-point guard: every coefficient from declared wire data; all math canalised through the axiom ops; no consumer identifiers in code or docs; every default documented and wire-overridable; unsupported shapes fail loud. A template coordinate that requires the engine to *choose* a functional/distribution/threshold for the consumer is redesigned as a declared field. Documentation-only (review checklist, not a pragma target). (Invariants 1 + 2; the decouple commitment)
+
 ## Development commands
 
 Julia tests (one file at a time; `ls test/test_*.jl` for the catalogue):

--- a/apps/skin/protocol.md
+++ b/apps/skin/protocol.md
@@ -1,6 +1,6 @@
 # Credence Skin Protocol
 
-Protocol-Version: 1.13
+Protocol-Version: 1.14
 
 JSON-RPC 2.0 over stdio. Skin reads newline-delimited JSON from stdin,
 writes newline-delimited JSON to stdout, logs to stderr.
@@ -13,6 +13,19 @@ truth, asserted in CI to equal `PROTOCOL_VERSION` in `server.jl`.
 
 ### Changelog
 
+- **1.14** — learning-policy knobs become wire-declared data (minimality-audit follow-up;
+  additive). The skin had been FIXING three modelling constants on the consumer's behalf —
+  a violation of the rule that the skin marshals declarations and never sets policy.
+  (a) `min_log_prior` (the enumeration floor, engine default `-20.0`) is now an optional
+  param on `create_state` (type `program_space`), `enumerate`, and `add_programs`.
+  (b) `min_frequency` / `min_complexity` (the subtree-extraction gate, defaults `0.01`/`2`)
+  are now optional params on `perturb_grammar` — the old hardcoded `0.01` could silently
+  foreclose extractions a consumer wants (a best subtree with weighted frequency below it
+  no-ops). Defaults reproduce 1.13 behaviour exactly. Also: the `perturb_grammar` response
+  is documented as it actually is (`{new_grammar_id}`; same id ⇒ structural no-op), the
+  `eu_interact` binary-outcome restriction is documented, and a skin bit-rot in
+  `build_grammar` (Grammar constructor argument order) that broke `create_state`
+  (program_space) and `enumerate` with a MethodError is fixed with first wire coverage.
 - **1.13** — the belief-derived tail + the per-context read (one additive unit; the
   governor wire requests R1+R2). (a) `structure_decide` gains an optional `tail` object
   `{model_id, state_id, features, function}`: a continuation model + belief + context plus a
@@ -264,9 +277,14 @@ Create a new measure or agent state. Returns its ID.
     }
   ],
   "max_depth": 3,
-  "action_space": ["food", "enemy"]
+  "action_space": ["food", "enemy"],
+  "min_log_prior": -20.0
 }}
 ```
+
+`min_log_prior` (optional, default `-20.0`) is the enumeration floor: programs whose
+complexity log-prior falls below it are not enumerated. Learning policy, so it is the
+consumer's declaration — the default reproduces pre-1.14 behaviour.
 
 Response (all types):
 
@@ -739,7 +757,8 @@ Enumerate programs from a grammar, compile kernels, add to state.
     }
   },
   "max_depth": 3,
-  "action_space": ["food", "enemy"]
+  "action_space": ["food", "enemy"],
+  "min_log_prior": -20.0
 }}
 ```
 
@@ -747,25 +766,41 @@ Enumerate programs from a grammar, compile kernels, add to state.
 {"result": {"n_added": 42, "grammar_id": 3, "n_components": 192}}
 ```
 
+`min_log_prior` (optional, default `-20.0`) — the enumeration floor, as on
+`create_state` (program_space).
+
 ### perturb_grammar
 
-Analyse posterior subtrees and create a perturbed grammar.
+Analyse posterior subtrees and create a perturbed grammar (the compression-class
+meta-action with the greatest positive `net_voc`; otherwise a structural no-op).
 
 ```json
 {"method": "perturb_grammar", "params": {
   "state_id": "s_5",
   "grammar_id": 1,
-  "all_features": ["colour", "speed", "wall_dist", "agent_dist", "x", "y"]
+  "all_features": ["colour", "speed", "wall_dist", "agent_dist", "x", "y"],
+  "min_frequency": 0.01,
+  "min_complexity": 2
 }}
 ```
 
 ```json
-{"result": {"new_grammar_id": 4, "n_new_rules": 3}}
+{"result": {"new_grammar_id": 4}}
 ```
+
+`new_grammar_id` equal to `grammar_id` means a structural no-op (the input grammar,
+unchanged — nothing to extract or reclaim at positive net value). `min_frequency`
+(optional, default `0.01`) and `min_complexity` (optional, default `2`) gate which
+posterior subtrees are extraction candidates: a subtree enters the frequency table only
+if its posterior-weighted frequency is ≥ `min_frequency` (a value in [0,1]; above 1 is
+unsatisfiable ⇒ always a no-op) and its complexity is ≥ `min_complexity`. These are
+learning policy — the consumer's declaration, not the skin's; defaults reproduce
+pre-1.14 behaviour.
 
 ### add_programs
 
-Enumerate from an existing grammar at a new depth.
+Enumerate from an existing grammar at a new depth. `min_log_prior` (optional, default
+`-20.0`) — the enumeration floor, as on `create_state` (program_space).
 
 ```json
 {"method": "add_programs", "params": {
@@ -876,6 +911,10 @@ sync_truncate in one round-trip.
 
 EU of interacting for a program-space agent. Evaluates all compiled
 kernels on features, returns weighted EU.
+
+**Restriction:** exactly two outcome labels in `rewards` (the per-component split
+assumes correct-recommendation vs a single complement); three or more labels fail loud
+with an informative error. Multi-label support needs per-component categorical beliefs.
 
 ```json
 {"method": "eu_interact", "params": {

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -726,7 +726,7 @@ end
 # rides the `credence-skin` image tag). MAJOR bumps on a breaking protocol
 # change; MINOR on additive. Apps pin the major in code and `initialize`
 # rejects a mismatching major with -32010. See docs/decouple/master-plan.md.
-const PROTOCOL_VERSION = "1.13"
+const PROTOCOL_VERSION = "1.14"
 protocol_major(v) = String(first(split(String(v), ".")))
 
 # Advertised method set, returned by `initialize` for client capability
@@ -887,6 +887,9 @@ function handle_create_state(params)
         grammars_spec = params["grammars"]
         max_depth = Int(get(params, "max_depth", 3))
         action_space = Symbol[Symbol(a) for a in params["action_space"]]
+        # The enumeration floor is learning policy — the consumer's, not the skin's
+        # (protocol 1.14; audit follow-up). The engine default is the documented fallback.
+        min_log_prior = Float64(get(params, "min_log_prior", -20.0))
 
         # Build grammars and enumerate programs
         grammar_pool = Grammar[]
@@ -904,7 +907,7 @@ function handle_create_state(params)
 
         for g in grammar_pool
             programs = enumerate_programs(g, max_depth;
-                action_space=action_space, min_log_prior=-20.0)
+                action_space=action_space, min_log_prior=min_log_prior)
             for (pi, p) in enumerate(programs)
                 tag = length(all_ck) + 1
                 push!(all_components, TaggedBetaPrevision(tag, BetaPrevision(1.0, 1.0)))
@@ -1511,7 +1514,8 @@ function handle_enumerate(params)
 
     state.grammars[grammar.id] = grammar
     n_added = add_programs_to_state!(state, grammar, max_depth;
-        action_space=action_space)
+        action_space=action_space,
+        min_log_prior=Float64(get(params, "min_log_prior", -20.0)))
 
     Dict("n_added" => n_added,
          "grammar_id" => grammar.id,
@@ -1528,11 +1532,14 @@ function handle_perturb_grammar(params)
     grammar = state.grammars[grammar_id]
 
     w = weights(state.belief)
-    # min_frequency is a posterior-weight threshold (weighted_frequency ≤ 1), so it must live in [0,1];
-    # the prior `2` was unsatisfiable and made every wire perturbation a no-op. Match the hosts' 0.01.
-    # (Finding 4, PR #160 adversarial review.)
+    # The extraction gate is learning policy — the consumer's, not the skin's (protocol
+    # 1.14; audit follow-up). min_frequency is a posterior-weight threshold
+    # (weighted_frequency ≤ 1), so it must live in [0,1] to be satisfiable — an
+    # unsatisfiable value makes every perturbation a structural no-op (Finding 4,
+    # PR #160 adversarial review; the old hardcoded default 0.01 is the fallback).
     freq_table = analyse_posterior_subtrees(state.all_programs, w;
-        min_frequency=0.01, min_complexity=2)
+        min_frequency=Float64(get(params, "min_frequency", 0.01)),
+        min_complexity=Int(get(params, "min_complexity", 2)))
 
     new_grammar = perturb_grammar(grammar, freq_table, all_features)
     state.grammars[new_grammar.id] = new_grammar
@@ -1549,7 +1556,8 @@ function handle_add_programs(params)
     haskey(state.grammars, grammar_id) || error("grammar not found: $grammar_id")
     grammar = state.grammars[grammar_id]
 
-    n_added = add_programs_to_state!(state, grammar, max_depth)
+    n_added = add_programs_to_state!(state, grammar, max_depth;
+        min_log_prior=Float64(get(params, "min_log_prior", -20.0)))
     Dict("n_added" => n_added,
          "n_components" => length(state.belief.components))
 end

--- a/apps/skin/server.jl
+++ b/apps/skin/server.jl
@@ -646,7 +646,10 @@ function build_grammar(spec)
         end
     end
     gid = next_grammar_id()
-    Grammar(gid, rules, features)
+    # 3-arg (feature_set, rules, id) convenience constructor — default per-feature
+    # threshold grid, computed complexity (types.jl). Argument order is load-bearing:
+    # asserted end-to-end by test_program_space_policy_params in test_skin.py.
+    Grammar(features, rules, gid)
 end
 
 # ═══════════════════════════════════════

--- a/apps/skin/test_skin.py
+++ b/apps/skin/test_skin.py
@@ -1358,6 +1358,63 @@ def test_structure_expect():
         skin.shutdown()
 
 
+def test_program_space_policy_params():
+    """Protocol 1.14: the program-space learning-policy knobs cross the wire as declared
+    data instead of being fixed skin-side — `min_log_prior` on create_state/enumerate/
+    add_programs (the enumeration floor), `min_frequency`/`min_complexity` on
+    perturb_grammar (the subtree-extraction gate). The asserted values are
+    engine-deterministic, calibrated at this exact grammar shape: 1 feature × 3 actions at
+    depth 3 enumerates 1323 programs (123 at min_log_prior=-6.0), and the best shared
+    subtree's weighted frequency ≈ 0.003 sits BELOW the old hardcoded 0.01 — so the fixed
+    skin default silently foreclosed a perturbation min_frequency=0.0 admits, which is
+    exactly why the knob must be the consumer's."""
+    skin = SkinClient()
+    try:
+        skin.initialize()
+        G = {"features": ["colour"], "rules": {}}
+        G2 = {"features": ["speed"], "rules": {}}
+        ACTIONS = ["food", "enemy", "flee"]
+
+        # (a) create_state: the enumeration floor bites.
+        s_def = skin._call("create_state", {
+            "type": "program_space", "grammars": [G], "max_depth": 3,
+            "action_space": ACTIONS})
+        assert s_def["n_components"] == 1323, f"default floor: {s_def['n_components']}"  # credence-lint: allow — precedent:test-oracle — deterministic enumeration count
+        s_res = skin._call("create_state", {
+            "type": "program_space", "grammars": [G], "max_depth": 3,
+            "action_space": ACTIONS, "min_log_prior": -6.0})
+        assert s_res["n_components"] == 123, f"restrictive floor: {s_res['n_components']}"  # credence-lint: allow — precedent:test-oracle — deterministic enumeration count
+
+        # (b) enumerate: the same floor threads through the verb path.
+        n_def = skin._call("enumerate", {
+            "state_id": s_res["state_id"], "grammar": G2, "max_depth": 3,
+            "action_space": ACTIONS})["n_added"]
+        assert n_def == 1323, f"enumerate default floor: {n_def}"  # credence-lint: allow — precedent:test-oracle — deterministic enumeration count
+        n_res = skin._call("enumerate", {
+            "state_id": s_res["state_id"], "grammar": G2, "max_depth": 3,
+            "action_space": ACTIONS, "min_log_prior": -6.0})["n_added"]
+        assert n_res == 123, f"enumerate restrictive floor: {n_res}"  # credence-lint: allow — precedent:test-oracle — deterministic enumeration count
+
+        # (c) perturb_grammar: the extraction gate is the consumer's. On the clean
+        # colour-only state the best subtree is under the 0.01 default, so: default
+        # no-ops (same grammar id — the no-op contract), min_frequency=0.0 extracts
+        # (fresh id), and unsatisfiable knobs no-op again.
+        sid = s_def["state_id"]
+        base = {"state_id": sid, "grammar_id": 1, "all_features": ["colour"]}
+        assert skin._call("perturb_grammar", dict(base))["new_grammar_id"] == 1, \
+            "default gate should no-op (same grammar id)"
+        opened = skin._call("perturb_grammar", {**base, "min_frequency": 0.0})
+        assert opened["new_grammar_id"] != 1, "min_frequency=0.0 must admit the extraction"
+        assert skin._call("perturb_grammar", {**base, "min_frequency": 1.1})["new_grammar_id"] == 1, \
+            "unsatisfiable min_frequency should no-op"
+        assert skin._call("perturb_grammar", {**base, "min_complexity": 1000})["new_grammar_id"] == 1, \
+            "unsatisfiable min_complexity should no-op"
+
+        print("PASS: program-space policy knobs (enumeration floor + extraction gate) are wire-declared")
+    finally:
+        skin.shutdown()
+
+
 def test_routing_verbs_roundtrip():
     """A non-embedding consumer drives EU-max model routing over the wire only: build the
     session (`routing_init`, warm counts inline), pick the EU-max model (`routing_decide`),
@@ -1428,7 +1485,7 @@ def test_initialize_returns_contract():
     skin = SkinClient()
     try:
         result = skin.initialize()
-        assert result["protocol"] == "1.13", f"protocol: {result.get('protocol')}"
+        assert result["protocol"] == "1.14", f"protocol: {result.get('protocol')}"
         assert "version" in result, "engine version missing"
         methods = result["methods"]
         # Core canalised verbs + the Move-3 structure-BMA verbs must be advertised.
@@ -1585,6 +1642,8 @@ if __name__ == "__main__":
     test_structure_decide_tail()
     print()
     test_structure_expect()
+    print()
+    test_program_space_policy_params()
     print()
     test_routing_verbs_roundtrip()
     print()

--- a/docs/precedents.md
+++ b/docs/precedents.md
@@ -117,6 +117,20 @@ The compact slug index lives in `CLAUDE.md` — that's what the lint reads to di
 **Escape hatch:** `# credence-lint: allow — precedent:untyped-mixture-construction — <reason>`. Admissible for deserialisation paths where types are recovered at parse time and the intermediate `Any[]` is a transient artefact.
 **Follows from Invariant 3** (single-responsibility representations: the container's element type is part of its representation, and `Any` conflates "I don't know the type" with "any type is allowed").
 
+**Slug:** `engine-template-guard`.
+**Context.** The decouple commitment moves probabilistic/EU *arithmetic* INTO the engine so wire consumers stay math-free ("a wire client ships the scalars, the engine does all the arithmetic" — `src/stdlib.jl`, `src/structure_bma.jl`). The price is a stratum of **domain templates** in engine code — `decide_with_voi` (the proceed/block/ask EVPI template), the routing state machine, the structure-BMA conveniences. Templates are the deliberate exception to engine minimality, and they are where consumer world-models creep inboard one coordinate at a time.
+**The guard.** A template (or a new template coordinate) may live engine-side only if ALL five hold:
+1. Every coefficient comes from **declared wire data** (utility scalars, belief references, declared functionals) — never from a constant the engine picks.
+2. All math is **canalised through the axiom ops** (`condition`/`expect`/`push`/`density` and their stdlib compositions, maximised by the one `optimise`).
+3. **No consumer identifiers** in code or docs (model names, app names, product rosters). Provenance comments are fine; consumer *semantics* are not.
+4. Every default is **documented and wire-overridable** (the `get(params, key, default)` idiom; the default named in `protocol.md`).
+5. Unsupported shapes **fail loud** with an informative error, never a silent approximation or a silent ignore.
+**Legal.** `decide_with_voi`'s coefficient assembly (all inputs are declared kwargs; the EVPI act/refrain/resolve triple is mathematical structure); `structure_decide`'s `tail` with a required consumer-declared `function` field; `alpha0`/`beta0`/`p_edge` as documented overridable defaults; `emission_prior` as an optional `routing_init` param.
+**Illegal.** The skin hardcoding `expect(tb, GeometricTail())` (the engine choosing the consumer's distributional world-model — redesigned as the declared `tail.function` field in 1.13); the skin fixing `min_frequency`/`min_complexity`/`min_log_prior` (learning policy the consumer could not override — exposed in 1.14); "OpenClaw's model" in a `src/` docstring.
+**Rewrite:** a coordinate that requires the engine to *choose* a functional, distribution, prior, or threshold for the consumer becomes a **declared field** in the wire request (Invariant 2 at the protocol boundary).
+**No pragma.** Documentation-only — this is a design-review checklist for template additions, not a line-level lint target. The audit surface is `protocol.md` diffs and template signatures.
+**Follows from Invariants 1 + 2 and the decouple commitment** (SPEC §6.9): no consumer math (Invariant 1 across the wire), no consumer modelling in the engine (true decoupling), declared structure at every boundary (Invariant 2). Sibling of the "reads are not decisions" contract (`structure_expect`, 1.13): that governs what *leaves* the engine; this governs what *enters* it.
+
 ## Specific derivations
 
 ### Indifference implies exploration

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -334,8 +334,9 @@ _pget(profile, key::AbstractString, default::Float64)::Float64 =
     route_decide(rt, features, roster, profile) -> Dict | nothing
 
 Resolve a routing decision over the LIVE roster (the user's actual models, sent per request)
-or the declared default roster. Returns `nothing` — body keeps OpenClaw's model — when fewer
-than 2 candidates exist. Per-request profile overrides reward/w_time with no daemon restart.
+or the declared default roster. Returns `nothing` — the caller keeps its incumbent model —
+when fewer than 2 candidates exist. Per-request profile overrides reward/w_time with no
+daemon restart.
 """
 function route_decide(rt::RoutingState, features, roster, profile = nothing)
     names, providers, ids, costs, tops = _resolve_roster(rt, roster)


### PR DESCRIPTION
Follow-up to #183, landing the engine-minimality audit's Tier-1 fixes plus the precedent that governs the class. Three separable commits (rebase-merge):

**1. `fix(skin): build_grammar bit-rot`** — the skin's program-space verbs (`create_state type=program_space`, `enumerate`) have been broken on master since the Grammar thresholds refactor changed the constructor to `(feature_set, rules, id)`; the skin still passed `(id, rules, features)` → `MethodError` on first use. Undetected because the wire suite had zero program-space coverage. Fixed, and the new test in commit 2 is the first wire coverage of that surface.

**2. `feat(skin): program-space learning-policy knobs become wire-declared (protocol 1.14)`** — the audit found three learning-policy constants hardcoded in the skin, invisible and un-overridable from the wire:

- `min_log_prior` (enumeration floor) — now a declared param on `create_state`, `enumerate`, and `add_programs` (default `-20.0`, documented);
- `min_frequency` / `min_complexity` (perturbation gate) — now declared params on `perturb_grammar` (defaults `0.01` / `2`, documented).

These are exactly the "engine picks the consumer's policy" shape the decouple commitment forbids: a hardcoded `0.01` frequency gate is a modelling commitment the consumer never declared. The calibrated wire test proves the point concretely — at the fixture's scale (1 feature × 3 actions × depth 3 ⇒ 1323 programs), the best shared subtree's weighted frequency (~0.003–0.0045) sits *below* the old hardcoded 0.01, so the silent default forecloses subprogram extraction that `min_frequency=0.0` admits. Protocol MINOR bump 1.13 → 1.14 with changelog; also documents `perturb_grammar`'s response shape (`new_grammar_id`; same id = structural no-op) and the `eu_interact` binary-outcome restriction.

**3. `docs: engine-template-guard precedent + consumer-name scrub`** — new documentation-only slug in CLAUDE.md + full prose in `docs/precedents.md`: domain templates may live engine-side only under the five-point guard (every coefficient from declared wire data; math canalised through axiom ops; no consumer identifiers; every default documented + wire-overridable; unsupported shapes fail loud). Founding legal cases: `decide_with_voi`'s declared coefficients and 1.13's `tail.function`; illegal cases include the skin-fixed knobs this PR retires. Also scrubs the one consumer identifier the audit found in engine code (`src/routing.jl` docstring: "OpenClaw's model" → "the caller keeps its incumbent model").

**Verification (all local gates green):**
- Wire suite: all tests incl. new `test_program_space_policy_params` — exit 0
- Julia core suite: 53/53 files, per-file exit codes checked
- credence-lint: 174 files, 0 violations; corpus self-test green
- Protocol invariant: server `PROTOCOL_VERSION` == protocol.md header == 1.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)