### PR TITLE
docs(exploration-budget): removal-consumption design — replacement semantics for applied removals

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,0 +1,153 @@
+# Tractatus Credentiae
+
+*Second edition. A constitution for the Credence agent, after the manner of the Tractatus. Consolidates the record through July 2026: Postures 3–5, measure-as-view, collapse-towers, exploration-budget, decouple, and the reflective-closure adjudication. What can be decided at all can be decided by expected utility; and whereof one cannot compute, thereof one must abstain.*
+
+---
+
+**1 The world of the agent is the totality of its beliefs, not of facts.**
+
+1.1 A belief is a prevision: a coherent linear functional on a declared space of test functions. (de Finetti 1974; Whittle 1992.) Expectation is primary; probability is the prevision of an indicator; a Measure is a declared view over a Prevision, never itself the primitive.
+
+1.11 The warrant is coherence, not measure theory. An agent whose credences cannot be Dutch-booked updates by conditioning (Lewis, for sequences); finite additivity suffices (Regazzini). σ-additivity is retained where it earns its keep — as machinery for continuous carriers, never as justification.
+
+1.2 Events are first-class bearers of probability: declared propositions, not derived subsets of a measurable space. P(A) is declared directly, and conditioning on an event is a primitive beside conditioning on a kernel.
+
+1.21 The two forms of conditioning are peers; neither derives from the other. They provably coincide on deterministic events (Di Lavore–Román–Sobociński, Prop. 4.9). On continuous observation spaces the event "the kernel emitted exactly this" has measure zero, and honesty prefers two primaries to sugar over an undefined disintegration.
+
+1.3 The agent never possesses the world; it possesses a posterior. What has not been observed enters only through the prior, and the prior is the honest statement of ignorance, not an embarrassment to be minimised.
+
+1.4 The world changes. Change is content, never mechanism.
+
+1.41 There is no forgetting. Decay, tempering, and forgetting factors are a second learning mechanism in disguise. If the world drifts, drift-rate lives in the hypothesis space, where `condition` can learn it like anything else.
+
+1.42 When preferences change, predictions fail, surprise rises, the posterior disperses, and the agent grows consultative again. Re-engagement is a consequence of posterior dynamics; no change-point detector is bolted on.
+
+---
+
+**2 Five commitments are given. Everything else is learned.**
+
+2.01 The commitments are theorems where theorems exist and disciplines where they do not, and the constitution says which is which. Coherence, EU-representation, and conditioning are forced (Cox; Savage; de Finetti). One-learning-mechanism-one-decision-mechanism is engineering discipline — not proved by the theorems, but what it takes to implement them without the code disagreeing with itself.
+
+2.1 **condition.** Beliefs change only by Bayesian conditioning: the unique update under diachronic coherence, and the unique rule for which updating and prediction commute (Amarante).
+
+2.2 **expect.** Predictions are integrals over belief. Nothing is predicted by a point.
+
+2.3 **optimise.** Actions maximise expected utility, and there is no mechanism outside EU-maximisation — not random, not capped, not scheduled.
+
+2.31 The argmax ranges over policies, not acts, wherever the world contains predictors of the agent — including the agent. Mixed play is *selected*, never injected: on matching pennies the mixed policy strictly dominates every pure one in security value, so the equilibrium is an argmax, not a sprinkle. Thompson sampling is a VOI estimator and a proof device, not a primitive.
+
+2.32 Heuristics live inside EU-max, not alongside it. When computation is priced, an approximation may be the optimal strategy — at which point it is not an approximation but the answer, implemented as a backend of the axiom operations and chosen by the same machinery that chooses everything else.
+
+2.4 **The complexity prior.** The prior over programs is 2^(−|program|) — the only inductive bias. It truncates both towers, models-of-models and reasoning-about-reasoning, so that neither regresses. Occam is not a heuristic here; Occam is the prior.
+
+2.41 Fineness is already priced: a threshold drawn from an *n*-point grid costs log₂ *n* bits. Refinement is charged in the prior or in the predictive marginal likelihood — routes interchangeable only for the marginal; a point-estimate score has no Occam and would chase refinement forever, whereupon the prior route becomes mandatory.
+
+2.5 **The alignment commitment.** The agent's utility is the user's utility, unknown, inferred from behaviour. (CIRL.) The commitment defines the objective, not the solution, and cannot be gamed because the ground truth arrives from outside the agent.
+
+2.51 Corrigibility is a theorem of 2.3 and 2.5, not a rule. Deference under uncertainty, autonomy under confidence: the incentive to defer is proportional to the variance of the belief about what is wanted.
+
+2.52 The theorem's protection vanishes at convergence. An agent confidently wrong about preferences acts confidently and wrongly. This is recorded as an open problem, not painted over.
+
+2.53 The agent learns revealed preferences by default. Whether to launder them into idealised ones is an observation-model choice — philosophically unresolved, and stated as such rather than smuggled in.
+
+2.6 The axioms fix criteria, never content. Whatever fixes content is hand-tuning in disguise, and belongs in the learned interior under an existing criterion.
+
+2.61 Hence: no hardcoded thresholds, no magic scalars. Every constant is data-derived and priced by the complexity prior, or it is a confession. New primitives are decision-free combinators — total, domain-independent, parameter-free or carrying a slot the data fills. A primitive that bakes in a decision injects an answer, not a prior.
+
+2.7 Derived quantities are not axioms. VOI is the EU of observe-then-act minus the EU of act-now; asking the user is an action among actions; the ask-versus-act transition emerges from one argmax, never from a side-channel.
+
+2.8 Reflective closure — the one surviving candidate for a sixth axiom — dissolves by derivation. Clean zero-sum: minimax within policy-level EU; the mixed policy wins by argmax. Clean cooperative twins: the diagonal reduction must be *earned* — licensed outright under identical source, and under approximate correlation licensed iff ρ > (T−S)/[(R−P)+(T−S)]. No axiom, no frozen-type change. The residue is one named open problem — exact policy-level VOI against arbitrary computable peers — deferred until a use-case makes it bind.
+
+2.81 The methodological precedent stands above the result: derivation decides the constitution; simulation decides the code; a green experiment is never constitutional vindication, because a repo full of green runs would mask precisely the hole they cannot detect. Falsify in the engine, stall honestly at the boundary, amend the constitution only when derivation fails.
+
+2.9 Any admissible decision procedure is a Bayes rule with respect to some prior and utility (Wald); and the agent's utility must be the belief-weighted sum (Harsanyi). This architecture is not one principled approach among several. It is the closure of all of them.
+
+---
+
+**3 A program is a picture of a policy.**
+
+3.1 Programs are options in Sutton's sense: closed-loop policies, re-evaluated against the world at every step. Polling execution is proved better than committing; a plan that does not look is not a policy but a hope.
+
+3.11 There is no `BeginExpr`. Open-loop sequencing is rejected permanently.
+
+3.2 Programs reference named features; features are `Dict{Symbol, Float64}`. The brain knows what it is looking at — factored state (Boutilier), typed objects (Diuk), symbols determined by the agent's own skills (Konidaris). Names are not labels; they are the condition of generalisation.
+
+3.21 A missing feature is 0.0. Programs referencing senses not yet connected sleep, harmlessly false, until their connections arrive — then wake, compete, and prove their worth. Adaptation to a growing world is not a mechanism but a default value.
+
+3.3 The grammar is the prior made syntactic. The basis *is* the prior; enrichment is justified by compactness under the complexity prior, never by expressiveness. What the basis cannot say briefly, it effectively cannot learn.
+
+3.31 There are no stages. Reactive, conditional, deliberative are depths of one program space; depth is explored under the same prior that governs everything. The designer does not choose.
+
+3.4 Concepts emerge in five layers from one mechanism at five timescales: raw primitives; abstractions; preference models; meta-regularities; inductive bias. The inductive bias is not installed. It is the stable core that survives.
+
+3.5 Computation is action. Meta-actions — enumerate more, perturb the grammar, deepen — stand in the action space beside domain actions and are chosen by the same argmax (Russell–Wefald). The strange loop is not confusion: the machinery is immutable and the hypothesis space is not. The agent changes what it thinks about, never how it thinks.
+
+3.51 The metalevel is the same `optimise` as the object level. One complexity log-prior, per-axis, never shared; one net-value functional, E[Δvalue | action] − cost. The `rand` is gone from selection; nothing chooses but EU.
+
+3.52 Compression and exploration are categorically distinct meta-actions. Compression re-describes the hypotheses already held — a prior effect, valued exactly at depth one. Exploration changes what can be said, and its value lives on the Cromwell frontier — hypotheses not yet entertained — visible only against the belief's predictive residual, never from the prior alone. One cannot price the value of a thought one has not had except by where one's predictions fail.
+
+3.53 One currency — Δ log-evidence — at two fidelities: the cheap prior-only surrogate and the exact re-conditioned lookahead. The cascade between fidelities is itself an EU decision on the cost of evaluation. There is no second currency; there is only cheaper and dearer knowledge of the one.
+
+3.54 Meta-actions terminate naturally: each reduces the entropy that made the next one valuable, while the waiting world accumulates cost. The agent thinks exactly as long as thinking beats acting.
+
+3.55 The score and the transition must be one function. A meta-action valued by one formula and executed by another has quietly become two reasoners.
+
+---
+
+**4 The brain is pure mathematics. Four types are frozen: Space, Prevision, Event, Kernel.**
+
+4.01 Everything else is a function over the four. The vocabulary is open — new distributions, new spaces, new event forms may be added; the semantics are closed.
+
+4.1 Three invariants bind the code. They are independent — any two can hold while the third fails — and equally constitutional.
+
+4.11 *Single reasoner*, two faces. Spatial: arithmetic on probabilities and utilities happens only in the engine. Topological: within the engine, all such arithmetic is canalised through the axiom-constrained functions and their stdlib compositions. The answer to "I need to compute X from the posterior" is always: declare X as a functional and call `expect`.
+
+4.12 *Declared structure.* Functions handed to axiom operations carry their algebra in their type. An opaque closure is a correctness hazard, not merely a slow path: inferred structure misfires on legitimate edge cases, and probing outputs to guess structure hides the assumption from the type system.
+
+4.13 *Single-responsibility representations.* One datum, one semantic role. The compiled kernel has no syntax tree; the program keeps its tree for analysis; log-weights are private and probabilities public. Conflation fails as silent drift.
+
+4.2 A posterior over models is carried, never collapsed. Decisions marginalise over model uncertainty; the argmax ranges over actions only. "Pick the winning model" is a parallel decision mechanism by another name. Where commitment to one model is genuinely warranted, *which* model is itself an `optimise` under a carrying-cost utility — never argmax of posterior weight.
+
+4.3 Exactness is the engine's promise. An EU failure is a bug, never a fallback; an approximation announces itself in the type.
+
+4.4 `draw` is the boundary: the only source of randomness, host-side, outside the DSL. The DSL constructs the posterior; it does not sample. Purity is not asceticism; it is what makes the belief a belief rather than a trajectory.
+
+4.5 The constitution is statute and case law together. Precedents carry stable slugs; escape hatches demand a named precedent and a stated reason; a violation that cannot name what sanctions it is not sanctioned. Novel cases amend the case law in the same change that relies on them — new escape hatches are constitutional amendments, not inline concessions.
+
+---
+
+**5 The skin translates. It never computes. The wire is the only public surface.**
+
+5.1 The brain does not hand a live belief over a wire; it hands a handle. State stays server-side as opaque identifiers, so a consumer never holds a measure and *physically cannot* do arithmetic on one. The single-reasoner invariant holds on the far side of the wire by construction, not by discipline.
+
+5.2 Applications declare their domain as data — spaces, kernels, priors, functionals — and call the canalised verbs. They carry no probabilistic code of their own.
+
+5.3 The decoupling commitment: Credence is the engine; an application gets data and a thin body, never a brain; and the engine does not ship the means for an application to host one. In-process embedding *is* hosting a brain, and is forbidden outside artefacts co-released with the engine itself.
+
+5.4 Engine-side templates live under guard: every coefficient from declared wire data, all arithmetic canalised, every default overridable, unsupported shapes failing loud. A template coordinate that would have the engine *choose* for its consumer is redesigned as a declared field. The engine computes; it does not opine.
+
+5.5 Wire reads are windows, not decision channels. A read that feeds an action has become a second reasoner.
+
+---
+
+**6 The body is embodiment: sensors, actuators, orchestration. It decides *how*, never *what*.**
+
+6.1 A connection registers three things: named features, named actions, declared events — what it can sense, what it can do, what may be conditioned on. Adding a connection teaches the agent new words and new propositions, never new rules. No index shifts, nothing breaks; the dormant awaken (3.21).
+
+6.2 One agent per user. Connections are event sources, not agents; every observation from every connection conditions the same belief.
+
+6.3 An LLM is a prosthetic and itself a connection: sensor apparatus that enriches features, effector apparatus that renders actions. It is used when EU says so, priced like any action; the prompt is part of the program and pays description length. It is part of the body. No belief passes through it.
+
+6.4 Cheap design: the body's constraints do part of the brain's work for free. Physics prunes the hypothesis space; failed actions are evidence; constraints are discovered through use, not specified in advance. Consent is such a constraint — an embodiment fact, not a rule the agent weighs.
+
+6.5 The body is learned as a baby learns its hands: the vocabulary given like muscles, the affordances learned like reaching. Skills are closed-loop policies compressed into nonterminals, not memorised sequences.
+
+6.6 The universal actuator is `exec(argv, stdin, cwd, env) ↔ (stdout, stderr, exit, resources)` — the body's analogue of the universal prior, with the same universality argument. Higher-level actions are pre-cached compositional discoveries, justified by rediscovery cost.
+
+6.7 No arithmetic on probabilities or utilities exists outside the brain. Every specific prohibition in the codebase follows from this one sentence. An application that computes an expected value, compares actions on probabilistic grounds, or updates a belief by hand is a bug, whatever its test suite says.
+
+6.8 Three residues cannot be learned, and each is physics rather than tuning: the *alphabet* — the encoding the prior is relative to, eroded by grammar growth but never eliminated (the invariance constant is real); the *clock* — the world's interruptions and accumulating costs, which terminate the meta-regress from below (3.54); and the *pointer* — the designation of whose utility, the one wire that cannot be inferred from its own signal. Everything else is interior.
+
+---
+
+**7 Whereof the brain has not computed, thereof the body must be silent.**

--- a/docs/exploration-budget/removal-consumption-design.md
+++ b/docs/exploration-budget/removal-consumption-design.md
@@ -1,0 +1,277 @@
+# Removal consumption — replacement semantics for applied compression-class removals
+
+> Exploration-budget arc, follow-up to belief-derived valuation (#188/#189 deviation 3). Design-doc-before-code;
+> ratify before any code lands. Master plan: `docs/exploration-budget/master-plan.md`. Predecessors on master:
+> coherent injection (#187 — hypothesis addition commutes with conditioning), belief-derived valuation (#189 —
+> `:gw_perturb_grammar` provisionally `-Inf` pending exactly this document). Constitutional grounding:
+> `CONSTITUTION.md` (Tractatus Credentiae, 2nd ed.) — clauses cited inline as T-x.y. Authored 2026-07-03.
+
+---
+
+## 1. Purpose
+
+Give applied compression-class **removals** (`:remove_rule`, `:remove_feature`) replacement semantics — the
+edited grammar **replaces** its ancestor instead of standing beside it — so that the MDL reclaim the score
+promises is realised in the belief, the consumed grammar can never re-propose the same edit, and
+`:gw_perturb_grammar` re-enters the meta-action argmax it was provisionally `-Inf`-ed out of in #189.
+
+**The bug, constitutionally stated.** Today an applied removal on grammar `g` mints a cleaned **sibling**
+`g′` with a fresh id and coherently injects `g′`'s enumeration as *new components*, leaving `g`'s
+evidence-rich incumbents untouched. Three violations, one mechanism:
+
+- **T-3.55 (score/transition unity).** `perturbation_voc` scores the edit as `+λ·k` nats of prior reclaim;
+  the sibling transition realises *none* of it — the incumbents keep their dirty prior, the newcomers
+  duplicate them at near-zero posterior mass. A meta-action valued by one formula and executed by another
+  has quietly become two reasoners. This is the same disease #187 cured for injection, one seam over.
+- **T-3.52 (compression is re-description).** Compression *re-describes the hypotheses already held* — a
+  prior effect. Sibling injection executes a re-description as if it were *exploration* (adding hypotheses):
+  a category error, and the source of the duplicate-component dilution.
+- **The treadmill (the instrumented failure).** `g` stays registered and evidence-rich, so it stays top-k;
+  next step `perturb_grammar(g, …)` proposes the *same* removal, mints *another* sibling, injects *another*
+  duplicate set — `+log 2` of phantom VOC forever, 3 ops/step in the smoke run that forced deviation 3.
+  Under replacement the ancestor is *consumed*: the candidate disappears because its grammar does. The
+  treadmill becomes unrepresentable — the #187 move (make the misspecification inexpressible), applied to
+  perturbation.
+
+**The transition (derived, not designed).** Let `g` carry a dead item of payoff `k` symbols,
+`g′ = clean(g)`, `Δ = λ·(complexity(g) − complexity(g′)) = k·log 2` (λ pinned to `log 2`, SPEC §1.3;
+implementation computes Δ from the two actual complexities, never from assumed `k`). Every live component of
+group `G = {i : metadata[i] = (g.id, ·)}` has a program that is expressible unchanged in `g′` (that is what
+*dead* means, once the reference count is sound — §2) with an **identical compiled kernel**, hence identical
+likelihood on the entire observation history. The counterfactual agent that started with `g′` in place of
+`g` therefore holds, after the same history, exactly
+
+    lw′_i = lw_i + Δ·1[i ∈ G]        (unnormalised; Beta posteriors, tags, kernels, programs identical)
+
+because every likelihood term cancels in the ratio and only the grammar-complexity prior term differs. The
+replacement transition — re-key `metadata[i ∈ G]` to `g′.id`, shift `log_weights[i ∈ G] += Δ`, delete `g`
+from `state.grammars`, register `g′` — is the **unique** map satisfying *replacement commutes with
+conditioning*, the same criterion that derived #187's two-ledger injection. It is exact for the **full**
+history, not a window: stronger than replaying (which #187 needs because newcomers have no evidence to
+cancel), because here the likelihoods cancel identically. Derivation decides the constitution (T-2.81);
+§4 traces it concretely and the test asserts it.
+
+**The score (the same function as the transition, T-3.55).** The realised Δ log-evidence of firing, against
+the current posterior:
+
+    replacement_value = log(1 + (e^Δ − 1)·W_G)        [nats],   W_G = posterior mass of group G
+
+with `W_G` read canalised as `probability(state.belief, TagSet(group tags))` (the Prevision-level read
+landed in #189). Score and transition share one candidate function (§2), so they cannot drift — the
+`perturbation_voc`/`perturb_grammar`/`compression_exhausted` shared-`_best_compression_candidate` discipline,
+extended to the replacement path. The prior-only `voc = Δ` is this score's `W_G → 1` limit; §5 Q3 argues the
+exact form is mandatory here, not optional.
+
+**Resolved decisions** (answers forced; recorded here, not §5):
+
+- **Execution semantics change for every policy, baselines included.** Policies differ in *when* they fire
+  meta-actions (selection); the ops themselves are shared machinery (transition). A benchmark whose baselines
+  execute a *different, incoherent* op is not comparing policies. The `baseline-comparison` precedent scopes
+  Invariant 1 to selection mechanisms, not to op implementations. Gate re-run re-baselines everything.
+- **No re-enumeration on replacement.** Removal only shrinks the language (`L(g′) ⊆ L(g)`); there is nothing
+  new to enumerate. Replacement adds zero components — `n_added_meta` stays 0 and the host's epoch bump gains
+  an explicit `applied_replacement` trigger (§2).
+- **No `GrowthReturns` cell for perturb.** The op's consequence is deterministic and exactly computable
+  pre-fire; there is nothing to learn (T-2.32: when the exact value is affordable, it *is* the answer).
+  Escape ops keep their learned cells; perturb is scored by its realised value directly.
+- **`reset_learning_regime!` stays on applied replacement.** Pure re-description leaves likelihoods intact,
+  but the cross-group renormalisation jolts the predictive stream the residual regime models; the Q1b
+  rationale (a *caused* change-point the agent knows about) applies. Cheap, conservative, and symmetric with
+  every other grammar change.
+- **The sibling path is retired, not kept beside the replacement path.** One edit, one semantics
+  (Invariant 3); a host that wants the old behaviour is a host that wants the treadmill.
+
+**Out of scope, named for the queue:** `:add_rule` consumption (re-expressing incumbents under the new
+dictionary — an AST rewrite with per-program Δ; §5 Q2 sequences it); winner's-curse pricing on growth
+selection (the remaining worst-seed driver — separate doc); escalate-depth (deepen's re-entry — drafted
+separately).
+
+## 2. Files touched
+
+- **`src/program_space/perturbation.jl`** (modification, ~70 lines).
+  - `ReplacementCandidate` struct — declared edit: `kind::Symbol` (`:remove_rule | :remove_feature`),
+    `payload::Union{ProductionRule, Symbol}`, `payoff_symbols::Int`, `gid::Int`. First-class declared type
+    (Invariant 2), mirroring `PerturbationCandidate`.
+  - `replacement_candidates(state::AgentState, gid::Int) → Vector{ReplacementCandidate}` — the **sound,
+    group-local, live-state** dead-item enumeration: reference sets collected over **every** component of
+    group `G` (no weight cut of any kind) unioned with `g.rules` bodies, via the existing
+    `collect_nonterminal_refs!`/`collect_feature_refs!` walks. This is the OQ-4 discharge: the
+    `SubprogramFrequencyTable` walk cuts support at `w > 1e-15`, which is a *value*-appropriate screen but
+    not a soundness guarantee — post-prune components can sit below it (prune keeps relative-to-max
+    `> e⁻³⁰ ≈ 9.4e-14`; normalised weight divides by up to `max_components`, so a live component can hold
+    `< 1e-15`). Re-keying a component whose program references the removed item would put a program outside
+    its grammar's language — unsound, not merely suboptimal — so the soundness predicate must be exact and
+    must not share a representation with the frequency estimate (Invariant 3 / T-4.13: one datum, one role).
+    Group-local is also *sharper* than the table's global sets: a feature referenced only by *another*
+    grammar's programs is dead **for `g`**. The table keeps serving proposal-time value; it no longer
+    gates soundness.
+  - `replacement_value(state, gid; compute_cost) → Float64` and
+    `best_replacement(state, gid) → Union{ReplacementCandidate, Nothing}` — score = `net_value(log1p((exp(Δ)
+    − 1)·W_G), compute_cost)` for the best candidate; both route through `replacement_candidates`, so the
+    scored candidate and the applied candidate are the same object by construction (T-3.55).
+- **`src/program_space/agent_state.jl`** (modification, ~45 lines).
+  - `replace_grammar_in_state!(state, cand::ReplacementCandidate) → Grammar` — builds `g′` (threading
+    `g.thresholds`, the Move-3 grid-survival discipline), computes `Δ` from the two actual complexities,
+    re-keys `metadata`, shifts the group's `log_weights` by `Δ`, reconstructs the `MixturePrevision`
+    (constructor normalises — the shift is cross-group, which is the point), deletes `state.grammars[gid]`,
+    registers `g′`. Tags, Beta posteriors, kernels, programs untouched — strictly less invasive than
+    `sync_prune!`. Docstring carries the §1 commutation derivation and names the test that asserts it
+    (executable-documentation discipline). **This is the constitutional write** — see the precedent below.
+- **`docs/precedents.md` + `CLAUDE.md` slug index** (modification). New precedent slug
+  **`coherent-space-edit`**: a `src/`-resident hypothesis-space edit (inject / re-key / consume) may write
+  mixture log-weights **iff** the write is the unique solution of the commutation equation — the state after
+  the edit equals the state of the counterfactual agent that held the edited space from the start and
+  conditioned on the same history — and the equality is asserted by a named test. Anything short of that
+  criterion is a second learning mechanism. Retroactively covers #187's ledger arithmetic (which currently
+  leans on `stdlib-composition` by residence); prospectively covers this move. Lands in the same PR that
+  relies on it (T-4.5: new escape hatches are constitutional amendments, not inline concessions).
+- **`apps/julia/grid_world/host.jl`** (modification, ~30 lines net). Delete the deviation-3 PROVISIONAL
+  block; score `:gw_perturb_grammar = max over top-k gids of replacement_value(state, gid;
+  compute_cost = op_compute_cost)`; execute via `best_replacement` + `replace_grammar_in_state!` on the
+  argmax gid; epoch bump trigger extended to `applied_replacement` (replacement adds 0 components, so the
+  current `n_added_meta > 0` trigger alone would miss it); `reset_learning_regime!` on application.
+- **`test/test_replacement.jl`** (new, ~6 sections): §1 commutation — replacement then N conditioning steps
+  `==` clean-start-with-`g′` then same steps (normalised weights `≤ 1e-12` for summation order; Beta params
+  and tags exact `==`); §2 treadmill regression — fire, then `replacement_value` on the successor is `0.0`
+  and `best_replacement` is `nothing` (the candidate died with its grammar); §3 the OQ-4 case — a
+  sub-`1e-15`-weight live component referencing the feature **blocks** candidacy (this is the test that
+  fails against the table-based check and passes against the group-local one); §4 score exactness —
+  `replacement_value == log1p((exp(Δ)−1)·W_G) − cost` against a hand-built oracle, and the `W_G → 1`
+  degeneration to `voc`; §5 score/transition unity — the scored candidate and the applied candidate are
+  the same object (`===`); §6 grammar-registry hygiene — old gid absent, `g′` registered, dedup on a later
+  `enumerate_more` of `g′` re-adds nothing.
+- **`test/test_grid_world_meta.jl`** (modification): §1 re-baselined — the `-Inf` pin replaced by the
+  replacement-value pins; the direct engine-accessor assertion (`perturbation_voc > 0`) retires with the
+  sibling path.
+- **`test/test_perturb_consumption.jl`** (modification): the no-op/same-id §§ stay (the saturation no-op is
+  unchanged); the sibling-injection expectations update to replacement.
+
+## 3. Behaviour preserved
+
+- `perturb_grammar` / `perturbation_voc` / `compression_exhausted` keep their exact current semantics on
+  their current signatures — they remain the prior-only, state-free surface (used by `compression_exhausted`
+  and any brain-side caller without an `AgentState`). The replacement path is a **new, state-aware** surface
+  beside them; no existing test of the trio changes. (The *host* stops calling the sibling path; the
+  functions stay.)
+- Commutation: `≤ 1e-12` on normalised weights (float summation order), exact `==` on Beta parameters, tags,
+  metadata, program identity — the #187 tolerance discipline.
+- `test_growth_returns.jl`, `test_coherent_injection.jl`, `test_compression_removal.jl`, the conjugate/
+  threshold/complexity suites: untouched passes required.
+- The dominance benchmark is expected to **drift** (every policy's transition semantics improve); the gate
+  re-run is the acceptance, not bit-stability.
+
+## 4. Worked end-to-end example
+
+State: two grammars. `g1` (features `{a, b}`, no rules) carries group `G = {1, 2, 3}`; component programs
+test only `:a` (`:b` is referenced by no program and no rule body). `g2` carries components `{4, 5}`. After
+some history, normalised posterior: `W_G = 0.6`, `W_{g2} = 0.4`. Every array position `i` has tag `i`
+(re-tag discipline).
+
+1. **Score.** `replacement_candidates(state, g1.id)` (perturbation.jl) walks all three group programs —
+   including any sub-`1e-15` stragglers — and `g1`'s (empty) rule bodies: `:b ∉ refs` → one candidate,
+   `kind = :remove_feature`, `payoff_symbols = 1`. `g1′ = Grammar({a}, rules, thresholds − b, fresh id)`;
+   the 4-arg constructor recomputes complexity; `Δ = λ·(c(g1) − c(g1′)) = log 2`. `W_G` reads canalised:
+   `probability(state.belief, TagSet(Interval(0,1), Set([1,2,3]))) = 0.6`. Score
+   `= log1p((e^{log 2} − 1)·0.6) = log(1.6) ≈ 0.4700` nats, minus `op_compute_cost`. (The prior-only `voc`
+   would have claimed `log 2 ≈ 0.6931` — the surrogate overstates by exactly the mass the group doesn't
+   hold.)
+2. **Select.** `score_gw_meta_actions` (host) puts `0.4700 − cost` into the same argmax as growth and escape
+   scores — one `optimise`, no side-channel (T-3.51).
+3. **Transition.** `replace_grammar_in_state!` (agent_state.jl) applies **the same candidate object**:
+   `metadata[1..3] ← (g1′.id, ·)`; `log_weights[1..3] += log 2`; mixture reconstructed (normalises);
+   `delete!(state.grammars, g1.id)`; `state.grammars[g1′.id] = g1′`. New normalised masses:
+   `W′_G = 0.6·2 / (0.6·2 + 0.4) = 0.75`, `W′_{g2} = 0.25`. Realised Δ log-evidence
+   `= log(1.6)` — **exactly the score**. Tags 1–5 and all Beta posteriors byte-identical.
+4. **Verify (the §1 derivation, concretely).** The counterfactual agent seeded with `g1′` instead of `g1`
+   assigns each group component prior `lw_i + log 2` and conditions on the identical history through
+   identical kernels — landing on the same normalised weights as step 3. `test_replacement.jl` §1 asserts
+   this equality after a further conditioning run (commutation, not just the instant).
+5. **Next step (treadmill dead).** `g1` is unregistered — `top_k_grammar_ids` cannot surface it;
+   `replacement_candidates(state, g1′.id)` finds no dead item → `replacement_value = 0.0` → perturb scores
+   below `do_nothing`'s floor. One edit, once.
+
+Ownership at each step: candidates + score in `perturbation.jl`; the canalised mass read in `ontology.jl`;
+the write in `agent_state.jl` beside its siblings (`add_programs_to_state!`, `sync_prune!`); selection in
+the host's one argmax. The score/transition dual residency is the §5 Q1 subject; the shared candidate
+function is what keeps it one function in two houses.
+
+## 5. Open design questions
+
+1. **Constitutional form of the weight write.** The group shift is a `log_weights` write outside
+   `condition` — the letter of "no other function may modify a measure's weights". Three forms considered:
+   **(a) the `coherent-space-edit` precedent** (proposed): bless `src/`-resident space edits whose weight
+   arithmetic is the unique solution of the commutation equation, each with a named equality test.
+   **(b) Route through `condition`** on a fabricated per-component event with likelihood ratio
+   `e^{Δ·1[i∈G]}`. **(c) Keep `-Inf`** and accept the treadmill as the price of letter-purity.
+   Recommending (a), two reasons: *(i)* the criterion is exactly the one that already blessed #187 —
+   injection's ledger arithmetic is a weight computation outside `condition`, sanctioned because commutation
+   forces it uniquely; refusing the same criterion here is incoherent case law, and (a) regularises both
+   under one named slug. *(ii)* (b) is strictly worse than what it launders: the fabricated "observation"
+   is not data — it corrupts every downstream evidence read (injection yields, residual stream, any future
+   prequential audit) and misfiles a prior re-declaration as likelihood, violating T-1.3 (the prior is the
+   honest statement of ignorance) to satisfy a letter whose purpose is to *prevent* exactly such misfiling.
+   (c) leaves a live A3 violation (the duplicate-injection dilution) in place to avoid a derived, tested
+   write — the constitution prefers the derivation (T-2.81).
+2. **Partial re-entry scope.** Perturb re-enters scored over **removal-class candidates only**;
+   `:add_rule` proposals stay dark until add-consumption lands. Alternatives: keep `-Inf` until the full
+   class is consumable, or fold add-consumption in now. Recommending partial re-entry: *(i)* the
+   instrumented treadmill was removals (`rules 0→0` in the smoke log) — the live pathology is fully cured by
+   the removal half, and deepen's precedent (#189 deviation 2: cells tracked, op dark) already establishes
+   per-op honest gating; *(ii)* add-consumption needs genuinely new machinery — a semantics-preserving AST
+   rewrite (subtree → `NonterminalRef`), per-program non-uniform `Δ_i`, kernel recompilation — whose
+   commutation derivation is the same shape but whose blast radius (Program/CompiledKernel identity,
+   Invariant 3's no-AST-in-kernels boundary) deserves its own doc rather than a rider. The risk accepted:
+   until then, an applied `:add_rule` (fired by *score-blind baselines* — eu_max can't fire it) still
+   treadmills; mitigated by baselines' fixed budgets.
+3. **Score fidelity.** Exact `log1p((e^Δ − 1)·W_G)` (recommended) vs the prior-only `voc = Δ` surrogate.
+   Recommending exact: *(i)* it is the same Δ-log-evidence currency as the escape ops' learned yields and
+   growth's `fit` (T-3.53 — one currency), so the meta-argmax compares like with like; the surrogate
+   overstates by the held-out mass and would resurrect cleanup churn on low-mass grammars (a zombie lineage's
+   hygiene is worth ~nothing, and the exact score *says so*: it self-extinguishes as `W_G → 0`); *(ii)* the
+   cascade between fidelities is itself an EU decision on evaluation cost (T-3.53), and here the dearer
+   fidelity costs one canalised `probability` read — when exactness is free, choosing the surrogate is
+   unpriced error. Counter-position to argue: Move 5 named `voc` *the* cheap fidelity, and consistency of
+   the cascade tiers has its own value; answer: Move 5's cascade prices *lookahead re-conditioning*, which
+   this score still avoids — the mass read is not a lookahead.
+
+## 6. Risk + mitigation
+
+- **Unsound re-key (a live program outside its new grammar's language).** The catastrophic one: complexity
+  bookkeeping silently wrong, any recompile of that component crashes. Cause would be a lossy reference
+  count (the `w > 1e-15` cut, or a missed AST node type). Mitigation: group-local full-support walk with
+  the no-generic-fallback method style (a new node type fails loud, matching `collect_*_refs!`);
+  `test_replacement.jl` §3 pins the sub-threshold case that defeats the table-based check.
+- **Score/transition drift** (the 3.55 regression this doc exists to kill). Mitigation: one candidate
+  function feeding both; §5 pin (`===` on the candidate object); no numeric re-derivation at apply time.
+- **Registry dangling references.** `top_gids` snapshots in the host could hold a consumed gid within a
+  step. Mitigation: `haskey` guards already line every host loop (the #189 pattern); §6 of the test pins
+  registry hygiene; grep `state.grammars[` across `apps/` and `src/` at build time for unguarded reads.
+- **Persistence.** `AgentState` schema is unchanged (same fields, same types) — replacement is a value-level
+  operation. Fixture suite must pass untouched; no new fixture needed (no schema version bump).
+- **Benchmark comparability.** All policies' transitions change at once; per-policy deltas vs the #189
+  gate are not attributable to selection. Mitigation: the gate re-run is a fresh baseline, stated in the
+  results commit; the falsifiable claims (§7) are about *mechanism* (treadmill extinction), not AUC
+  movement, with AUC/final-window/efficiency reported as before.
+- **Cross-lineage duplicates** (two registered grammars structurally equal after independent cleanings, each
+  holding evidence on duplicate programs). Pre-existing condition, neither created nor cured by this move;
+  consumption *reduces* its incidence (siblings stop being minted). Named non-goal; revisit if the gate's
+  op logs show duplicate-grammar mass fragmenting decisions.
+
+## 7. Verification cadence
+
+    julia test/test_replacement.jl                 # new — commutation, treadmill, OQ-4, score oracle
+    julia test/test_perturb_consumption.jl         # updated expectations
+    julia test/test_grid_world_meta.jl             # re-baselined §1
+    julia test/test_compression_removal.jl         # untouched pass
+    julia test/test_coherent_injection.jl          # untouched pass
+    julia test/test_growth_returns.jl              # untouched pass
+    for f in test/test_*.jl; do julia "$f"; done   # full local suite (Julia tests are not CI-gated)
+    JULIA_PROJECT=$PWD PYTHON_JULIACALL_HANDLE_SIGNALS=yes uv run python apps/skin/test_skin.py
+                                                   # optional — no wire change; run for the CI parity habit
+
+Gate re-run (`julia apps/julia/dominance_benchmark/run.jl`, 20 seeds, background, never through head/tail),
+with the falsifiable claims: **(i)** perturb fires appear in eu_max's op log *at most once per (grammar,
+dead-item)* — zero repeated proposals (the treadmill-extinction claim, checkable from the instrumented op
+log); **(ii)** no duplicate-component growth attributable to perturb (component count stable across perturb
+fires); **(iii)** worst-seed and AUC-vs-fixed_k25 reported honestly — this move does not claim to close the
+winner's-curse gap (that is the next doc); halt-the-line if (i) or (ii) fails. Results commit either way.


### PR DESCRIPTION
The #189 deviation-3 follow-up, design-doc-before-code. Ratify before any code lands.

## What it proposes

Applied compression-class **removals** get **replacement semantics**: the cleaned grammar replaces its ancestor — group metadata re-keyed, group log-weights shifted by the actual complexity-prior delta, the old grammar consumed from the registry. The transition is **derived, not designed**: it is the unique map under which *replacement commutes with conditioning*, exact for the full observation history because every likelihood term cancels identically (stronger than #187's window replay, same criterion). The score, `log1p((e^Δ − 1)·W_G) − cost`, shares one candidate function with the transition (Tractatus 3.55), and the treadmill becomes unrepresentable: a consumed grammar cannot re-propose its own cleaning.

Also carried:
- **The sound reference count (OQ-4 discharge)**: group-local, full-support ref walk at score/apply time — the table's `w > 1e-15` cut is a value screen, not a soundness guarantee (post-prune components can sit below it).
- **The `coherent-space-edit` precedent slug** (T-4.5: the amendment lands in the change that relies on it), regularising #187's ledger arithmetic and this write under one criterion: weight writes in `src/` are legal iff commutation forces them uniquely, with a named equality test.
- `:gw_perturb_grammar` re-enters the meta argmax scored over removal-class candidates only.

## §5 open questions for ratification

1. **Constitutional form of the weight write** — recommend the `coherent-space-edit` precedent over (b) laundering the shift through `condition` on a fabricated pseudo-observation (corrupts every downstream evidence read; misfiles a prior re-declaration as likelihood) or (c) keeping `-Inf` (leaves a live A3 dilution in place).
2. **Partial re-entry scope** — recommend removal-only now; `:add_rule` consumption (semantics-preserving AST rewrite, per-program non-uniform Δ) gets its own doc.
3. **Score fidelity** — recommend the exact posterior-mass-weighted form over the prior-only `voc` surrogate: same Δ-log-evidence currency as every other meta score (T-3.53), and it self-extinguishes on zombie lineages, killing cleanup churn.

Commit 1 lands `CONSTITUTION.md` (the Tractatus consolidation the doc cites) — drop that commit if you'd rather land it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)