### PR TITLE
Stage A': the discarded outcome half is instrument failure, not a label choice

### DIFF
--- a/docs/superpowers/specs/2026-08-09-proplang-replan-post-19.md
+++ b/docs/superpowers/specs/2026-08-09-proplang-replan-post-19.md
@@ -3,6 +3,14 @@
 **Status: Stage A CLOSED 2026-08-09. Phase 1 remains not-started, for a
 different reason than Phase 0 gave.**
 
+> **[CORRECTED IN PART 2026-08-09 by Stage A′]** §6 below is wrong as written.
+> It called the waste label *"a decision, not a measurement"* and handed it to
+> the user. It was a measurement, the data was already on disk, and it has now
+> been made: a `completed=False` with no revert evidence is an **absence 94.7%
+> of the time**, so the shipped convention is correct and there is nothing to
+> rule on. The binding constraint is instrument coverage, not the label.
+> Reading: `2026-08-09-stage-a-prime-results.md`.
+
 Supersedes the exit blockers in `2026-07-20-proplang-migration-phase-0-design.md`
 §7. Reading: `2026-08-09-stage-a-prestatement.md` (criteria, committed first),
 `2026-08-09-stage-a-results.md` (the numbers).
@@ -76,6 +84,14 @@ against 38 zeros. Change that one convention and the rate moves to **0.5068**.
 **The engine was reporting a degenerate channel faithfully. The channel is
 degenerate because of our label.**
 
+> **[CORRECTED 2026-08-09 by Stage A′.]** The first sentence stands. The
+> falsified words are ***"because of our label"***: the channel is degenerate
+> because of our **instrument**. Of the 69,850 discarded records, 94.66% are
+> calls the structural classifier could not locate — 95.09% among calls the live
+> result hook proves executed — against 4.31% that genuinely errored. The label
+> is not discarding negatives; there are few negatives to discard, because the
+> instrument cannot see them.
+
 ## 4. The consequence, stated plainly
 
 Extending the θ grid — the capability the `#19` sitting handed us, and the thing
@@ -101,8 +117,22 @@ in our label rather than our codebook. Against a corrected label the **shipped
 3. **NEW, and the binding one: the evidence channel is degenerate.** No change
    to grid, namespace, or engine alters this while 49.3% of outcomes are
    discarded and the boot prior is 99.1% ones.
+   **[REFINED 2026-08-09 by Stage A′]** Still binding, but it is not the
+   discarding that binds — the discarded records are 94.66% unlocatable calls
+   and discarding them is correct. What binds is that the structural classifier
+   can only locate about half the calls it grounds, and the result hook applies
+   no error test to string-bodied responses. **Instrument coverage, not label
+   convention.** The boot prior is worse than "99.1% ones": **zero** of its 118
+   contexts contain both classes, and it covers 12 of the 1,190 contexts live
+   traffic visits.
 
-## 6. What happens next is a decision, not a measurement
+## 6. ~~What happens next is a decision, not a measurement~~ — SUPERSEDED 2026-08-09
+
+> **This section is wrong as written.** Falsified words: ***"a decision, not a
+> measurement"*** and ***"it is the user's call"***. Stage A′ measured it. The
+> original text is kept below because the error is the instructive part — the
+> question was handed over precisely when it was one more classifier run away
+> from being answered.
 
 The next question is **what the waste label should be** — whether a
 `completed=False` outcome with no revert evidence is a negative or an absence.
@@ -113,6 +143,29 @@ user's call.
 
 Until it is answered, a `said@1` shadow would reproduce this rail at
 substantially higher cost, and Phase 1 should not start.
+
+### 6.1 What replaces it
+
+`completed=False` is an **absence 94.66%** of the time (95.09% among calls the
+live result hook proves executed) and a genuine failure 4.31% of the time, so
+the shipped `_outcome_good_bit` handles it correctly and there is no ruling to
+issue. The remaining findings:
+
+- **Flipping the label would have been harmful.** Treating `completed=False` as
+  a negative yields a large per-context spread that survives unchanged when
+  restricted to calls known to have executed — it is an observability gradient
+  keyed on `parent-tool-call-name`, and the engine would have learned that
+  unobservable calls are wasteful.
+- **The corrected label does not move the reading.** `errored`→0 gives 0.9592,
+  whose KL-nearest rung on the shipped grid is still **0.9**. The retired
+  shadow's `p1` was faithful under every defensible label.
+- **The defect is in the instruments, and both halves of the fix already exist
+  in-tree.** `hook.py:74` records `completed=True` for any string-bodied
+  `tool_response`; `outcomes._is_error` is the test it is missing; and the
+  `/result` payload already carries an `error` field nothing populates.
+
+Phase 1 still should not start, now because the outcome instrument resolves ~4%
+of a signal it can observe on only half the traffic.
 
 ### Deferred, with the work already scoped
 

--- a/docs/superpowers/specs/2026-08-09-stage-a-prime-prestatement.md
+++ b/docs/superpowers/specs/2026-08-09-stage-a-prime-prestatement.md
@@ -1,0 +1,127 @@
+# Stage A′ pre-statement — how the `completed=False` decomposition will be read
+
+**Committed before the numbers exist**, same discipline and for the same reason
+as `2026-08-09-stage-a-prestatement.md`: I already hold a strong expectation
+about the answer, which is exactly when fixing the reading in advance is worth
+something.
+
+Stage A closed by saying the waste label was *"a decision, not a measurement …
+a question about what waste **means**, and it is the user's call."* That was too
+quick, and this document is the retraction of the framing rather than of the
+numbers. `completed=False` is not one fact awaiting a ruling; it is **three
+facts wearing one name**, and which of them dominates is measurable from data
+we already hold.
+
+---
+
+## 1. What is already known at authoring time
+
+A pre-statement written after peeking is worthless. Everything below was
+computed before this document was written:
+
+| known | value | where from |
+|---|---|---|
+| outcome records discarded by `_outcome_good_bit` | 69,850 of 141,717 (49.3%) | Stage A |
+| grounding field tuples | `completed=T` 71,825 · `completed=F` 69,818 · `reverted=T` 38 | Stage A′ census |
+| `error` / `retries` on grounding records | `error=None` universally; `retries≥1` on **32** records | Stage A′ census |
+| events carrying **both** a result-hook and a grounding record | 54,573 | Stage A′ cross-tab |
+| of those, result-hook `completed=True` | 54,561 (99.98%) | Stage A′ cross-tab |
+| …**and** grounding `completed=False`| **26,868** (49.25%) | Stage A′ cross-tab |
+
+The last row is the reason this stage exists. `log.py:83` states that a
+shadow-mode result-hook's `completed=true` is *universal* — it asserts the call
+**executed**, nothing more. So on the overlap we have independent confirmation
+that the call ran, and the structural classifier still declines `completed` on
+essentially half of them.
+
+**Not** yet known, and what this document fixes the reading of: *why* it
+declines.
+
+## 2. The mechanism, read from code
+
+`ground_capture.py:99`:
+
+```python
+"completed": bool(o.executed and o.continued and not o.errored),
+```
+
+with `outcomes.SessionIndex.classify` supplying the three inputs. A `False` is
+therefore reachable three ways, and they are not the same kind of thing:
+
+| | condition | in `classify` | what it is |
+|---|---|---|---|
+| **D1** | `not executed` | call not located in any later snapshot, or unobserved tail | an **absence** — the classifier failed to observe |
+| **D2** | `executed, not continued` | located, but no follow-on action | an **absence** — the session ended |
+| **D3** | `errored` | located, continued, `tool_result` matched `_ERR` | a **negative** — real evidence |
+
+Only D3 is information about the world. D1 and D2 are information about the
+instrument. The recorded records cannot tell them apart: `ground_capture` writes
+the collapsed bool, and `o.label` (`accepted`/`reverted`/`ambiguous`) is
+discarded. Hence a re-run of the classifier over the raw capture.
+
+`retries` is the one surviving hint — `_retries_after` returns 0 unless
+`errored` — so `retries≥1` ⇒ D3. That gives a **floor of 32**, and the
+docstring says the count is deliberately strict and under-counts, so it is a
+floor and nothing more.
+
+## 3. The readings, fixed in advance
+
+Let `d3` be D3's share of the 69,818 `completed=False, reverted=False` records.
+
+**S1 — INSTRUMENT-LIMITED (`d3` small, under ~10%).** The discarded half is
+overwhelmingly unobserved, not failed. Then the shipped label's conservatism is
+**correct**, there is no ruling that recovers the channel, and Stage A's framing
+was wrong in a specific way: the question was never what waste *means*. The
+remedy is upstream instrumentation — result-hook coverage, session-tail capture
+— and **no label convention, and no θ grid, rescues this corpus**. Phase 1 does
+not start on it.
+
+**S2 — LABEL-LOSSY (`d3` large, over ~25%).** Real failures are being thrown
+away by a convention that cannot distinguish them from absences. Then the fix is
+a **code change** — `errored → 0` — with a computable expected information gain,
+not a philosophical ruling, and the corrected channel is two-sided.
+
+**S3 — INTERMEDIATE.** Report both; `d3` sizes the gain, and the decision is
+whether that gain is worth the cost law of §2.1 of the replan.
+
+### 3.1 The sensitivity check that can flip S2
+
+`_ERR` includes bare `Error:` and `error:`, which `outcomes.py`'s own docstring
+concedes benign output contains (*"never flips accepted↔reverted, since benign
+output legitimately contains the word 'error'"*) — it was written as an
+annotation, and `ground_capture` then promoted it to a label input. So D3 is
+computed **twice**: once with the shipped `_ERR`, once with a strict subset
+dropping `Error:|error:|: Exception`. If `d3` is large under the shipped regex
+and collapses under the strict one, **S2 is withdrawn in favour of S1**, and the
+finding is that the label is not merely lossy but noisy in a way that would have
+fed the engine false negatives.
+
+## 4. The independent test: does a corrected channel carry anything?
+
+Even a perfectly corrected label is worthless if its rate is the same
+everywhere: the engine conditions on **per-context** θ pairs, so a global 0.5068
+that is 0.5068 in every context is exactly as uninformative as a global 0.9995.
+Computed from the pinned corpus, per declared feature context, under each label
+variant — n-weighted mean absolute deviation from the global rate, and the share
+of evidence mass in contexts more than 0.1 away.
+
+- **Flat** (spread near zero) → the corrected channel is *also* degenerate, S1
+  and S2 both terminate in the same place, and the corpus is spent.
+- **Spread** → the shipped label is destroying per-context signal that exists,
+  and that quantity is the expected gain a successor would be buying.
+
+This test is pre-stated because it can contradict S2: `d3` can be large while
+the corrected channel is still flat, and in that case the label fix buys
+nothing.
+
+## 5. Non-claims
+
+- Re-running the classifier over the **concatenated** archives gives it strictly
+  more session context than the original incremental runs had, which were cut by
+  four rotations. This biases the pass toward locating **more** calls, i.e.
+  toward under-counting D1. Agreement with the recorded `completed`/`reverted`
+  is reported alongside, and the decomposition is trusted only that far.
+- Nothing here measures `said@1`, current `proplang-host`, or any engine. It
+  measures our own instrument against our own data.
+- `_is_error` is a regex over tool output. D3 is "the classifier's error test
+  fired", never "the call was waste".

--- a/docs/superpowers/specs/2026-08-09-stage-a-prime-results.md
+++ b/docs/superpowers/specs/2026-08-09-stage-a-prime-results.md
@@ -1,0 +1,188 @@
+# Stage A′ results — the discarded half is instrument failure, not a label choice
+
+**Verdict: S1 (INSTRUMENT-LIMITED) fires, decisively.** Reading fixed in advance
+in `2026-08-09-stage-a-prime-prestatement.md` (commit `b015f31`, committed before
+the reclassification ran). The pre-stated threshold for S1 was `d3 < 10%`;
+measured `d3 = 4.31%`.
+
+**Stage A's closing framing is falsified.** It said the next question was
+*"a decision, not a measurement … a question about what waste **means**, and it
+is the user's call."* It was a measurement, the data to make it was already on
+disk, and it is now made.
+
+---
+
+## 1. What was measured
+
+`outcomes.SessionIndex.classify` re-run over the raw capture — four zstd
+archives, 185 GiB decompressed, 141,714 records, 644 sessions — reproducing the
+grounding classifier exactly, but **keeping the three inputs that
+`ground_capture.py:99` collapses into one bool**.
+
+Harness: `~/git/research/w1-prime/stagea2_reclassify.py` (local-only; the capture
+is months of real tool telemetry and `gfrmin/credence` is public).
+
+### Validity first
+
+| | agreement |
+|---|---|
+| `completed` reproduced | 141,448 / 141,712 = **99.81%** |
+| `reverted` reproduced | 141,712 / 141,712 = **100%** |
+
+The 264 disagreements are dominated by 235 in the **predicted** direction:
+calls the original run could not locate but this one can, because the original
+ran incrementally against a capture file cut by four rotations while this pass
+sees the concatenated whole. That bias runs *against* the finding below — it can
+only make D1 look smaller than it was.
+
+## 2. The split
+
+Of the 69,850 outcome records `_outcome_good_bit` discards:
+
+| cause | n | share | what it is |
+|---|---|---|---|
+| **D1 — not located** | 66,117 | **94.66%** | the classifier could not find the call |
+| D3 — errored | 3,014 | 4.31% | a genuine negative |
+| D2 — no follow-on | 484 | 0.69% | session ended |
+| (this pass located it) | 235 | 0.34% | rotation artefact |
+
+And the subset that removes all doubt. Restricted to the **26,867 calls the live
+result hook proves executed** — the hook fired at result time, so the call
+demonstrably ran:
+
+| cause | n | share |
+|---|---|---|
+| **D1 — not located** | 25,547 | **95.09%** |
+| D3 — errored | 1,005 | 3.74% |
+| D2 — no follow-on | 215 | 0.80% |
+
+These calls ran. The structural classifier could not find them. That is not a
+label convention being conservative; it is an instrument missing half its
+targets.
+
+**The shipped `_outcome_good_bit` is therefore correct.** Discarding those
+records is the right thing to do with them — they carry no information about
+whether the call was worth making. The engine was fed a thin but honest stream.
+
+## 3. The sensitivity check resolved the other way
+
+§3.1 pre-stated that if D3 collapsed under a strict error regex, S2 would be
+withdrawn. It does shrink (3,014 → 1,140), but inspection of 400 sampled
+matches says the **shipped regex is the better test, not the worse one**:
+
+- the identified false-positive class — a match explained entirely by a
+  zero-valued counter such as `n_error: 0` in a benchmark readout — accounts for
+  **3%** of loose-only matches;
+- the remainder is dominated by recognisable failures (compiler diagnostics,
+  rejected pushes, build-tool compilation errors, authorisation failures), all
+  of which use a lowercase `error:` and are therefore **missed** by the strict
+  regex.
+
+So `outcomes.py`'s docstring worry ("benign output legitimately contains the word
+'error'") is real but small, and the strict alternative trades a 3% false-positive
+rate for a much larger false-negative one. Either way D3 is a small minority and
+the verdict is unchanged.
+
+## 4. Why flipping the label would have been actively harmful
+
+The obvious "fix" — treat `completed=False` as a negative — produces a global
+rate of 0.5068 and a large per-context spread. That spread is not waste signal:
+
+| variant | contexts | n | global | weighted MAD | mass >0.1 away | contexts w/ both classes |
+|---|---|---|---|---|---|---|
+| V0 shipped | 1,084 | 71,867 | 0.9995 | 0.0010 | 0.03% | 20 |
+| V1 `False`→0 | 1,179 | 141,717 | 0.5068 | **0.3075** | 91.4% | 531 |
+| V1, restricted to hook-proved-executed | 104 | 42,850 | 0.4656 | **0.3137** | 92.0% | — |
+| **V2 corrected** (`errored`→0) | 1,089 | 74,879 | 0.9592 | 0.0303 | 1.5% | 196 |
+| warm prior | 118 | 39,314 | 0.9909 | 0.0179 | 0.9% | **0** |
+
+Row 3 is the tell: restricting V1 to calls **known to have executed** leaves its
+spread untouched (0.3075 → 0.3137). The variation is driven almost entirely by
+`parent-tool-call-name` — roughly 0.75 when the parent is `bash`, roughly 0.05
+when it is `other` — which is a measure of whether a call sat inside a chain
+with later tool calls to locate it against. It is an **observability gradient**.
+
+Since 94.7% of V1's zeros are calls that ran fine and could not be found,
+adopting V1 would have taught the engine that *unobservable* calls are wasteful.
+That is worse than the degenerate channel it had: a confident, structured,
+wrong signal in place of a flat one.
+
+### 4.1 A correction to this stage's own pre-statement
+
+§4 of the pre-statement said spread would mean *"the shipped label is destroying
+per-context signal that exists, and that quantity is the expected gain."* That
+inference does not hold and I withdraw it. Spread establishes that **something**
+varies by context, not that the something is waste. The hook-restricted row is
+what distinguishes them, and it was not in the pre-stated plan — it was added
+when the V1 numbers came back with a suspicious shape.
+
+## 5. The corrected label does not move the reading
+
+Even taking the best available correction (V2: a located, continued call whose
+result matched the error test is a 0), the rate is **0.9592**, and on the shipped
+9-rung grid the KL-nearest rung to 0.9592 is still **0.9**:
+
+| label | rate | KL-nearest rung on `[0.1 … 0.9]` |
+|---|---|---|
+| V0 shipped | 0.999471 | 0.9 |
+| V2 corrected (shipped regex) | 0.959161 | **0.9** |
+| V2 corrected (strict regex) | 0.983822 | **0.9** |
+| V1 flip-the-label | 0.506848 | 0.5 |
+
+So the retired shadow's `p1 = 0.9` was a faithful report under the shipped label
+**and** under every defensible correction of it. Stage A's headline — the
+posterior converged correctly on a near-constant channel — survives this stage
+intact and is now better founded: the channel is near-constant because the
+instrument cannot see failures, not because we chose to ignore them.
+
+The underlying failure rate this traffic actually supports is ~4% (3,014 of
+75,361 located calls). Reporting *that* faithfully would need a rung near 0.96 —
+10 rungs, 3,520 models, ~403 ms/tick against the shipped 2,817 / ~266 ms — but
+with a weighted MAD of 0.0303 it is a global rate, not a per-context signal, so
+the extra rung buys a better-calibrated constant rather than a better decision.
+
+## 6. Where the real defect is
+
+The two instruments are mismatched in complementary ways:
+
+- **`result-hook`** proves the call executed, but `hook.py:74` returns `True` for
+  any plain-string `tool_response`. A Bash call that fails with a traceback
+  returns a string body, so it is recorded `completed=True`. Hence 99.98% true,
+  and `log.py:83`'s note that its `completed` is "universal".
+- **`grounding`** applies a real error test, but can only locate ~50% of the
+  calls it grounds, and its `error` field is `None` on all 141,713 records.
+
+Neither alone yields a two-sided label with coverage. The same repository already
+contains both halves: `outcomes._is_error` is exactly the test `hook.py`'s
+string-body branch is missing, and the `/result` payload already carries an
+`error` field (`daemon.py:447`) that nothing ever populates. Applying the
+existing error test to the response body at result time would produce a
+two-sided label over ~54,800 events with no structural replay at all.
+
+**Flagged, not actioned** — that is a change to a live production hook and to the
+meaning of a recorded field, and it is outside this stage's scope.
+
+## 7. Consequences for the migration
+
+1. **The waste-label question is answered, and the answer is "leave it alone."**
+   A `completed=False` with no revert evidence is an absence 94.7% of the time,
+   and the shipped convention treats it correctly.
+2. **The binding constraint is instrument coverage, not the label and not the
+   grid.** No θ declaration, no namespace projection, and no engine change
+   affects it.
+3. **Phase 1 still should not start**, but the reason has moved again: not
+   "awaiting a ruling on what waste means" but "the outcome instrument resolves
+   ~4% of a signal it can only observe half the time." A `said@1` shadow would
+   reproduce the same rail at higher cost.
+4. The cheapest thing that would change any of this is a hook fix (§6), and its
+   effect is measurable in advance from this corpus.
+
+## 8. Non-claims
+
+- Nothing here measures `said@1`, current `proplang-host`, or any engine.
+- D3 is "the classifier's error test fired", never "the call was waste". A failed
+  call can be worth making; a successful one can be waste. This corpus contains
+  no label for value, only for outcome.
+- The ~4% failure rate is over **located** calls. The 66,117 unlocated ones have
+  no error evidence either way, so it is an estimate on the observable half, not
+  a population rate.

--- a/docs/superpowers/specs/2026-08-09-stage-a-results.md
+++ b/docs/superpowers/specs/2026-08-09-stage-a-results.md
@@ -23,6 +23,18 @@ The channel is that way because of **our own label definition**, not proplang's
 ceiling. And so the ceiling's dissolution at the `#19` sitting — the event that
 prompted this replan — **does not unblock this consumer**.
 
+> **[CORRECTED 2026-08-09 by Stage A′.]** The verdict and every number above
+> stand. The falsified words are ***"because of our own label definition"***.
+> Re-running the grounding classifier over the raw capture (99.81% agreement on
+> `completed`, 100% on `reverted`) shows the discarded records are **94.66%
+> calls the classifier could not locate** — 95.09% among calls the live result
+> hook proves executed — against **4.31%** that genuinely errored. The label is
+> not suppressing negatives; the instrument cannot see them. R2 therefore
+> resolves *into* an instrument-coverage finding rather than a labelling one,
+> and the remedy named in §7 below (choose a label) is replaced by: fix the
+> result hook's error test. Reading:
+> `2026-08-09-stage-a-prime-results.md`.
+
 ## 2. What the engine was actually fed
 
 Three evidence paths reach it, not the two the pre-statement named. The third
@@ -138,14 +150,30 @@ adequate** — 0.5068 lands on the interior rung 0.5, nowhere near an extreme.
 
 **The grid was never this consumer's binding constraint.**
 
+> **[CORRECTED 2026-08-09 by Stage A′.]** The bolded conclusion stands; its
+> stated reason does not. Falsified words: ***"0.5068 lands on the interior rung
+> 0.5"***. 0.5068 is V1's rate — treating every `completed=False` as a negative
+> — and V1 is now known to be the **wrong** correction: 94.66% of its zeros are
+> calls that ran fine and could not be located, so its rate and its large
+> per-context spread are both measures of observability. The defensible
+> correction (`errored`→0) gives **0.9592**, whose KL-nearest rung on the
+> shipped grid is **0.9** — the same rung, not an interior one. The final
+> column of the table above should therefore read 0.9, not 0.5. The grid is
+> still not the binding constraint, but that is because the *instrument* is.
+
 ## 6. What this does not establish
 
 - **Not a measurement of `said@1` on current `proplang-host`.** These records
   come from the retired `proplang-govhost` at `d-close`. Stage A makes no claim
   about the current engine, as the pre-statement fixed in advance.
-- **Not a verdict on which label is correct.** V1/V2 are the range the rate
+- ~~**Not a verdict on which label is correct.** V1/V2 are the range the rate
   moves over, not proposals. Choosing among them is a decision about what waste
-  means and it is not a measurement's to make.
+  means and it is not a measurement's to make.~~
+  **[WITHDRAWN 2026-08-09 by Stage A′.]** Falsified words: ***"not a
+  measurement's to make"***. It was a measurement's to make, and it made it:
+  the shipped label is correct, because what it discards is 94.66% absence.
+  This non-claim was too modest, and being too modest about what the data can
+  settle is how the question got handed to the user in the first place.
 - **Not a claim that proplang's ceiling never mattered.** It bound here — but it
   bound *because* our stream sat above it, and the second consumer (life-agent)
   hit it on a genuinely different path.


### PR DESCRIPTION
Follow-up to #199. Stage A closed by handing the waste label to the user as *"a decision, not a measurement … it is the user's call."* That was wrong. It was a measurement, the data was already on disk, and this makes it.

## The mechanism

`ground_capture.py:99` defines

```python
completed = bool(o.executed and o.continued and not o.errored)
```

so a `False` is three different facts wearing one name, and `o.label` is dropped on the floor. Recovering them means re-running the grounding classifier over the raw capture — 4 zstd archives, 185 GiB decompressed, 141,714 records, 644 sessions.

## Validity first

| | agreement |
|---|---|
| `completed` reproduced | 141,448 / 141,712 = **99.81%** |
| `reverted` reproduced | 141,712 / 141,712 = **100%** |

The 264 disagreements are dominated by 235 in the *predicted* direction — this pass sees sessions the four rotations had cut, so it can locate calls the original could not. That bias runs against the finding below.

## The split

Of the 69,850 records `_outcome_good_bit` discards:

| cause | n | share |
|---|---|---|
| **not located** | 66,117 | **94.66%** |
| errored (a real negative) | 3,014 | 4.31% |
| no follow-on | 484 | 0.69% |

Restricted to the **26,867 calls the live result hook proves executed**, "not located" is **95.09%**. Those calls ran; the structural replay could not find them.

**So the shipped `_outcome_good_bit` is correct and there is nothing to rule on.**

## Flipping the label would have been harmful

Treating `completed=False` as a negative gives a large per-context spread (weighted MAD 0.3075) — but the spread survives *unchanged* (0.3137) when restricted to calls known to have executed, and is keyed on `parent-tool-call-name` (~0.75 for `bash`, ~0.05 for `other`). It is an observability gradient. Since 94.66% of its zeros are calls that ran fine, adopting it would have taught the engine that **unobservable** calls are wasteful — a confident, structured, wrong signal in place of a flat one.

## No label moves the reading

| label | rate | KL-nearest rung on `[0.1 … 0.9]` |
|---|---|---|
| shipped | 0.999471 | 0.9 |
| corrected (`errored`→0) | 0.959161 | **0.9** |
| corrected, strict regex | 0.983822 | **0.9** |

## Where the defect actually is

Both halves are already in-tree: `hook.py:74` returns `completed=True` for any plain-string `tool_response` (hence result-hook's 99.98% true), `outcomes._is_error` is exactly the test it is missing, and the `/result` payload already carries an `error` field nothing populates. **Flagged, not actioned** — live hook, out of scope.

## Discipline

- Pre-statement committed before the job ran (`b015f31`), with the already-known cross-tab disclosed.
- Its own §4 inference is **withdrawn** in §4.1 of the results: spread shows that *something* varies by context, not that the something is waste.
- Its §3.1 sensitivity check resolved *against* the expected direction — the loose error regex is the better test (3% identified false positives; the strict one misses the compiler/push/parse failures that dominate).
- Corrections in place with the falsified words quoted, per the convention both repos use.

Harness and pinned outputs stay in local-only `~/git/research/w1-prime` — the capture is months of real tool telemetry and this repo is public. Only aggregates here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)