### PR TITLE
packaging: track answer-brain-daemon.service next to the daemon it starts

### DIFF
--- a/apps/answer-brain/packaging/README.md
+++ b/apps/answer-brain/packaging/README.md
@@ -1,0 +1,34 @@
+# apps/answer-brain/packaging
+
+The `systemd --user` unit that runs the answer-brain decision daemon on `:8799`.
+
+It sits next to the daemon it starts (`../daemon/main.jl`) so the two version together —
+`WorkingDirectory` and the `--project=.` in `ExecStart` are a claim about this repo's
+layout, and a unit kept anywhere else would silently rot the first time that layout moved.
+
+Until 2026-08-21 this unit existed only in `~/.config/systemd/user/` on one machine: in no
+repo, and on no backup source list. life-agent's ask read-path depends on this daemon
+answering, so the deployment of a documented dependency was the least durable part of it.
+
+## Install
+
+```bash
+cd ~/git/credence
+ln -sfn "$PWD"/apps/answer-brain/packaging/answer-brain-daemon.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now answer-brain-daemon.service
+```
+
+Symlink, never copy — a copied unit is a second copy free to drift, and the repo stops
+being the source.
+
+## Paths
+
+`WorkingDirectory=%h/git/credence` assumes the repo is checked out at `~/git/credence`;
+edit it if yours is elsewhere. The installed copy hard-coded `/home/g/...` for both this
+and `PATH`, which is fine on one machine and wrong in a public repo — `%h` is systemd's
+own specifier for the user's home and is what makes the unit portable.
+
+`ExecStart` uses the system `julia` at `/usr/bin/julia` deliberately: the daemon runs
+against the repo's `Project.toml`, not a pinned toolchain, so a Julia upgrade is visible
+here rather than silently absorbed.

--- a/apps/answer-brain/packaging/answer-brain-daemon.service
+++ b/apps/answer-brain/packaging/answer-brain-daemon.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Answer-brain decision daemon (credence/Julia, :8799) — life-agent ask read-path
+Documentation=https://github.com/gfrmin/life-agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/git/credence
+# julia + (for any engine shim) the user bin; mirrors credence-governor.service.
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/julia --project=. apps/answer-brain/daemon/main.jl
+Restart=on-failure
+RestartSec=10
+# Give the Julia daemon room to precompile on a cold boot before restart logic kicks in.
+TimeoutStartSec=300
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
life-agent's ask read-path depends on this daemon answering on `:8799`, and the unit that starts it existed only in `~/.config/systemd/user/` on one machine — in no repo and on no backup source list. The deployment of a documented dependency was the least durable part of it.

Filed under `apps/answer-brain/packaging/` rather than a top-level `packaging/`, because `WorkingDirectory` and the `--project=.` in `ExecStart` are both claims about *this* directory's layout; a unit kept further away rots silently the first time that layout moves.

The installed copy hard-coded `/home/g/git/credence` and `/home/g/.local/bin` — fine on one machine, wrong in a public repo, and not portable to a second checkout. Both are now `%h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)