### PR TITLE
fix(program-space): target-scoped compression candidates — no cross-grammar dangling nonterminals

### DIFF
--- a/src/program_space/perturbation.jl
+++ b/src/program_space/perturbation.jl
@@ -190,7 +190,7 @@ collect_feature_refs!(acc::Set{Symbol}, e::IfExpr) =
 # ═══════════════════════════════════════
 
 """
-    _compression_payoff(table) → Union{Tuple{ProductionRule, Int}, Nothing}
+    _compression_payoff(table[, defined_nonterminals]) → Union{Tuple{ProductionRule, Int}, Nothing}
 
 The best `:add_rule` candidate and its description-length payoff (symbols saved), or `nothing` if no
 posterior subtree compresses (payoff ≤ 0). Defining the most-frequent subtree `s` as a nonterminal
@@ -201,10 +201,33 @@ the rule once (cost `1 + expr_complexity(s)`):
 
 This is the two-part-MDL saving (CLAUDE.md §1.3). It is the single home of the payoff arithmetic,
 shared by `propose_nonterminal` (the gate) and `net_voc` (the value), so the two never drift.
+
+`defined_nonterminals` — the TARGET grammar's rule names — restricts the argmax to subtrees whose
+`NonterminalRef`s all resolve in that grammar. The frequency table spans the posterior over ALL
+grammars, so the globally best subtree may reference a nonterminal defined only in its ORIGIN
+grammar's rules; installing it elsewhere creates a dangling reference and every later enumeration
+of that lineage crashes in `compile_expr` ("Undefined nonterminal" — the 2026-07-03 gate-run
+regression). `nothing` preserves the un-targeted legacy form (`propose_nonterminal`'s surface).
+Asserted by test_perturb_consumption.jl §6.
 """
-function _compression_payoff(table::SubprogramFrequencyTable)::Union{Tuple{ProductionRule, Int}, Nothing}
+function _compression_payoff(table::SubprogramFrequencyTable,
+                             defined_nonterminals::Union{Nothing, Set{Symbol}} = nothing
+                            )::Union{Tuple{ProductionRule, Int}, Nothing}
     isempty(table.subtrees) && return nothing
-    best_idx = argmax(table.weighted_frequency)
+    best_idx = 0
+    if defined_nonterminals === nothing
+        best_idx = argmax(table.weighted_frequency)
+    else
+        best_w = -Inf
+        for i in eachindex(table.subtrees)
+            table.weighted_frequency[i] > best_w || continue
+            refs = collect_nonterminal_refs!(Set{Symbol}(), table.subtrees[i])
+            issubset(refs, defined_nonterminals) || continue
+            best_idx = i
+            best_w = table.weighted_frequency[i]
+        end
+        best_idx == 0 && return nothing
+    end
     best_expr = table.subtrees[best_idx]
     n_sources = length(table.source_programs[best_idx])
     expr_c = expr_complexity(best_expr)
@@ -367,10 +390,15 @@ function _best_compression_candidate(g::Grammar, freq_table::SubprogramFrequency
                                      compute_cost::Float64 = 0.0)::Union{Nothing, PerturbationCandidate}
     best = nothing  # the running argmax (a PerturbationCandidate); see _candidate_better
 
-    add = _compression_payoff(freq_table)
+    # Target-scoped :add selection: only subtrees whose NonterminalRefs resolve in THIS grammar
+    # are candidates (the dangling-reference guard — _compression_payoff docstring). Because the
+    # validity filter lives here in the shared core, perturb_grammar (the transition),
+    # perturbation_voc (the score), and compression_exhausted (the signal) agree by construction.
+    rule_names = Set(r.name for r in g.rules)
+    add = _compression_payoff(freq_table, rule_names)
     if !isnothing(add)
         rule, net_payoff = add
-        if !(rule.name in Set(r.name for r in g.rules))         # idempotence guard (already-present name)
+        if !(rule.name in rule_names)                           # idempotence guard (already-present name)
             v = net_voc(net_payoff, compute_cost)               # VOC gate (forward compute priced in)
             v > 0 && (best = _pick_better(best, PerturbationCandidate(v, false, string(rule.name), :add, rule)))
         end

--- a/test/test_perturb_consumption.jl
+++ b/test/test_perturb_consumption.jl
@@ -17,6 +17,7 @@ using Credence: Grammar, ProductionRule, SubprogramFrequencyTable, ProgramExpr, 
                 perturb_grammar, analyse_posterior_subtrees, enumerate_programs, compile_kernel,
                 add_programs_to_state!, ExploreObservation, AgentState, weights, show_expr
 using Credence: TaggedBetaPrevision, BetaPrevision, MixturePrevision, CompiledKernel
+using Credence: NonterminalRef, collect_nonterminal_refs!, perturbation_voc, propose_nonterminal
 
 function check(name, cond, detail = "")
     cond ? println("PASSED: $name") : (println("FAILED: $name — $detail"); error("fail: $name"))
@@ -92,6 +93,68 @@ let
           "expected a non-empty table")
     check("min_frequency=2 (>1) is unsatisfiable ⇒ empty table (the Finding-4 bug)",
           isempty(ft_bad.subtrees), "a >1 weighted-frequency threshold cannot be met")
+end
+
+# ── (4) cross-grammar dangling nonterminal (the 2026-07-03 gate-run regression) ──
+# The frequency table spans the posterior over ALL grammars. The globally best subtree may
+# reference a nonterminal defined only in its ORIGIN grammar; installing it into another grammar
+# creates a dangling NonterminalRef, and every later enumeration of that lineage crashes in
+# compile_expr ("Undefined nonterminal"). The fix: _compression_payoff's argmax is scoped to
+# subtrees whose refs resolve in the TARGET grammar — shared by perturb_grammar (transition),
+# perturbation_voc (score), and compression_exhausted (signal), so the three stay one function.
+let
+    origin_rule = ProductionRule(:NT_ORIGIN, GTExpr(FeatureRef(:red), 0.7))
+    gA = Grammar(Set([:red, :blue]), [origin_rule], 41)          # defines :NT_ORIGIN
+    gB = Grammar(Set([:red, :blue]), ProductionRule[], 42)       # does NOT
+
+    # The dominant subtrees reference :NT_ORIGIN (4 sources × 0.2); plain, fully-resolvable
+    # subtrees are next (3 sources × 0.15). All have positive MDL payoff.
+    nt_subtree = AndExpr(NonterminalRef(:NT_ORIGIN), GTExpr(FeatureRef(:red), 0.7))
+    plain_subtree = AndExpr(GTExpr(FeatureRef(:red), 0.7), LTExpr(FeatureRef(:blue), 0.3))
+    progs = Program[]
+    for _ in 1:4
+        push!(progs, Program(IfExpr(nt_subtree, ActionExpr(:a), ActionExpr(:b)), 6, gA.id))
+    end
+    for _ in 1:3
+        push!(progs, Program(IfExpr(plain_subtree, ActionExpr(:a), ActionExpr(:b)), 6, gB.id))
+    end
+    w = [fill(0.2, 4); fill(0.15, 3)]
+    ft = analyse_posterior_subtrees(progs, w; min_frequency = 0.0, min_complexity = 2)
+
+    proposed = propose_nonterminal(ft)   # the un-targeted legacy surface: global argmax
+    check("(4) precondition: the GLOBAL best subtree references the origin-only nonterminal",
+          proposed !== nothing && :NT_ORIGIN in collect_nonterminal_refs!(Set{Symbol}(), proposed.body),
+          "proposed=$(proposed === nothing ? "nothing" : show_expr(proposed.body))")
+
+    # Target B (lacks :NT_ORIGIN): the invalid subtrees are skipped; the best RESOLVABLE subtree
+    # is installed instead — never a dangling reference.
+    gB2 = perturb_grammar(gB, ft)
+    check("(4) perturbing the foreign grammar still compresses (fallthrough to a valid subtree)",
+          gB2.id != gB.id && length(gB2.rules) == 1, "id=$(gB2.id) rules=$(length(gB2.rules))")
+    check("(4) the installed rule has NO dangling refs (B has no other rules ⇒ refs must be empty)",
+          isempty(collect_nonterminal_refs!(Set{Symbol}(), gB2.rules[1].body)),
+          show_expr(gB2.rules[1].body))
+
+    # The crash repro: enumerate + compile the perturbed lineage — must not throw.
+    for (pi, p) in enumerate(enumerate_programs(gB2, 3; action_space = Symbol[:a, :b]))
+        compile_kernel(p, gB2, pi)
+    end
+    check("(4) enumerate + compile of the perturbed lineage does not crash", true)
+
+    # Target A (defines :NT_ORIGIN): targeting must not block valid installs — every installed
+    # rule's refs resolve within A's own rules.
+    gA2 = perturb_grammar(gA, ft)
+    rule_names_A = Set(r.name for r in gA2.rules)
+    check("(4) the origin grammar still compresses, with every ref resolvable there",
+          gA2.id != gA.id &&
+          all(issubset(collect_nonterminal_refs!(Set{Symbol}(), r.body), rule_names_A)
+              for r in gA2.rules))
+
+    # Score == transition: VOC is positive exactly when the executor changes the grammar,
+    # for both targets (the shared _best_compression_candidate core).
+    check("(4) perturbation_voc > 0 ⟺ perturb_grammar changes the grammar (both targets)",
+          (perturbation_voc(gB, ft) > 0.0) == (gB2.id != gB.id) &&
+          (perturbation_voc(gA, ft) > 0.0) == (gA2.id != gA.id))
 end
 
 println("="^64)


### PR DESCRIPTION
## What

A latent master bug, extracted from the belief-derived-valuation work because it is independent of that design: the posterior frequency table spans ALL grammars, and the perturb executor installs the globally best subtree into each of the top-3 grammars. A subtree referencing an origin grammar's nonterminal, installed into a grammar lacking that rule, dangles — and every later enumeration of that lineage crashes in `compile_expr` ("Undefined nonterminal").

Reproduced live: it aborted the first belief-derived-valuation gate re-run attempt on its very first cell (the new horizon-boosted growth dynamics reach perturb+explore interleavings the old entropy-shadowed dynamics never did). On PR #189 as committed the bug is dodged (perturb is `-Inf`'d pending the removal-consumption design), not fixed — it returns the moment perturb re-enables.

## How

`_compression_payoff` gains a target-validity filter: with the TARGET grammar's rule names, the argmax ranges only over subtrees whose `NonterminalRef`s all resolve there (fallthrough to the best resolvable subtree, not a blanket no-op). Applied inside `_best_compression_candidate` — which `perturb_grammar` (transition), `perturbation_voc` (score), and `compression_exhausted` (signal) all share, so the three stay one function by construction (CONSTITUTION §3.55). `propose_nonterminal` keeps its un-targeted legacy surface.

## Verification

`test_perturb_consumption.jl` §4: the crash repro (enumerate + compile of a perturbed foreign lineage), fallthrough-to-valid-subtree, origin-grammar installs unaffected, and `voc > 0 ⟺ grammar-changed` agreement on both targets. Locally green: test_perturb_consumption, test_voc_gate, test_compression_removal, test_program_space (on this master-based branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)